### PR TITLE
Fixed : Next/Prev not visible in editor issue.

### DIFF
--- a/dist/blocks/post/index.php
+++ b/dist/blocks/post/index.php
@@ -301,11 +301,15 @@ function uagb_render_pagination( $query, $attributes ) {
 	$format              = UAGB_Helper::paged_format( $permalink_structure, $base );
 	$paged				 = UAGB_Helper::get_paged( $query );
 	
+	$current_page = $paged;
+	if ( ! $current_page ) {
+		$current_page = 1;
+	}
 	$links               = paginate_links(
 		array(
 			'base'      => $base . '%_%',
 			'format'    => $format,
-			'current'   => $paged,
+			'current'   => $current_page,
 			'total'     => $total_pages,
 			'type'      => 'array',
 			'mid_size'  => 4,

--- a/dist/blocks/post/index.php
+++ b/dist/blocks/post/index.php
@@ -301,15 +301,11 @@ function uagb_render_pagination( $query, $attributes ) {
 	$format              = UAGB_Helper::paged_format( $permalink_structure, $base );
 	$paged				 = UAGB_Helper::get_paged( $query );
 	
-	$current_page = $paged;
-	if ( ! $current_page ) {
-		$current_page = 1;
-	}
 	$links               = paginate_links(
 		array(
 			'base'      => $base . '%_%',
 			'format'    => $format,
-			'current'   => $current_page,
+			'current' 	=> ( ! $paged ) ? 1 : $paged,
 			'total'     => $total_pages,
 			'type'      => 'array',
 			'mid_size'  => 4,


### PR DESCRIPTION
### Description
Fixed: Next/Prev not visible in the editor issue.

### Screenshots
https://imgur.com/Nmo1nth

### Types of changes

Bug fix (non-breaking change which fixes an issue) 


### How has this been tested?
Next/Prev visible in editor.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
