### PR TITLE
wp-rocket "javascript defered without safe mode jQuery" compatibility

### DIFF
--- a/classes/class-uagb-helper.php
+++ b/classes/class-uagb-helper.php
@@ -193,7 +193,7 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 
 			ob_start();
 			?>
-			<script type="text/javascript" id="uagb-script-frontend">( function( $ ) { <?php echo self::$script; ?> })(jQuery) </script>
+			<script type="text/javascript" id="uagb-script-frontend">document.addEventListener("DOMContentLoaded", function(){( function( $ ) { <?php echo self::$script; ?> })(jQuery)}) </script>
 			<?php
 			ob_end_flush();
 		}

--- a/dist/blocks/post/index.php
+++ b/dist/blocks/post/index.php
@@ -85,17 +85,19 @@ function uagb_post_block_add_script() {
 		foreach ( $uagb_post_settings['masonry'] as $key => $value ) {
 			?>
 			<script type="text/javascript" id="uagb-post-masonry-script-<?php echo $key; ?>">
-				( function( $ ) {
+				document.addEventListener("DOMContentLoaded", function(){
+					( function( $ ) {
 
-					var $scope = $( '.uagb-block-<?php echo $key; ?>' );
-					$scope.imagesLoaded( function() {
-						$scope.find( '.is-masonry' ).isotope();
-					});
+						var $scope = $( '.uagb-block-<?php echo $key; ?>' );
+						$scope.imagesLoaded( function() {
+							$scope.find( '.is-masonry' ).isotope();
+						});
 
-					$( window ).resize( function() {
-						$scope.find( '.is-masonry' ).isotope();
-					} );
-				} )( jQuery );
+						$( window ).resize( function() {
+							$scope.find( '.is-masonry' ).isotope();
+						} );
+					} )( jQuery );
+				});
 			</script>
 			<?php
 		}
@@ -112,62 +114,64 @@ function uagb_post_block_add_script() {
 
 			?>
 			<script type="text/javascript" id="<?php echo $key; ?>">
-				( function( $ ) {
-					var cols = parseInt( '<?php echo $value['columns']; ?>' );
-					var $scope = $( '.uagb-block-<?php echo $key; ?>' ).find( '.is-carousel' );
+				document.addEventListener("DOMContentLoaded", function(){
+					( function( $ ) {
+						var cols = parseInt( '<?php echo $value['columns']; ?>' );
+						var $scope = $( '.uagb-block-<?php echo $key; ?>' ).find( '.is-carousel' );
 
-					if ( cols >= $scope.children().length ) {
-						return;
-					}
+						if ( cols >= $scope.children().length ) {
+							return;
+						}
 
-					var slider_options = {
-						'slidesToShow' : cols,
-						'slidesToScroll' : 1,
-						'autoplaySpeed' : <?php echo $value['autoplaySpeed']; ?>,
-						'autoplay' : Boolean( '<?php echo $value['autoplay']; ?>' ),
-						'infinite' : Boolean( '<?php echo $value['infiniteLoop']; ?>' ),
-						'pauseOnHover' : Boolean( '<?php echo $value['pauseOnHover']; ?>' ),
-						'speed' : <?php echo $value['transitionSpeed']; ?>,
-						'arrows' : Boolean( '<?php echo $arrows; ?>' ),
-						'dots' : Boolean( '<?php echo $dots; ?>' ),
-						'rtl' : false,
-						'prevArrow' : '<button type=\"button\" data-role=\"none\" class=\"slick-prev\" aria-label=\"Previous\" tabindex=\"0\" role=\"button\"><svg width=\"20\" height=\"20\" viewBox=\"0 0 256 512\"><path d=\"M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z\"></path></svg><\/button>',
-						'nextArrow' : '<button type=\"button\" data-role=\"none\" class=\"slick-next\" aria-label=\"Next\" tabindex=\"0\" role=\"button\"><svg width=\"20\" height=\"20\" viewBox=\"0 0 256 512\"><path d=\"M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z\"></path></svg><\/button>',
-						'responsive' : [
-							{
-								'breakpoint' : 1024,
-								'settings' : {
-									'slidesToShow' : <?php echo $tcolumns; ?>,
-									'slidesToScroll' : 1,
+						var slider_options = {
+							'slidesToShow' : cols,
+							'slidesToScroll' : 1,
+							'autoplaySpeed' : <?php echo $value['autoplaySpeed']; ?>,
+							'autoplay' : Boolean( '<?php echo $value['autoplay']; ?>' ),
+							'infinite' : Boolean( '<?php echo $value['infiniteLoop']; ?>' ),
+							'pauseOnHover' : Boolean( '<?php echo $value['pauseOnHover']; ?>' ),
+							'speed' : <?php echo $value['transitionSpeed']; ?>,
+							'arrows' : Boolean( '<?php echo $arrows; ?>' ),
+							'dots' : Boolean( '<?php echo $dots; ?>' ),
+							'rtl' : false,
+							'prevArrow' : '<button type=\"button\" data-role=\"none\" class=\"slick-prev\" aria-label=\"Previous\" tabindex=\"0\" role=\"button\"><svg width=\"20\" height=\"20\" viewBox=\"0 0 256 512\"><path d=\"M31.7 239l136-136c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9L127.9 256l96.4 96.4c9.4 9.4 9.4 24.6 0 33.9L201.7 409c-9.4 9.4-24.6 9.4-33.9 0l-136-136c-9.5-9.4-9.5-24.6-.1-34z\"></path></svg><\/button>',
+							'nextArrow' : '<button type=\"button\" data-role=\"none\" class=\"slick-next\" aria-label=\"Next\" tabindex=\"0\" role=\"button\"><svg width=\"20\" height=\"20\" viewBox=\"0 0 256 512\"><path d=\"M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z\"></path></svg><\/button>',
+							'responsive' : [
+								{
+									'breakpoint' : 1024,
+									'settings' : {
+										'slidesToShow' : <?php echo $tcolumns; ?>,
+										'slidesToScroll' : 1,
+									}
+								},
+								{
+									'breakpoint' : 767,
+									'settings' : {
+										'slidesToShow' : <?php echo $mcolumns; ?>,
+										'slidesToScroll' : 1,
+									}
 								}
-							},
-							{
-								'breakpoint' : 767,
-								'settings' : {
-									'slidesToShow' : <?php echo $mcolumns; ?>,
-									'slidesToScroll' : 1,
-								}
-							}
-						]
-					};
+							]
+						};
 
-					$scope.imagesLoaded( function() {
-						$scope.slick( slider_options );
-					});
-
-					var enableEqualHeight = ( '<?php echo $equal_height; ?>' )
-
-					if( enableEqualHeight ){
 						$scope.imagesLoaded( function() {
-							UAGBPostCarousel._setHeight( $scope );
+							$scope.slick( slider_options );
 						});
 
-						$scope.on( 'afterChange', function() {
-							UAGBPostCarousel._setHeight( $scope );
-						} );
-					}
+						var enableEqualHeight = ( '<?php echo $equal_height; ?>' )
 
-				} )( jQuery );
+						if( enableEqualHeight ){
+							$scope.imagesLoaded( function() {
+								UAGBPostCarousel._setHeight( $scope );
+							});
+
+							$scope.on( 'afterChange', function() {
+								UAGBPostCarousel._setHeight( $scope );
+							} );
+						}
+
+					} )( jQuery );
+				});
 			</script>
 			<?php
 		}


### PR DESCRIPTION
This pull request makes ultimate-addons compatible with 
@wp-media [wp-rocket ](https://github.com/wp-media/wp-rocket) (very popular cache plugin) "javascript defered without safe mode jQuery"

![Captura de tela de 2020-03-05 14-44-46](https://user-images.githubusercontent.com/736104/75987608-79644d80-5ef0-11ea-916d-ec4ba808f2cf.png)

Basically this commit is just 3 wrappers around jquery script (but because of indent, the commit seems longer)

```
document.addEventListener("DOMContentLoaded", function(){
// jquery stuff
}
```

With this, i have instant rendering of my content, no jquery to wait, so the Time to first Paint is super low.


best regards,
