### PR TITLE
fix: PHP warnings for users who have built their site prior to v1.14.9 and never migrated the blocks.

### DIFF
--- a/classes/class-uagb-block-helper.php
+++ b/classes/class-uagb-block-helper.php
@@ -1791,8 +1791,11 @@ if ( ! class_exists( 'UAGB_Block_Helper' ) ) {
 
 			if ( ! $attr['childMigrate'] ) {
 
+				$defaults = UAGB_Helper::$block_list['uagb/social-share-child']['attributes'];
+
 				foreach ( $attr['socials'] as $key => $socials ) {
 
+					$socials                        = array_merge( $defaults, (array) $socials );
 					$socials['icon_color']          = ( isset( $socials['icon_color'] ) ) ? $socials['icon_color'] : '';
 					$socials['icon_hover_color']    = ( isset( $socials['icon_hover_color'] ) ) ? $socials['icon_hover_color'] : '';
 					$socials['icon_bg_color']       = ( isset( $socials['icon_bg_color'] ) ) ? $socials['icon_bg_color'] : '';

--- a/classes/class-uagb-block-helper.php
+++ b/classes/class-uagb-block-helper.php
@@ -915,11 +915,15 @@ if ( ! class_exists( 'UAGB_Block_Helper' ) ) {
 
 			if ( ! $attr['childMigrate'] ) {
 
+				$defaults = UAGB_Helper::$block_list['uagb/buttons-child']['attributes'];
+
 				foreach ( $attr['buttons'] as $key => $button ) {
 
 					if ( $attr['btn_count'] <= $key ) {
 						break;
 					}
+
+					$button = array_merge( $defaults, (array) $button );
 
 					$wrapper = ( ! $attr['childMigrate'] ) ? ' .uagb-buttons-repeater-' . $key . '.uagb-button__wrapper' : ' .uagb-buttons-repeater';
 
@@ -2144,6 +2148,8 @@ if ( ! class_exists( 'UAGB_Block_Helper' ) ) {
 			}
 			if ( ! $attr['childMigrate'] ) {
 
+				$defaults = UAGB_Helper::$block_list['uagb/icon-list-child']['attributes'];
+
 				foreach ( $attr['icons'] as $key => $icon ) {
 
 					$wrapper = ( ! $attr['childMigrate'] ) ? ' .uagb-icon-list-repeater-' . $key . '.uagb-icon-list__wrapper' : ' .uagb-icon-list-repeater';
@@ -2167,18 +2173,11 @@ if ( ! class_exists( 'UAGB_Block_Helper' ) ) {
 						'line-height' => $attr['lineHeightTablet'] . $attr['lineHeightType'],
 					);
 
-					$icon['icon_color']              = ( isset( $icon['icon_color'] ) ) ? $icon['icon_color'] : '';
-					$icon['icon_hover_color']        = ( isset( $icon['icon_hover_color'] ) ) ? $icon['icon_hover_color'] : '';
-					$icon['icon_bg_color']           = ( isset( $icon['icon_bg_color'] ) ) ? $icon['icon_bg_color'] : '';
-					$icon['icon_bg_hover_color']     = ( isset( $icon['icon_bg_hover_color'] ) ) ? $icon['icon_bg_hover_color'] : '';
-					$icon['icon_border_color']       = ( isset( $icon['icon_border_color'] ) ) ? $icon['icon_border_color'] : '';
-					$icon['icon_border_hover_color'] = ( isset( $icon['icon_border_hover_color'] ) ) ? $icon['icon_border_hover_color'] : '';
-					$icon['label_color']             = ( isset( $icon['label_color'] ) ) ? $icon['label_color'] : '';
-					$icon['label_hover_color']       = ( isset( $icon['label_hover_color'] ) ) ? $icon['label_hover_color'] : '';
-
 					if ( $attr['icon_count'] <= $key ) {
 						break;
 					}
+
+					$icon = array_merge( $defaults, (array) $icon );
 
 					$child_selectors = self::get_icon_list_child_selectors( $icon, $key, $attr['childMigrate'] );
 					$selectors       = array_merge( $selectors, (array) $child_selectors );


### PR DESCRIPTION
### Description
This PR fixes the warnings shown on the front page for some users. These users have created their site before the [Blocks migration](https://www.ultimategutenberg.com/control-child-items/).
The users who have never edited the page and migrated the blocks see this issue.

### Screenshots
[Link](https://i.imgur.com/ic67zsU.png)

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
- Create Multi Buttons/ Social Share/ Icon List from v1.14.8
- Update to the latest version you will see PHP warnings on the frontend.
- Checkout to this branch the warnings will go away.

### Checklist:
- [x] My code is tested
- [x] I've added proper labels to this pull request <!-- if applicable -->
