### PR TITLE
Fix: Pagination not calculating Pages properly

### DIFF
--- a/dist/blocks/post/index.php
+++ b/dist/blocks/post/index.php
@@ -296,8 +296,8 @@ function uagb_render_pagination( $query, $attributes ) {
 	$base                = UAGB_Helper::build_base_url( $permalink_structure, $base );
 	$format              = UAGB_Helper::paged_format( $permalink_structure, $base );
 	$paged               = UAGB_Helper::get_paged( $query );
-	$page_limit 		 = isset( $attributes['pageLimit'] ) ? $attributes['pageLimit'] : $attributes['postsToShow'];
-	$links = paginate_links(
+	$page_limit          = isset( $attributes['pageLimit'] ) ? $attributes['pageLimit'] : $attributes['postsToShow'];
+	$links               = paginate_links(
 		array(
 			'base'      => $base . '%_%',
 			'format'    => $format,

--- a/dist/blocks/post/index.php
+++ b/dist/blocks/post/index.php
@@ -293,20 +293,16 @@ function uagb_render_pagination( $query, $attributes ) {
 
 	$permalink_structure = get_option( 'permalink_structure' );
 	$base                = untrailingslashit( wp_specialchars_decode( get_pagenum_link() ) );
-	$total_posts         = ( isset( $attributes['pageLimit'] ) ? $attributes['pageLimit'] : $query->found_posts );
-	$max                 = $query->found_posts;
-	$max                 = ( $total_posts <= $max ) ? $total_posts : $max;
-	$total_pages         = ceil( $max / $attributes['postsToShow'] );
 	$base                = UAGB_Helper::build_base_url( $permalink_structure, $base );
 	$format              = UAGB_Helper::paged_format( $permalink_structure, $base );
 	$paged               = UAGB_Helper::get_paged( $query );
-
+	$page_limit 		 = isset( $attributes['pageLimit'] ) ? $attributes['pageLimit'] : $attributes['postsToShow'];
 	$links = paginate_links(
 		array(
 			'base'      => $base . '%_%',
 			'format'    => $format,
 			'current'   => ( ! $paged ) ? 1 : $paged,
-			'total'     => $total_pages,
+			'total'     => $page_limit,
 			'type'      => 'array',
 			'mid_size'  => 4,
 			'end_size'  => 4,

--- a/readme.txt
+++ b/readme.txt
@@ -157,6 +157,7 @@ When you use the Ultimate Addons for Gutenberg along with the free Astra theme, 
 
 = 1.14.11.1 =
 * Fix: 404 error because of empty Font Family passed to link tag.
+* Fix: Pagination not calculating Pages properly.
 
 = 1.14.11 =
 * Fix: File Generation issue on WooCommerce Pages.


### PR DESCRIPTION
### Description
Fix: Pagination not calculating Pages properly

### Types of changes
Bugfix (non-breaking change which fixes an issue) 

### How has this been tested?
Pagination Working Properly.
Post Per Page - 10.
Page Limit - 10
Total Posts - 10*10 = 100 in 10 pages 10 posts each.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
