### PR TITLE
Fix: 404 error because of empty Font Family passed to link tag.

### DIFF
--- a/classes/class-uagb-helper.php
+++ b/classes/class-uagb-helper.php
@@ -262,7 +262,9 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 			if ( ! empty( $subsets ) ) {
 				$link .= '&amp;subset=' . implode( ',', $subsets );
 			}
-			echo '<link href="//fonts.googleapis.com/css?family=' . esc_attr( str_replace( '|', '%7C', $link ) ) . '" rel="stylesheet">'; //phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet 
+			if ( isset( $link ) && ! empty( $link ) ) {
+				echo '<link href="//fonts.googleapis.com/css?family=' . esc_attr( str_replace( '|', '%7C', $link ) ) . '" rel="stylesheet">'; //phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+			}
 		}
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -155,6 +155,9 @@ When you use the Ultimate Addons for Gutenberg along with the free Astra theme, 
 
 == Changelog ==
 
+= 1.14.11.1 =
+* Fix: 404 error because of empty Font Family passed to link tag.
+
 = 1.14.11 =
 * Fix: File Generation issue on WooCommerce Pages.
 * Fix: Advanced Columns - Handled background image attachment type on smaller devices.


### PR DESCRIPTION
### Description
Fix: 404 error because of empty Font Family passed to link tag.



### Types of changes

Bug fix (non-breaking change which fixes an issue) -


### How has this been tested?
No error is console.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
