### PR TITLE
Fix: Settings Icons overlapp on Label when Gutenberg plugin is activated. 

### DIFF
--- a/dist/blocks.commoneditorstyle.build.css
+++ b/dist/blocks.commoneditorstyle.build.css
@@ -239,6 +239,7 @@ hr.uagb-editor__separator {
 
 .uagb-size-type-field__common-tabs .components-tab-panel__tabs {
 	margin-bottom: -34px;
+	display: block;
 }
 
 .uagb-typography-advanced,

--- a/readme.txt
+++ b/readme.txt
@@ -161,6 +161,7 @@ When you use the Ultimate Addons for Gutenberg along with the free Astra theme, 
 * Fix: Icon List - Accessibility issue when link is enabled.
 * Fix: Info Box - Hide margin option for Separator.
 * Fix: Post Grid - Multiple AJAX requests generated if Pagination Markup is returned empty.
+* Fix: Settings Icon overlapping on the Label when Gutenberg plugin is active.
 
 = 1.14.11 =
 * Fix: File Generation issue on WooCommerce Pages.


### PR DESCRIPTION
### Description
Trello Task - https://trello.com/c/SLlU9Q3a/135-settings-get-disturbed-when-activated-gutenberg-plugin

### Screenshots
 https://imgur.com/fgyoJLh

### Types of changes
Bugfix (non-breaking change which fixes an issue) 

### How has this been tested?
Settings icon not overlapping when Gutenberg active.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
