### PR TITLE
Fixed - Pagination not working when using different permalink structure.

### DIFF
--- a/dist/blocks/post/index.php
+++ b/dist/blocks/post/index.php
@@ -274,7 +274,7 @@ function uagb_get_post_html( $attributes, $query, $layout ) {
 		if ( isset( $attributes['postPagination'] ) && true === $attributes['postPagination'] ) {
 
 			echo '<div class="uagb-post-pagination-wrap">';
-			echo uagb_render_pagination( $query, $attributes );
+			echo uagb_render_pagination( $query, $attributes );//phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			echo '</div>';
 		}
 		?>

--- a/dist/blocks/post/index.php
+++ b/dist/blocks/post/index.php
@@ -314,7 +314,12 @@ function uagb_render_pagination( $query, $attributes ) {
 		)
 	);
 
-	return wp_kses_post( implode( PHP_EOL, $links ) );
+	if ( isset( $links ) ) {
+
+		return wp_kses_post( implode( PHP_EOL, $links ) );
+	}
+
+	return '';
 }
 /**
  * Builds the base url.

--- a/dist/blocks/post/index.php
+++ b/dist/blocks/post/index.php
@@ -298,8 +298,8 @@ function uagb_render_pagination( $query, $attributes ) {
 	$max         = $query->found_posts;
 	$max         = ( $total_posts <= $max ) ? $total_posts : $max;
 	$total_pages = ceil( $max / $attributes['postsToShow'] );
-	$base = build_base_url( $permalink_structure, $base );
-	$format = paged_format( $permalink_structure, $base );
+	$base = uagb_build_base_url( $permalink_structure, $base );
+	$format = uagb_paged_format( $permalink_structure, $base );
 	$links       = paginate_links(
 		array(
 			'base'      => $base . '%_%',
@@ -327,7 +327,7 @@ function uagb_render_pagination( $query, $attributes ) {
  * @param string $base Base.
  * @since x.x.x
  */
-function build_base_url( $permalink_structure, $base ) {
+function uagb_build_base_url( $permalink_structure, $base ) {
 	// Check to see if we are using pretty permalinks
 	if ( ! empty( $permalink_structure ) ) {
 
@@ -363,7 +363,7 @@ function build_base_url( $permalink_structure, $base ) {
  * @param string $base Base.
  * @since x.x.x
  */
-function paged_format( $permalink_structure, $base ) {
+function uagb_paged_format( $permalink_structure, $base ) {
 
 	$page_prefix = empty( $permalink_structure ) ? 'paged' : 'page';
 

--- a/dist/blocks/post/index.php
+++ b/dist/blocks/post/index.php
@@ -291,16 +291,19 @@ function uagb_get_post_html( $attributes, $query, $layout ) {
  */
 function uagb_render_pagination( $query, $attributes ) {
 
+	$permalink_structure = get_option('permalink_structure');
 	$base        = untrailingslashit( wp_specialchars_decode( get_pagenum_link() ) );
 	$paged       = ( get_query_var( 'paged' ) ) ? get_query_var( 'paged' ) : 1;
 	$total_posts = ( isset( $attributes['pageLimit'] ) ? $attributes['pageLimit'] : $query->found_posts );
 	$max         = $query->found_posts;
 	$max         = ( $total_posts <= $max ) ? $total_posts : $max;
 	$total_pages = ceil( $max / $attributes['postsToShow'] );
+	$base = build_base_url( $permalink_structure, $base );
+	$format = paged_format( $permalink_structure, $base );
 	$links       = paginate_links(
 		array(
 			'base'      => $base . '%_%',
-			'format'    => '&paged=%#%',
+			'format'    => $format,
 			'current'   => $paged,
 			'total'     => $total_pages,
 			'type'      => 'array',
@@ -312,6 +315,65 @@ function uagb_render_pagination( $query, $attributes ) {
 	);
 
 	return wp_kses_post( implode( PHP_EOL, $links ) );
+}
+/**
+ * Builds the base url.
+ * @param string $permalink_structure Premalink Structure.
+ * @param string $base Base.
+ * @since x.x.x
+ */
+function build_base_url( $permalink_structure, $base ) {
+	// Check to see if we are using pretty permalinks
+	if ( ! empty( $permalink_structure ) ) {
+
+		if ( strrpos( $base, 'paged-' ) ) {
+			$base = substr_replace( $base, '', strrpos( $base, 'paged-' ), strlen( $base ) );
+		}
+
+		// Remove query string from base URL since paginate_links() adds it automatically.
+		// This should also fix the WPML pagination issue that was added since 1.10.2.
+		if ( count( $_GET ) > 0 ) {
+			$base = strtok( $base, '?' );
+		}
+
+		// Add trailing slash when necessary.
+		if ( '/' == substr( $permalink_structure, -1 ) ) {
+			$base = trailingslashit( $base );
+		} else {
+			$base = untrailingslashit( $base );
+		}
+	} else {
+		$url_params = wp_parse_url( $base, PHP_URL_QUERY );
+
+		if ( empty( $url_params ) ) {
+			$base = trailingslashit( $base );
+		}
+	}
+
+	return $base;
+}
+/**
+ * Returns the Paged Format.
+ * @param string $permalink_structure Premalink Structure.
+ * @param string $base Base.
+ * @since x.x.x
+ */
+function paged_format( $permalink_structure, $base ) {
+
+	$page_prefix = empty( $permalink_structure ) ? 'paged' : 'page';
+
+	if ( ! empty( $permalink_structure ) ) {
+		$format  = substr( $base, -1 ) != '/' ? '/' : '';
+		$format .= $page_prefix . '/';
+		$format .= '%#%';
+		$format .= substr( $permalink_structure, -1 ) == '/' ? '/' : '';
+	} elseif ( empty( $permalink_structure ) || is_search() ) {
+		$parse_url = wp_parse_url( $base, PHP_URL_QUERY );
+		$format    = empty( $parse_url ) ? '?' : '&';
+		$format   .= $page_prefix . '=%#%';
+	}
+
+	return $format;
 }
 /**
  * Registers the `core/latest-posts` block on server.


### PR DESCRIPTION
### Description
Fixed - Pagination not working when using different permalink structures.
### Screenshots
https://share.getcloudapp.com/xQuWvgLp

### Types of changes

 Bug fix (non-breaking change which fixes an issue) 


### How has this been tested?
Check by changing the different Permalink structure if pagination works

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
