### PR TITLE
fix: allow links to be clickable within FAQ sections

### DIFF
--- a/assets/js/faq.js
+++ b/assets/js/faq.js
@@ -123,7 +123,9 @@ window.addEventListener(
 );
 
 function faqClick( e, faqItem, questionButtons ) {
-
+	if ( e.target.tagName == "A" ) {
+		return;
+	}
 	e.preventDefault();
 					
 	if ( faqItem.classList.contains('uagb-faq-item-active') ) {


### PR DESCRIPTION
### Description
Allow links to be clickable within FAQ sections. The `e.preventDefault();` in the FAQ click handler was preventing links from being opened as normal.

### Screenshots
N/A, no visual changes.

### Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue).

Return early from the click handler when clicking an `a` link. Clicking a link should not change the open/closed state of the FAQ item.

### How has this been tested?
* Click the link. Expected behavior: link opens, faq section stays open. PASSED
* Click on the open FAQ section but not the link. Expected behavior: faq section closes. Link is not open. PASSED

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
