### PR TITLE
Add support for EditorsKit navigator toolbar

### DIFF
--- a/src/blocks/column/block.js
+++ b/src/blocks/column/block.js
@@ -968,7 +968,9 @@ registerBlockType( "uagb/column", {
 	category: uagb_blocks_info.category,
 	parent: [ "uagb/columns" ],
 	supports: {
-		inserter: false
+		inserter: false,
+		// Add EditorsKit block navigator toolbar
+		editorsKitBlockNavigator: true,
 	},
 	attributes: {
 		block_id: {

--- a/src/blocks/columns/block.js
+++ b/src/blocks/columns/block.js
@@ -37,6 +37,10 @@ registerBlockType( "uagb/columns", {
 		return { "data-align": attributes.align }
 		return { "data-valign": attributes.vAlign }
 	},
+	supports: {
+		// Add EditorsKit block navigator toolbar
+		editorsKitBlockNavigator: true,
+	},
 	save : function( props ) {
 
 		const { attributes, className } = props


### PR DESCRIPTION
Hi,

I've just recently added Block Navigation toolbar on my [EditorsKit](https://wordpress.org/plugins/block-options/) plugin. I think this will be of great help on user navigation when both plugins are activated. The toolbar will only be shown on blocks with multiple inner blocks capability.

- [x] Columns
- [x] Columns

Here's how it works:
![Screen Capture on 2019-09-23 at 14-38-38](https://user-images.githubusercontent.com/3365507/65405897-4b8ebf00-de10-11e9-86c7-1dca08b71143.gif)

Let me know your thoughts.

Thanks,
Jeffrey
