### PR TITLE
fix: allow links to be clickable within FAQ sections

### DIFF
--- a/assets/js/faq.js
+++ b/assets/js/faq.js
@@ -123,6 +123,9 @@ window.addEventListener(
 );
 
 function faqClick( e, faqItem, questionButtons ) {
+	if ( e.target.tagName == "A" ) {
+		return;
+	}
 
 	e.preventDefault();
 					

--- a/dist/blocks.editor.build.css
+++ b/dist/blocks.editor.build.css
@@ -1,26 +1,1110 @@
-.uag-typography-range-options .components-base-control__label{width:auto;display:block;margin-bottom:8px}
-.uagb-post-grid h2 a{text-decoration:none}.uagb-post-grid a{pointer-events:none;cursor:default}.uagb-post-grid .uagb-post__load-more-wrap{width:100%}.uagb-post-grid .uagb-post__load-more-wrap .uagb-post-pagination-button{cursor:pointer}.uagb-post-grid .uagb-post__load-more-wrap a{color:inherit}.block-editor-page #wpwrap .edit-post-visual-editor .slick-dots button{color:transparent}.block-editor-page #wpwrap .edit-post-visual-editor .uagb-post__image-position-background .uagb-post__image img{position:absolute;width:auto;height:auto;min-width:100%;max-width:none;left:50%;top:50%;transform:translate(-50%, -50%);min-height:100%}
-.uagb-section__wrap:before{content:'';position:absolute;border:1px dashed #03ddff;top:-1px;right:-1px;bottom:-1px;left:-1px;z-index:0}.uagb-section__edit-active.uagb-section__wrap:before{border-color:#035cff}.editor-bg-image-control .components-button,.editor-bg-video-control .components-button{vertical-align:middle}.editor-bg-image-control .components-button:last-child,.editor-bg-video-control .components-button:last-child{margin-left:10px}.editor-block-list__layout .editor-block-list__block[data-align="full"][data-type="uagb/section"]{margin-left:0;margin-right:0}
-.uagb-buttons__outer-wrap .uagb-button__wrapper{display:flex}.uagb-buttons__outer-wrap .uagb-button__wrapper div{display:inline-flex}[data-type="uagb/buttons"] .block-editor-inner-blocks>.block-editor-block-list__layout{display:flex}.wp-block[data-type="uagb/buttons"][data-btn-width="full"] .block-editor-inner-blocks,.wp-block[data-type="uagb/buttons"][data-btn-width="full"] .wp-block[data-type="uagb/buttons-child"]{width:100%}.wp-block[data-type="uagb/buttons"][data-btn-width="full"] .block-editor-block-list__layout{flex-grow:1;justify-content:space-between}.wp-block[data-type="uagb/buttons"][data-btn-width="full"] .uagb-buttons-repeater{justify-content:center}.wp-block[data-type="uagb/buttons"][data-btn-width="full"] .uagb-buttons-repeater .block-editor-rich-text__editable{text-align:center;justify-content:center}[data-type="uagb/buttons"] .block-editor-inner-blocks>.block-editor-block-list__layout>.wp-block{width:auto;padding-left:0;padding-right:0;margin-left:10px;margin-right:10px}.uagb-buttons__outer-wrap .uagb-buttons__wrap.uagb-buttons-stack-desktop .block-list-appender{width:60px}.uagb-buttons__outer-wrap .block-list-appender{margin-top:24px;margin-bottom:24px;margin-left:10px}
-.uagb-ifb-separator{display:inline-block;width:30%;margin:0}.uagb-infobox__content-wrap.uagb-infobox-icon-above-title{text-align:center}.block-editor-page #wpwrap .edit-post-visual-editor a.uagb-infobox-link-wrap{color:inherit}.block-editor-page #wpwrap .block-editor-rich-text__editable.uagb-ifb-title-prefix{margin-bottom:5px}.block-editor-page #wpwrap .block-editor-rich-text__editable.uagb-ifb-title{margin-bottom:10px}.block-editor-page #wpwrap .uagb-ifb-separator-parent{margin-bottom:10px}.block-editor-page #wpwrap .block-editor-rich-text__editable.uagb-ifb-desc{margin:0;margin-bottom:10px}.block-editor-page #wpwrap a.uagb-infbox__link-to-all{z-index:-1}
-.gutenberg-editor-page #wpwrap .uagb-testomonial__outer-wrap ul.slick-dots{margin:0 auto}#wpwrap .edit-post-visual-editor button.slick-arrow{line-height:1em}.uagb-tm__desc,.editor-block-list__layout .uagb-tm__desc.block-editor-rich-text__editable{margin-bottom:15px}.uagb-tm__author-name,.editor-block-list__layout .uagb-tm__author-name.block-editor-rich-text__editable{margin-bottom:5px;font-size:30px;line-height:1em}#wpwrap .edit-post-visual-editor ul.slick-dots{margin:0}
-.block-editor-page #wpwrap .edit-post-visual-editor ul.uagb-team__social-list{list-style:none;display:flex;margin:0;padding:0}.block-editor-page #wpwrap .edit-post-visual-editor .uagb-team__social-icon a{color:#333}.wp-block-uagb-team .components-button:focus:enabled,.wp-block-uagb-team .components-button{background:transparent;border:none;box-shadow:none}.wp-block-uagb-team p.uagb-team__desc.block-editor-rich-text__editable{margin:0;margin-bottom:10px}
-#wpwrap .edit-post-visual-editor a.uagb-ss__link{color:#3a3a3a}#wpwrap .edit-post-visual-editor a.uagb-ss__link{color:#3a3a3a}.uagb-social-share__layout-vertical .uagb-social-share__wrap>.block-editor-inner-blocks{width:100%}[data-type="uagb/social-share"] .uagb-social-share__layout-horizontal .block-editor-inner-blocks>.block-editor-block-list__layout{display:flex}[data-type="uagb/social-share"] .block-editor-inner-blocks>.block-editor-block-list__layout>.wp-block{width:auto;padding-left:0;padding-right:0;margin-left:10px;margin-right:10px}
-.wp-block.block-editor-block-list__block[data-type="uagb/social-share-child"]{margin-top:15px;margin-bottom:15px}.uagb-social-share__layout-vertical .uagb-social-share__wrap .block-list-appender{margin-top:28px;width:60px}.uagb-social-share__layout-horizontal .uagb-social-share__wrap .block-list-appender{margin-top:0;margin-left:20px}
-#wpwrap .edit-post-visual-editor a.uagb-icon-list__link{color:#3a3a3a}#wpwrap .uagb-icon-list__outer-wrap .uagb-icon-list__label-wrap{cursor:text}[data-type="uagb/icon-list"] .uagb-icon-list__layout-horizontal .block-editor-inner-blocks>.block-editor-block-list__layout{display:flex}[data-type="uagb/icon-list"] .block-editor-inner-blocks>.block-editor-block-list__layout>.wp-block{width:auto;padding-left:0;padding-right:0;margin-left:0;margin-right:0}
-.uagb-icon-list__wrap>.block-editor-inner-blocks{width:100%}.wp-block.block-editor-block-list__block[data-type="uagb/icon-list-child"]{margin-top:15px;margin-bottom:15px}.uagb-icon-list__layout-vertical .uagb-icon-list__wrap .block-list-appender{margin-top:28px;width:60px}.uagb-icon-list__layout-horizontal .uagb-icon-list__wrap .block-list-appender{margin-top:0;margin-bottom:0;margin-left:20px;width:52px;height:52px}
-.uagb-rm__desc,.editor-block-list__layout .uagb-rm__desc.block-editor-rich-text__editable{margin-bottom:15px}.block-editor-page #wpwrap .uagb-rm__separator-parent{margin-bottom:10px}
-#wpwrap .edit-post-visual-editor .uagb-timeline__widget a{text-decoration:none;color:inherit}#wpwrap .edit-post-visual-editor .uagb-timeline__heading a,.gutenberg-editor-page #wpwrap .edit-post-visual-editor a{font-size:inherit;color:inherit;margin:0}#wpwrap .edit-post-visual-editor .uagb-timeline__heading{margin:0}#wpwrap .edit-post-visual-editor .uagb-timeline-wrapper a{pointer-events:none}
-.uagb-cta__content-wrap.uagb-cta__icon-position-above-title{text-align:center}.block-editor-page #wpwrap .edit-post-visual-editor a.uagb-cta__block-link-wrap{color:inherit}.block-editor-page #wpwrap .uagb-cta__title{margin-bottom:10px}.block-editor-page #wpwrap .uagb-cta-separator-parent{margin-bottom:10px}.block-editor-page #wpwrap .uagb-cta__desc{margin:0;margin-bottom:10px}.block-editor-page #wpwrap .uagb-cta__block-link i{font-style:normal}.wp-block-uagb-call-to-action.uagb-cta__outer-wrap a.uagb-cta__link-to-all{z-index:0}
-.wp-block[data-type="uagb/column"]:before{content:'';position:absolute;border:1px dashed #A3AEB6;top:0;right:0;bottom:0;left:0;z-index:0;width:100%;height:100%}.is-selected.wp-block[data-type="uagb/column"]:before{border-color:#59646C}.editor-bg-image-control .components-button,.editor-bg-video-control .components-button{vertical-align:middle}.editor-bg-image-control .components-button:last-child,.editor-bg-video-control .components-button:last-child{margin-left:10px}.wp-block[data-type="uagb/column"] .block-editor-block-list__block-edit{height:100%}.wp-block[data-type="uagb/column"] .block-editor-block-list__block-edit{height:100%}.uagb-column__inner-wrap .block-editor-block-list__block{margin-left:0;margin-right:0;width:100%}.block-editor-page #wpwrap .wp-block .wp-block-uagb-column .uagb-column__inner-wrap{width:100%;padding:30px}.edit-post-visual-editor .uagb-column__inner-wrap .block-editor-block-list__block>.editor-block-mover{left:-30px}@media (max-width: 449px){.block-editor-page #wpwrap .uagb-columns__inner-wrap .block-editor-block-list__block{background-attachment:scroll !important}}
-.uagb-columns__wrap:before{content:'';position:absolute;border:1px dashed #03ddff;top:0;right:0;bottom:0;left:0;z-index:1}.uagb-columns__edit-active.uagb-columns__wrap:before{border-color:#035cff}.editor-bg-image-control .components-button,.editor-bg-video-control .components-button{vertical-align:middle}.editor-bg-image-control .components-button:last-child,.editor-bg-video-control .components-button:last-child{margin-left:10px}.uagb-columns__inner-wrap>.block-editor-inner-blocks>.block-editor-block-list__layout{display:flex;flex-wrap:nowrap}.uagb-columns__inner-wrap>.block-editor-inner-blocks,.uagb-columns__inner-wrap>.block-editor-block-list__layout{width:100%}.uagb-columns__columns-1 .block-editor-block-list__block[data-type="uagb/column"]{width:100%}.uagb-columns__columns-2 .block-editor-block-list__block[data-type="uagb/column"]{width:50%}.uagb-columns__columns-3 .block-editor-block-list__block[data-type="uagb/column"]{width:33.33%}.uagb-columns__columns-4 .block-editor-block-list__block[data-type="uagb/column"]{width:25%}.uagb-columns__columns-5 .block-editor-block-list__block[data-type="uagb/column"]{width:20%}.uagb-columns__columns-6 .block-editor-block-list__block[data-type="uagb/column"]{width:16.66%}.wp-block-uagb-columns .block-editor-block-list__layout{margin-left:0;margin-right:0}.wp-block-uagb-columns .block-editor-block-list__layout .editor-block-list__block{max-width:none !important}.block-editor-block-list__block[data-type="uagb/columns"]{clear:both}.block-editor-block-list__block[data-align=center][data-type="uagb/columns"]{text-align:inherit}.block-editor-block-list__block[data-type="uagb/column"]>.editor-block-contextual-toolbar{top:38px;transform:translateY(-38px);margin-left:-29px;margin-right:-29px}.block-editor-block-list__block[data-type="uagb/column"]>.editor-block-list__insertion-point{top:0;margin-top:0}.block-editor-block-list__block[data-align="full"] .wp-block-uagb-columns>.block-editor-inner-blocks>.block-editor-block-list__layout:first-child{margin-left:30px}.block-editor-block-list__block[data-align="full"] .wp-block-uagb-columns>.block-editor-inner-blocks>.block-editor-block-list__layout:last-child{margin-right:30px}.wp-block-uagb-columns.uagb-columns__valign-center{display:flex;flex-direction:column;justify-content:center}.wp-block-uagb-columns.uagb-columns__valign-center>.uagb-columns__inner-wrap{width:100%}.wp-block-uagb-columns.uagb-columns__valign-bottom{display:flex;flex-direction:column;justify-content:flex-end}.wp-block-uagb-columns.uagb-columns__valign-bottom>.uagb-columns__inner-wrap{width:100%}.block-editor-block-list__layout .block-editor-block-list__block[data-type="uagb/column"]>.block-editor-block-list__block-edit{margin-left:14px;margin-right:14px}.block-editor-block-list__layout .block-editor-block-list__block[data-type="uagb/column"]>.block-editor-block-list__block-edit>div:not(.editor-block-contextual-toolbar){width:100%}.block-editor-block-list__layout .block-editor-block-list__block[data-type="uagb/column"]>.block-editor-block-list__block-edit>.editor-block-contextual-toolbar{position:absolute;top:0;transform:translateY(-39px)}.wp-block-uagb-columns>.uagb-columns__inner-wrap>.block-editor-inner-blocks>.block-editor-block-list__layout>[data-type="uagb/column"]>.block-editor-block-list__block-edit:before{bottom:0;top:0}.block-editor-block-list__block[data-align="full"] .wp-block-uagb-columns{padding-left:15px;padding-right:15px}.wp-block-uagb-columns{display:block;position:relative}.wp-block-uagb-columns>.uagb-columns__inner-wrap{z-index:10;position:relative;margin:0 auto;display:flex;flex-direction:column}.wp-block-uagb-columns>.uagb-columns__inner-wrap>.block-editor-inner-blocks>.block-editor-block-list__layout{display:flex;flex-wrap:nowrap;justify-content:space-between;margin-left:0;margin-right:0}.wp-block-uagb-columns>.uagb-columns__inner-wrap>.block-editor-inner-blocks>.block-editor-block-list__layout>[data-type="uagb/column"]{display:flex;flex-direction:column;max-width:none;margin-top:0;margin-bottom:0}.wp-block-uagb-columns>.uagb-columns__inner-wrap>.block-editor-inner-blocks>.block-editor-block-list__layout>[data-type="uagb/column"] .block-editor-block-list__block-edit{flex-basis:100%}.wp-block-uagb-columns.uagb-columns__valign-center>.uagb-columns__inner-wrap{justify-content:center}.wp-block-uagb-columns.uagb-columns__valign-bottom>.uagb-columns__inner-wrap{justify-content:flex-end}.wp-block-uagb-columns.uagb-columns__valign-center>.uagb-columns__inner-wrap>.block-editor-inner-blocks>.block-editor-block-list__layout>[data-type="uagb/column"]>.block-editor-block-list__block-edit{align-items:center;display:flex}.wp-block-uagb-columns.uagb-columns__valign-bottom>.uagb-columns__inner-wrap>.block-editor-inner-blocks>.block-editor-block-list__layout>[data-type="uagb/column"]>.block-editor-block-list__block-edit{align-items:flex-end;display:flex}.wp-block-uagb-column{width:100%}.block-editor-block-list__layout .block-editor-block-list__block[data-align="full"][data-type="uagb/columns"]{margin-left:0;margin-right:0}.edit-post-visual-editor .editor-writing-flow .block-editor-block-list__layout .block-editor-block-list__block[data-type="uagb/column"]>.block-editor-block-list__block-edit{margin-left:0;margin-right:0}.block-editor-block-list__layout .uagb-column__wrap .uagb-column__inner-wrap{z-index:unset}.block-editor-block-list__layout .uagb-column__wrap{overflow:visible}@media (min-width: 600px){.edit-post-visual-editor .block-editor-block-list__block[data-type="uagb/column"] .block-editor-block-list__block-edit{padding-left:0;padding-right:0}}@media (max-width: 976px){.uagb-columns__reverse-tablet.wp-block-uagb-columns>.uagb-columns__inner-wrap>.block-editor-inner-blocks>.block-editor-block-list__layout{flex-direction:column-reverse}}@media (max-width: 767px){.uagb-columns__reverse-mobile.wp-block-uagb-columns>.uagb-columns__inner-wrap>.block-editor-inner-blocks>.block-editor-block-list__layout{flex-direction:column-reverse}}@media (max-width: 600px){.wp-block-uagb-columns>.uagb-columns__inner-wrap>.block-editor-inner-blocks>.block-editor-block-list__layout{flex-direction:column}.wp-block-uagb-columns>.uagb-columns__inner-wrap>.block-editor-inner-blocks>.block-editor-block-list__layout>[data-type="uagb/column"]{flex:none !important;width:100%;margin-right:0}}.block-editor-block-list__block[data-type="uagb/columns"]>.block-editor-block-list__block-edit:before{pointer-events:inherit}.block-editor-block-list__block[data-type="uagb/columns"]>.editor-block-list__insertion-point{height:16px}.block-editor-block-list__block[data-type="uagb/columns"]>.editor-block-list__insertion-point .editor-block-list__insertion-point-inserter{height:16px}
-.wp-block-uagb-cf7-styler .wpcf7 form{position:relative}.wp-block-uagb-cf7-styler .wpcf7 form>div,.wp-block-uagb-cf7-styler .wpcf7 form>p{margin-bottom:1.2em}.wp-block-uagb-cf7-styler .wpcf7 .wpcf7-form-control-wrap{width:100%;display:block}.wp-block-uagb-cf7-styler .wpcf7 input:not([type=submit]):focus,.wp-block-uagb-cf7-styler .wpcf7 select:focus,.wp-block-uagb-cf7-styler .wpcf7 textarea:focus{background:#fff;border-color:#eaeaea;outline:0;box-shadow:none}.wp-block-uagb-cf7-styler .wpcf7 input:not([type=submit]),.wp-block-uagb-cf7-styler .wpcf7 select,.wp-block-uagb-cf7-styler .wpcf7 textarea{width:100%;padding:.75em}.wp-block-uagb-cf7-styler .wpcf7 input[type=file]{color:#666;height:auto;border-width:1px;border-style:solid;border-color:#eaeaea;border-radius:2px;background:#fafafa;box-shadow:none;box-sizing:border-box;transition:all .2s linear}.wp-block-uagb-cf7-styler .wpcf7 input[type=checkbox],.wp-block-uagb-cf7-styler .wpcf7 input[type=radio]{background:#e9eef2;color:#555;clear:none;cursor:pointer;line-height:0;height:1.2em;margin:-3px 4px 0 0;outline:0;padding:0;border-radius:.2em;text-align:center;vertical-align:middle;width:1.4em;min-width:1.4em;transition:all .2s linear;display:none}.wp-block-uagb-cf7-styler .wpcf7 .wpcf7-validation-errors{border-color:red}.wp-block-uagb-cf7-styler div.wpcf7{margin:0;padding:0}.wp-block-uagb-cf7-styler div.wpcf7 .screen-reader-response{position:absolute;overflow:hidden;clip:rect(1px, 1px, 1px, 1px);height:1px;width:1px;margin:0;padding:0;border:0}.wp-block-uagb-cf7-styler div.wpcf7-response-output{margin:2em 0.5em 1em;padding:0.2em 1em;border:2px solid #ff0000}.wp-block-uagb-cf7-styler div.wpcf7-mail-sent-ok{border:2px solid #398f14}.wp-block-uagb-cf7-styler div.wpcf7-mail-sent-ng,.wp-block-uagb-cf7-styler div.wpcf7-aborted{border:2px solid #ff0000}.wp-block-uagb-cf7-styler div.wpcf7-spam-blocked{border:2px solid #ffa500}.wp-block-uagb-cf7-styler div.wpcf7-validation-errors,.wp-block-uagb-cf7-styler div.wpcf7-acceptance-missing{border:2px solid #f7e700}.wp-block-uagb-cf7-styler .wpcf7-form-control-wrap{position:relative}.wp-block-uagb-cf7-styler span.wpcf7-not-valid-tip{color:#f00;font-size:1em;font-weight:normal;display:block}.wp-block-uagb-cf7-styler .use-floating-validation-tip span.wpcf7-not-valid-tip{position:absolute;top:20%;left:20%;z-index:100;border:1px solid #ff0000;background:#fff;padding:.2em .8em}.wp-block-uagb-cf7-styler span.wpcf7-list-item{display:inline-block;margin:0 1em 0 0}.wp-block-uagb-cf7-styler span.wpcf7-list-item-label::before,.wp-block-uagb-cf7-styler span.wpcf7-list-item-label::after{content:" "}.wp-block-uagb-cf7-styler .wpcf7-display-none{display:none}.wp-block-uagb-cf7-styler div.wpcf7 .ajax-loader{visibility:hidden;display:inline-block;background-image:url("../../images/ajax-loader.gif");width:16px;height:16px;border:none;padding:0;margin:0 0 0 4px;vertical-align:middle}.wp-block-uagb-cf7-styler div.wpcf7 .ajax-loader.is-active{visibility:visible}.wp-block-uagb-cf7-styler div.wpcf7 div.ajax-error{display:none}.wp-block-uagb-cf7-styler div.wpcf7 .placeheld{color:#888}.wp-block-uagb-cf7-styler div.wpcf7 input[type="file"]{cursor:pointer}.wp-block-uagb-cf7-styler div.wpcf7 input[type="file"]:disabled{cursor:default}.wp-block-uagb-cf7-styler div.wpcf7 .wpcf7-submit:disabled{cursor:not-allowed}.block-editor-page #wpwrap .edit-post-visual-editor .wp-block-uagb-cf7-styler .button,.block-editor-page #wpwrap .edit-post-visual-editor .wp-block-uagb-cf7-styler button,.block-editor-page #wpwrap .edit-post-visual-editor .wp-block-uagb-cf7-styler input,.block-editor-page #wpwrap .edit-post-visual-editor .wp-block-uagb-cf7-styler select,.block-editor-page #wpwrap .edit-post-visual-editor .wp-block-uagb-cf7-styler textarea{font-size:100%;color:inherit}
-.wp-block-uagb-gf-styler .uagb-gf-styler__gform-heading-none .gform_heading,.wp-block-uagb-gf-styler .uagb-gf-styler__gform-heading-no .gform_heading,.wp-block-uagb-gf-styler .uagb-gf-styler__gform-heading-yes .gform_heading.custom_gform_heading{display:none}.wp-block-uagb-gf-styler .uagb-gf-styler__gform-heading-no .gform_heading.custom_gform_heading,.wp-block-uagb-gf-styler .uagb-gf-styler__gform-heading-yes .gform_heading{display:block}.wp-block-uagb-gf-styler .uagb-gf-styler__check-style-enabled input[type="radio"],.wp-block-uagb-gf-styler .uagb-gf-styler__check-style-enabled input[type="checkbox"]{-webkit-appearance:none}.wp-block-uagb-gf-styler input[type="radio"]{-webkit-appearance:radio}.wp-block-uagb-gf-styler input[type="checkbox"]{-webkit-appearance:checkbox}.wp-block-uagb-gf-styler input[type="checkbox"]:checked:before,.wp-block-uagb-gf-styler input[type="radio"]:checked:before{content:''}.wp-block-uagb-gf-styler input[type="radio"]:focus,.wp-block-uagb-gf-styler input[type="checkbox"]:focus,.wp-block-uagb-gf-styler input[type="radio"]:checked:focus,.wp-block-uagb-gf-styler input[type="checkbox"]:checked:focus{box-shadow:none}.wp-block-uagb-gf-styler input[type="radio"]:checked:before,.wp-block-uagb-gf-styler input[type="checkbox"]:checked:before{float:unset;display:inline}.wp-block-uagb-gf-styler input[type=number]{height:auto}.block-editor-page #wpwrap .edit-post-visual-editor .wp-block-uagb-gf-styler .button,.block-editor-page #wpwrap .edit-post-visual-editor .wp-block-uagb-gf-styler button,.block-editor-page #wpwrap .edit-post-visual-editor .wp-block-uagb-gf-styler input,.block-editor-page #wpwrap .edit-post-visual-editor .wp-block-uagb-gf-styler select,.block-editor-page #wpwrap .edit-post-visual-editor .wp-block-uagb-gf-styler textarea{font-size:100%;color:inherit}.block-editor-page #wpwrap .edit-post-visual-editor .wp-block-uagb-gf-styler select,.block-editor-page #wpwrap .edit-post-visual-editor .wp-block-uagb-gf-styler .gform_button.button{height:auto}
-#wpwrap .edit-post-visual-editor .uagb-blockquote__skin-quotation blockquote.uagb-blockquote{margin:0;padding:0;border:0;outline:0;font-size:100%;vertical-align:baseline;background:transparent;quotes:none;border-left:0 none;border-right:0 none;border-top:0 none;border-bottom:0 none;font-style:normal}#wpwrap .edit-post-visual-editor blockquote.uagb-blockquote{margin:0;padding:0}#wpwrap .edit-post-visual-editor .uagb-blockquote__skin-border blockquote{padding-left:10px}#wpwrap .edit-post-visual-editor .uagb-blockquote__content,#wpwrap .edit-post-visual-editor cite.uagb-blockquote__author,#wpwrap .edit-post-visual-editor .uagb-blockquote__author{font-style:normal}#wpwrap .edit-post-visual-editor .uagb-blockquote a{color:#1DA1F2;box-shadow:none;text-decoration:none}#wpwrap .edit-post-visual-editor .uagb-blockquote__tweet-style-classic a.uagb-blockquote__tweet-button,#wpwrap .edit-post-visual-editor .uagb-blockquote__tweet-style-bubble a.uagb-blockquote__tweet-button{color:#fff}#wpwrap .edit-post-visual-editor .uagb-blockquote__align-center a.uagb-blockquote__tweet-button{margin:0 auto}
-p.uagb-marketing-btn__prefix.block-editor-rich-text__editable{margin:0 !important}
-.uagb-toc__list>p{font-size:13px;font-style:italic;color:#666}.block-editor-page .uagb-toc__scroll-top.dashicons{right:300px}.block-editor-page .uagb-toc__scroll-top.uagb-toc__show-scroll{display:block}.uagb-light-font-weight{font-weight:400}
-.editor-styles-wrapper [data-type="uagb/how-to"] .how-to-schema-notices{background-color:#FFF8E5;border-left:5px solid #FFB901;padding:8px 10px;font-size:13px;line-height:20px;color:#32373c}.editor-styles-wrapper [data-type="uagb/how-to"] .how-to-schema-notices ul{margin:0;padding-bottom:0}.editor-styles-wrapper [data-type="uagb/how-to"] .how-to-schema-notices h6{margin:0;font-size:inherit;line-height:inherit}.editor-styles-wrapper [data-type="uagb/how-to"] .how-to-schema-notices p{margin:0;margin-top:15px;font-size:inherit;color:#555d66}.wp-block-uagb-how-to .block-editor-button-block-appender{margin-top:0px;margin-left:20px;width:10%}.editor-styles-wrapper .uagb-howto__time-wrap h3,.editor-styles-wrapper .uagb-howto__cost-wrap h3,.editor-styles-wrapper .uagb-how-to-tools__wrap h3,.editor-styles-wrapper .uagb-how-to-steps__wrap h3{margin-bottom:20px;margin-top:20px}.editor-styles-wrapper .uagb-howto__time-wrap p,.editor-styles-wrapper .uagb-howto__cost-wrap p,.editor-styles-wrapper .uagb-how-to-tools__wrap p,.editor-styles-wrapper .uagb-how-to-steps__wrap p{margin-top:25px}
-[data-type="uagb/faq"] .block-editor-inner-blocks>.block-editor-block-list__layout>.wp-block{width:auto;padding-left:0;padding-right:0;margin-top:0px;margin-bottom:0px}[data-type="uagb/faq"] .block-editor-inner-blocks>.block-editor-block-list__layout{display:block}[data-type="uagb/faq"] .uagb-faq-layout-grid .block-editor-inner-blocks>.block-editor-block-list__layout{display:grid}[data-type="uagb/faq"] .uagb-faq-layout-grid.uagb-faq-equal-height .block-editor-inner-blocks>.block-editor-block-list__layout .block-editor-block-list__block,[data-type="uagb/faq"] .uagb-faq-layout-grid.uagb-faq-equal-height .block-editor-inner-blocks>.block-editor-block-list__layout .uagb-faq-child__outer-wrap,[data-type="uagb/faq"] .uagb-faq-layout-grid.uagb-faq-equal-height .block-editor-inner-blocks>.block-editor-block-list__layout .uagb-faq-child__wrapper,[data-type="uagb/faq"] .uagb-faq-layout-grid.uagb-faq-equal-height .block-editor-inner-blocks>.block-editor-block-list__layout .uagb-faq-item{height:100%}
-.uagb-faq-layout-accordion .uagb-faq-child__outer-wrap .uagb-faq-questions-button{cursor:pointer}[data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap .uagb-faq-questions-button{display:flex;align-items:center;width:100%}[data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap .uagb-faq-questions-button .uagb-faq-icon-wrap{display:inline-block;vertical-align:middle}[data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap .uagb-faq-questions-button .uagb-question{width:100%;margin-top:0px;margin-bottom:0px}[data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap .uagb-faq-content p{margin:0}[data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap .uagb-faq-content{border-width:0px}[data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap .uagb-faq-content span{display:inline-block}[data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap .uagb-faq-item .uagb-icon-active,[data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap .uagb-faq-item.uagb-faq-item-active .uagb-icon{display:none}[data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap .uagb-faq-item .uagb-icon,[data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap .uagb-faq-item.uagb-faq-item-active .uagb-icon-active{display:inline-block}[data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap.uagb-faq__active .uagb-faq-child__wrapper .uagb-faq-item .uagb-faq-content{display:block}[data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap.uagb-faq__active .uagb-faq-child__wrapper .uagb-faq-item .uagb-icon{display:none}[data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap.uagb-faq__active .uagb-faq-child__wrapper .uagb-faq-item .uagb-icon-active{display:inline-block}
-.editor-styles-wrapper [data-type="uagb/inline-notice"] h4{margin:0}.block-editor-rich-text__editable.uagb-notice-title.keep-placeholder-on-focus{font-size:inherit}
-[data-type="uagb/wp-search"] .uagb-layout-input-button .uagb-search-submit{color:#fff;border:none;border-radius:0}[data-type="uagb/wp-search"] .uagb-layout-input-button svg{fill:currentColor}[data-type="uagb/wp-search"] .uagb-layout-input .uagb-wp-search-icon-wrap{display:flex;align-items:center}[data-type="uagb/wp-search"] .uagb-layout-input svg{fill:currentColor;opacity:0.6}[data-type="uagb/wp-search"] .uagb-wp-search__outer-wrap{min-height:20px;width:100%}[data-type="uagb/wp-search"] .uagb-wp-search__outer-wrap .uagb-search-wrapper .uagb-search-form__container{display:flex;overflow:hidden}[data-type="uagb/wp-search"] .uagb-wp-search__outer-wrap .uagb-search-wrapper .uagb-search-form__container .uagb-search-form__input{width:100%}
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+.uag-typography-range-options .components-base-control__label {
+  width: auto;
+  display: block;
+  margin-bottom: 8px; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * Editor styles for the admin
+ */
+.uagb-post-grid h2 a {
+  text-decoration: none; }
+
+.uagb-post-grid a {
+  pointer-events: none;
+  cursor: default; }
+
+.uagb-post-grid .uagb-post__load-more-wrap {
+  width: 100%; }
+  .uagb-post-grid .uagb-post__load-more-wrap .uagb-post-pagination-button {
+    cursor: pointer; }
+  .uagb-post-grid .uagb-post__load-more-wrap a {
+    color: inherit; }
+
+.block-editor-page #wpwrap .edit-post-visual-editor .slick-dots button {
+  color: transparent; }
+
+.block-editor-page #wpwrap .edit-post-visual-editor .uagb-post__image-position-background .uagb-post__image img {
+  position: absolute;
+  width: auto;
+  height: auto;
+  min-width: 100%;
+  max-width: none;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  min-height: 100%; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.uagb-section__wrap:before {
+  content: '';
+  position: absolute;
+  border: 1px dashed #03ddff;
+  top: -1px;
+  right: -1px;
+  bottom: -1px;
+  left: -1px;
+  z-index: 0; }
+
+.uagb-section__edit-active.uagb-section__wrap:before {
+  border-color: #035cff; }
+
+.editor-bg-image-control .components-button,
+.editor-bg-video-control .components-button {
+  vertical-align: middle; }
+
+.editor-bg-image-control .components-button:last-child,
+.editor-bg-video-control .components-button:last-child {
+  margin-left: 10px; }
+
+.editor-block-list__layout .editor-block-list__block[data-align="full"][data-type="uagb/section"] {
+  margin-left: 0;
+  margin-right: 0; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * Editor styles for the admin
+ */
+.uagb-buttons__outer-wrap .uagb-button__wrapper {
+  display: flex; }
+  .uagb-buttons__outer-wrap .uagb-button__wrapper div {
+    display: inline-flex; }
+
+[data-type="uagb/buttons"] .block-editor-inner-blocks > .block-editor-block-list__layout {
+  display: flex; }
+
+.wp-block[data-type="uagb/buttons"][data-btn-width="full"] .block-editor-inner-blocks,
+.wp-block[data-type="uagb/buttons"][data-btn-width="full"] .wp-block[data-type="uagb/buttons-child"] {
+  width: 100%; }
+
+.wp-block[data-type="uagb/buttons"][data-btn-width="full"] .block-editor-block-list__layout {
+  flex-grow: 1;
+  justify-content: space-between; }
+
+.wp-block[data-type="uagb/buttons"][data-btn-width="full"] .uagb-buttons-repeater {
+  justify-content: center; }
+  .wp-block[data-type="uagb/buttons"][data-btn-width="full"] .uagb-buttons-repeater .block-editor-rich-text__editable {
+    text-align: center;
+    justify-content: center; }
+
+[data-type="uagb/buttons"] .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block {
+  width: auto;
+  padding-left: 0;
+  padding-right: 0;
+  margin-left: 10px;
+  margin-right: 10px; }
+
+.uagb-buttons__outer-wrap .uagb-buttons__wrap.uagb-buttons-stack-desktop .block-list-appender {
+  width: 60px; }
+
+.uagb-buttons__outer-wrap .block-list-appender {
+  margin-top: 24px;
+  margin-bottom: 24px;
+  margin-left: 10px; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.uagb-ifb-separator {
+  display: inline-block;
+  width: 30%;
+  margin: 0; }
+
+.uagb-infobox__content-wrap.uagb-infobox-icon-above-title {
+  text-align: center; }
+
+.block-editor-page #wpwrap .edit-post-visual-editor a.uagb-infobox-link-wrap {
+  color: inherit; }
+
+.block-editor-page #wpwrap .block-editor-rich-text__editable.uagb-ifb-title-prefix {
+  margin-bottom: 5px; }
+
+.block-editor-page #wpwrap .block-editor-rich-text__editable.uagb-ifb-title {
+  margin-bottom: 10px; }
+
+.block-editor-page #wpwrap .uagb-ifb-separator-parent {
+  margin-bottom: 10px; }
+
+.block-editor-page #wpwrap .block-editor-rich-text__editable.uagb-ifb-desc {
+  margin: 0;
+  margin-bottom: 10px; }
+
+.block-editor-page #wpwrap a.uagb-infbox__link-to-all {
+  z-index: -1; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.gutenberg-editor-page #wpwrap .uagb-testomonial__outer-wrap ul.slick-dots {
+  margin: 0 auto; }
+
+#wpwrap .edit-post-visual-editor button.slick-arrow {
+  line-height: 1em; }
+
+.uagb-tm__desc,
+.editor-block-list__layout .uagb-tm__desc.block-editor-rich-text__editable {
+  margin-bottom: 15px; }
+
+.uagb-tm__author-name,
+.editor-block-list__layout .uagb-tm__author-name.block-editor-rich-text__editable {
+  margin-bottom: 5px;
+  font-size: 30px;
+  line-height: 1em; }
+
+#wpwrap .edit-post-visual-editor ul.slick-dots {
+  margin: 0; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.block-editor-page #wpwrap .edit-post-visual-editor ul.uagb-team__social-list {
+  list-style: none;
+  display: flex;
+  margin: 0;
+  padding: 0; }
+
+.block-editor-page #wpwrap .edit-post-visual-editor .uagb-team__social-icon a {
+  color: #333; }
+
+.wp-block-uagb-team .components-button:focus:enabled,
+.wp-block-uagb-team .components-button {
+  background: transparent;
+  border: none;
+  box-shadow: none; }
+
+.wp-block-uagb-team p.uagb-team__desc.block-editor-rich-text__editable {
+  margin: 0;
+  margin-bottom: 10px; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * Editor styles for the admin
+ */
+#wpwrap .edit-post-visual-editor a.uagb-ss__link {
+  color: #3a3a3a; }
+
+#wpwrap .edit-post-visual-editor a.uagb-ss__link {
+  color: #3a3a3a; }
+
+.uagb-social-share__layout-vertical .uagb-social-share__wrap > .block-editor-inner-blocks {
+  width: 100%; }
+
+[data-type="uagb/social-share"] .uagb-social-share__layout-horizontal .block-editor-inner-blocks > .block-editor-block-list__layout {
+  display: flex; }
+
+[data-type="uagb/social-share"] .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block {
+  width: auto;
+  padding-left: 0;
+  padding-right: 0;
+  margin-left: 10px;
+  margin-right: 10px; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+.wp-block.block-editor-block-list__block[data-type="uagb/social-share-child"] {
+  margin-top: 15px;
+  margin-bottom: 15px; }
+
+.uagb-social-share__layout-vertical .uagb-social-share__wrap .block-list-appender {
+  margin-top: 28px;
+  width: 60px; }
+
+.uagb-social-share__layout-horizontal .uagb-social-share__wrap .block-list-appender {
+  margin-top: 0;
+  margin-left: 20px; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * Editor styles for the admin
+ */
+#wpwrap .edit-post-visual-editor a.uagb-icon-list__link {
+  color: #3a3a3a; }
+
+#wpwrap .uagb-icon-list__outer-wrap .uagb-icon-list__label-wrap {
+  cursor: text; }
+
+[data-type="uagb/icon-list"] .uagb-icon-list__layout-horizontal .block-editor-inner-blocks > .block-editor-block-list__layout {
+  display: flex; }
+
+[data-type="uagb/icon-list"] .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block {
+  width: auto;
+  padding-left: 0;
+  padding-right: 0;
+  margin-left: 0;
+  margin-right: 0; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+.uagb-icon-list__wrap > .block-editor-inner-blocks {
+  width: 100%; }
+
+.wp-block.block-editor-block-list__block[data-type="uagb/icon-list-child"] {
+  margin-top: 15px;
+  margin-bottom: 15px; }
+
+.uagb-icon-list__layout-vertical .uagb-icon-list__wrap .block-list-appender {
+  margin-top: 28px;
+  width: 60px; }
+
+.uagb-icon-list__layout-horizontal .uagb-icon-list__wrap .block-list-appender {
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-left: 20px;
+  width: 52px;
+  height: 52px; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.uagb-rm__desc,
+.editor-block-list__layout .uagb-rm__desc.block-editor-rich-text__editable {
+  margin-bottom: 15px; }
+
+.block-editor-page #wpwrap .uagb-rm__separator-parent {
+  margin-bottom: 10px; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+#wpwrap .edit-post-visual-editor .uagb-timeline__widget a {
+  text-decoration: none;
+  color: inherit; }
+
+#wpwrap .edit-post-visual-editor .uagb-timeline__heading a,
+.gutenberg-editor-page #wpwrap .edit-post-visual-editor a {
+  font-size: inherit;
+  color: inherit;
+  margin: 0; }
+
+#wpwrap .edit-post-visual-editor .uagb-timeline__heading {
+  margin: 0; }
+
+#wpwrap .edit-post-visual-editor .uagb-timeline-wrapper a {
+  pointer-events: none; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.uagb-cta__content-wrap.uagb-cta__icon-position-above-title {
+  text-align: center; }
+
+.block-editor-page #wpwrap .edit-post-visual-editor a.uagb-cta__block-link-wrap {
+  color: inherit; }
+
+.block-editor-page #wpwrap .uagb-cta__title {
+  margin-bottom: 10px; }
+
+.block-editor-page #wpwrap .uagb-cta-separator-parent {
+  margin-bottom: 10px; }
+
+.block-editor-page #wpwrap .uagb-cta__desc {
+  margin: 0;
+  margin-bottom: 10px; }
+
+.block-editor-page #wpwrap .uagb-cta__block-link i {
+  font-style: normal; }
+
+.wp-block-uagb-call-to-action.uagb-cta__outer-wrap a.uagb-cta__link-to-all {
+  z-index: 0; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.wp-block[data-type="uagb/column"]:before {
+  content: '';
+  position: absolute;
+  border: 1px dashed #A3AEB6;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 0;
+  width: 100%;
+  height: 100%; }
+
+.is-selected.wp-block[data-type="uagb/column"]:before {
+  border-color: #59646C; }
+
+.editor-bg-image-control .components-button,
+.editor-bg-video-control .components-button {
+  vertical-align: middle; }
+
+.editor-bg-image-control .components-button:last-child,
+.editor-bg-video-control .components-button:last-child {
+  margin-left: 10px; }
+
+.wp-block[data-type="uagb/column"] .block-editor-block-list__block-edit {
+  height: 100%; }
+
+.wp-block[data-type="uagb/column"] .block-editor-block-list__block-edit {
+  height: 100%; }
+
+.uagb-column__inner-wrap .block-editor-block-list__block {
+  margin-left: 0;
+  margin-right: 0;
+  width: 100%; }
+
+.block-editor-page #wpwrap .wp-block .wp-block-uagb-column .uagb-column__inner-wrap {
+  width: 100%;
+  padding: 30px; }
+
+.edit-post-visual-editor .uagb-column__inner-wrap .block-editor-block-list__block > .editor-block-mover {
+  left: -30px; }
+
+@media (max-width: 449px) {
+  .block-editor-page #wpwrap .uagb-columns__inner-wrap .block-editor-block-list__block {
+    background-attachment: scroll !important; } }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.uagb-columns__wrap:before {
+  content: '';
+  position: absolute;
+  border: 1px dashed #03ddff;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1; }
+
+.uagb-columns__edit-active.uagb-columns__wrap:before {
+  border-color: #035cff; }
+
+.editor-bg-image-control .components-button,
+.editor-bg-video-control .components-button {
+  vertical-align: middle; }
+
+.editor-bg-image-control .components-button:last-child,
+.editor-bg-video-control .components-button:last-child {
+  margin-left: 10px; }
+
+.uagb-columns__inner-wrap > .block-editor-inner-blocks > .block-editor-block-list__layout {
+  display: flex;
+  flex-wrap: nowrap; }
+
+.uagb-columns__inner-wrap > .block-editor-inner-blocks,
+.uagb-columns__inner-wrap > .block-editor-block-list__layout {
+  width: 100%; }
+
+.uagb-columns__columns-1 .block-editor-block-list__block[data-type="uagb/column"] {
+  width: 100%; }
+
+.uagb-columns__columns-2 .block-editor-block-list__block[data-type="uagb/column"] {
+  width: 50%; }
+
+.uagb-columns__columns-3 .block-editor-block-list__block[data-type="uagb/column"] {
+  width: 33.33%; }
+
+.uagb-columns__columns-4 .block-editor-block-list__block[data-type="uagb/column"] {
+  width: 25%; }
+
+.uagb-columns__columns-5 .block-editor-block-list__block[data-type="uagb/column"] {
+  width: 20%; }
+
+.uagb-columns__columns-6 .block-editor-block-list__block[data-type="uagb/column"] {
+  width: 16.66%; }
+
+.wp-block-uagb-columns .block-editor-block-list__layout {
+  margin-left: 0;
+  margin-right: 0; }
+  .wp-block-uagb-columns .block-editor-block-list__layout .editor-block-list__block {
+    max-width: none !important; }
+
+.block-editor-block-list__block[data-type="uagb/columns"] {
+  clear: both; }
+
+.block-editor-block-list__block[data-align=center][data-type="uagb/columns"] {
+  text-align: inherit; }
+
+.block-editor-block-list__block[data-type="uagb/column"] > .editor-block-contextual-toolbar {
+  top: 38px;
+  transform: translateY(-38px);
+  margin-left: -29px;
+  margin-right: -29px; }
+
+.block-editor-block-list__block[data-type="uagb/column"] > .editor-block-list__insertion-point {
+  top: 0;
+  margin-top: 0; }
+
+.block-editor-block-list__block[data-align="full"] .wp-block-uagb-columns > .block-editor-inner-blocks > .block-editor-block-list__layout:first-child {
+  margin-left: 30px; }
+
+.block-editor-block-list__block[data-align="full"] .wp-block-uagb-columns > .block-editor-inner-blocks > .block-editor-block-list__layout:last-child {
+  margin-right: 30px; }
+
+.wp-block-uagb-columns.uagb-columns__valign-center {
+  display: flex;
+  flex-direction: column;
+  justify-content: center; }
+
+.wp-block-uagb-columns.uagb-columns__valign-center > .uagb-columns__inner-wrap {
+  width: 100%; }
+
+.wp-block-uagb-columns.uagb-columns__valign-bottom {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end; }
+
+.wp-block-uagb-columns.uagb-columns__valign-bottom > .uagb-columns__inner-wrap {
+  width: 100%; }
+
+.block-editor-block-list__layout .block-editor-block-list__block[data-type="uagb/column"] > .block-editor-block-list__block-edit {
+  margin-left: 14px;
+  margin-right: 14px; }
+  .block-editor-block-list__layout .block-editor-block-list__block[data-type="uagb/column"] > .block-editor-block-list__block-edit > div:not(.editor-block-contextual-toolbar) {
+    width: 100%; }
+  .block-editor-block-list__layout .block-editor-block-list__block[data-type="uagb/column"] > .block-editor-block-list__block-edit > .editor-block-contextual-toolbar {
+    position: absolute;
+    top: 0;
+    transform: translateY(-39px); }
+
+.wp-block-uagb-columns > .uagb-columns__inner-wrap > .block-editor-inner-blocks > .block-editor-block-list__layout > [data-type="uagb/column"] > .block-editor-block-list__block-edit:before {
+  bottom: 0;
+  top: 0; }
+
+.block-editor-block-list__block[data-align="full"] .wp-block-uagb-columns {
+  padding-left: 15px;
+  padding-right: 15px; }
+
+.wp-block-uagb-columns {
+  display: block;
+  position: relative; }
+  .wp-block-uagb-columns > .uagb-columns__inner-wrap {
+    z-index: 10;
+    position: relative;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column; }
+    .wp-block-uagb-columns > .uagb-columns__inner-wrap > .block-editor-inner-blocks > .block-editor-block-list__layout {
+      display: flex;
+      flex-wrap: nowrap;
+      justify-content: space-between;
+      margin-left: 0;
+      margin-right: 0; }
+      .wp-block-uagb-columns > .uagb-columns__inner-wrap > .block-editor-inner-blocks > .block-editor-block-list__layout > [data-type="uagb/column"] {
+        display: flex;
+        flex-direction: column;
+        max-width: none;
+        margin-top: 0;
+        margin-bottom: 0; }
+        .wp-block-uagb-columns > .uagb-columns__inner-wrap > .block-editor-inner-blocks > .block-editor-block-list__layout > [data-type="uagb/column"] .block-editor-block-list__block-edit {
+          flex-basis: 100%; }
+
+.wp-block-uagb-columns.uagb-columns__valign-center > .uagb-columns__inner-wrap {
+  justify-content: center; }
+
+.wp-block-uagb-columns.uagb-columns__valign-bottom > .uagb-columns__inner-wrap {
+  justify-content: flex-end; }
+
+.wp-block-uagb-columns.uagb-columns__valign-center > .uagb-columns__inner-wrap > .block-editor-inner-blocks > .block-editor-block-list__layout > [data-type="uagb/column"] > .block-editor-block-list__block-edit {
+  align-items: center;
+  display: flex; }
+
+.wp-block-uagb-columns.uagb-columns__valign-bottom > .uagb-columns__inner-wrap > .block-editor-inner-blocks > .block-editor-block-list__layout > [data-type="uagb/column"] > .block-editor-block-list__block-edit {
+  align-items: flex-end;
+  display: flex; }
+
+.wp-block-uagb-column {
+  width: 100%; }
+
+.block-editor-block-list__layout .block-editor-block-list__block[data-align="full"][data-type="uagb/columns"] {
+  margin-left: 0;
+  margin-right: 0; }
+
+.edit-post-visual-editor .editor-writing-flow .block-editor-block-list__layout .block-editor-block-list__block[data-type="uagb/column"] > .block-editor-block-list__block-edit {
+  margin-left: 0;
+  margin-right: 0; }
+
+.block-editor-block-list__layout .uagb-column__wrap .uagb-column__inner-wrap {
+  z-index: unset; }
+
+.block-editor-block-list__layout .uagb-column__wrap {
+  overflow: visible; }
+
+@media (min-width: 600px) {
+  .edit-post-visual-editor .block-editor-block-list__block[data-type="uagb/column"] .block-editor-block-list__block-edit {
+    padding-left: 0;
+    padding-right: 0; } }
+
+@media (max-width: 976px) {
+  .uagb-columns__reverse-tablet.wp-block-uagb-columns > .uagb-columns__inner-wrap > .block-editor-inner-blocks > .block-editor-block-list__layout {
+    flex-direction: column-reverse; } }
+
+@media (max-width: 767px) {
+  .uagb-columns__reverse-mobile.wp-block-uagb-columns > .uagb-columns__inner-wrap > .block-editor-inner-blocks > .block-editor-block-list__layout {
+    flex-direction: column-reverse; } }
+
+@media (max-width: 600px) {
+  .wp-block-uagb-columns > .uagb-columns__inner-wrap > .block-editor-inner-blocks > .block-editor-block-list__layout {
+    flex-direction: column; }
+  .wp-block-uagb-columns > .uagb-columns__inner-wrap > .block-editor-inner-blocks > .block-editor-block-list__layout > [data-type="uagb/column"] {
+    flex: none !important;
+    width: 100%;
+    margin-right: 0; } }
+
+.block-editor-block-list__block[data-type="uagb/columns"] > .block-editor-block-list__block-edit:before {
+  pointer-events: inherit; }
+
+.block-editor-block-list__block[data-type="uagb/columns"] > .editor-block-list__insertion-point {
+  height: 16px; }
+  .block-editor-block-list__block[data-type="uagb/columns"] > .editor-block-list__insertion-point .editor-block-list__insertion-point-inserter {
+    height: 16px; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.wp-block-uagb-cf7-styler .wpcf7 form {
+  position: relative; }
+
+.wp-block-uagb-cf7-styler .wpcf7 form > div, .wp-block-uagb-cf7-styler .wpcf7 form > p {
+  margin-bottom: 1.2em; }
+
+.wp-block-uagb-cf7-styler .wpcf7 .wpcf7-form-control-wrap {
+  width: 100%;
+  display: block; }
+
+.wp-block-uagb-cf7-styler .wpcf7 input:not([type=submit]):focus, .wp-block-uagb-cf7-styler .wpcf7 select:focus, .wp-block-uagb-cf7-styler .wpcf7 textarea:focus {
+  background: #fff;
+  border-color: #eaeaea;
+  outline: 0;
+  box-shadow: none; }
+
+.wp-block-uagb-cf7-styler .wpcf7 input:not([type=submit]), .wp-block-uagb-cf7-styler .wpcf7 select, .wp-block-uagb-cf7-styler .wpcf7 textarea {
+  width: 100%;
+  padding: .75em; }
+
+.wp-block-uagb-cf7-styler .wpcf7 input[type=file] {
+  color: #666;
+  height: auto;
+  border-width: 1px;
+  border-style: solid;
+  border-color: #eaeaea;
+  border-radius: 2px;
+  background: #fafafa;
+  box-shadow: none;
+  box-sizing: border-box;
+  transition: all .2s linear; }
+
+.wp-block-uagb-cf7-styler .wpcf7 input[type=checkbox], .wp-block-uagb-cf7-styler .wpcf7 input[type=radio] {
+  background: #e9eef2;
+  color: #555;
+  clear: none;
+  cursor: pointer;
+  line-height: 0;
+  height: 1.2em;
+  margin: -3px 4px 0 0;
+  outline: 0;
+  padding: 0;
+  border-radius: .2em;
+  text-align: center;
+  vertical-align: middle;
+  width: 1.4em;
+  min-width: 1.4em;
+  transition: all .2s linear;
+  display: none; }
+
+.wp-block-uagb-cf7-styler .wpcf7 .wpcf7-validation-errors {
+  border-color: red; }
+
+.wp-block-uagb-cf7-styler div.wpcf7 {
+  margin: 0;
+  padding: 0; }
+
+.wp-block-uagb-cf7-styler div.wpcf7 .screen-reader-response {
+  position: absolute;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  width: 1px;
+  margin: 0;
+  padding: 0;
+  border: 0; }
+
+.wp-block-uagb-cf7-styler div.wpcf7-response-output {
+  margin: 2em 0.5em 1em;
+  padding: 0.2em 1em;
+  border: 2px solid #ff0000; }
+
+.wp-block-uagb-cf7-styler div.wpcf7-mail-sent-ok {
+  border: 2px solid #398f14; }
+
+.wp-block-uagb-cf7-styler div.wpcf7-mail-sent-ng,
+.wp-block-uagb-cf7-styler div.wpcf7-aborted {
+  border: 2px solid #ff0000; }
+
+.wp-block-uagb-cf7-styler div.wpcf7-spam-blocked {
+  border: 2px solid #ffa500; }
+
+.wp-block-uagb-cf7-styler div.wpcf7-validation-errors,
+.wp-block-uagb-cf7-styler div.wpcf7-acceptance-missing {
+  border: 2px solid #f7e700; }
+
+.wp-block-uagb-cf7-styler .wpcf7-form-control-wrap {
+  position: relative; }
+
+.wp-block-uagb-cf7-styler span.wpcf7-not-valid-tip {
+  color: #f00;
+  font-size: 1em;
+  font-weight: normal;
+  display: block; }
+
+.wp-block-uagb-cf7-styler .use-floating-validation-tip span.wpcf7-not-valid-tip {
+  position: absolute;
+  top: 20%;
+  left: 20%;
+  z-index: 100;
+  border: 1px solid #ff0000;
+  background: #fff;
+  padding: .2em .8em; }
+
+.wp-block-uagb-cf7-styler span.wpcf7-list-item {
+  display: inline-block;
+  margin: 0 1em 0 0; }
+
+.wp-block-uagb-cf7-styler span.wpcf7-list-item-label::before,
+.wp-block-uagb-cf7-styler span.wpcf7-list-item-label::after {
+  content: " "; }
+
+.wp-block-uagb-cf7-styler .wpcf7-display-none {
+  display: none; }
+
+.wp-block-uagb-cf7-styler div.wpcf7 .ajax-loader {
+  visibility: hidden;
+  display: inline-block;
+  background-image: url("../../images/ajax-loader.gif");
+  width: 16px;
+  height: 16px;
+  border: none;
+  padding: 0;
+  margin: 0 0 0 4px;
+  vertical-align: middle; }
+
+.wp-block-uagb-cf7-styler div.wpcf7 .ajax-loader.is-active {
+  visibility: visible; }
+
+.wp-block-uagb-cf7-styler div.wpcf7 div.ajax-error {
+  display: none; }
+
+.wp-block-uagb-cf7-styler div.wpcf7 .placeheld {
+  color: #888; }
+
+.wp-block-uagb-cf7-styler div.wpcf7 input[type="file"] {
+  cursor: pointer; }
+
+.wp-block-uagb-cf7-styler div.wpcf7 input[type="file"]:disabled {
+  cursor: default; }
+
+.wp-block-uagb-cf7-styler div.wpcf7 .wpcf7-submit:disabled {
+  cursor: not-allowed; }
+
+.block-editor-page #wpwrap .edit-post-visual-editor .wp-block-uagb-cf7-styler .button,
+.block-editor-page #wpwrap .edit-post-visual-editor .wp-block-uagb-cf7-styler button,
+.block-editor-page #wpwrap .edit-post-visual-editor .wp-block-uagb-cf7-styler input,
+.block-editor-page #wpwrap .edit-post-visual-editor .wp-block-uagb-cf7-styler select,
+.block-editor-page #wpwrap .edit-post-visual-editor .wp-block-uagb-cf7-styler textarea {
+  font-size: 100%;
+  color: inherit; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Editor Styles
+ *
+ * CSS for just Backend enqueued after style.scss
+ * which makes it higher in priority.
+ */
+.wp-block-uagb-gf-styler .uagb-gf-styler__gform-heading-none .gform_heading,
+.wp-block-uagb-gf-styler .uagb-gf-styler__gform-heading-no .gform_heading,
+.wp-block-uagb-gf-styler .uagb-gf-styler__gform-heading-yes .gform_heading.custom_gform_heading {
+  display: none; }
+
+.wp-block-uagb-gf-styler .uagb-gf-styler__gform-heading-no .gform_heading.custom_gform_heading,
+.wp-block-uagb-gf-styler .uagb-gf-styler__gform-heading-yes .gform_heading {
+  display: block; }
+
+.wp-block-uagb-gf-styler .uagb-gf-styler__check-style-enabled input[type="radio"],
+.wp-block-uagb-gf-styler .uagb-gf-styler__check-style-enabled input[type="checkbox"] {
+  -webkit-appearance: none; }
+
+.wp-block-uagb-gf-styler input[type="radio"] {
+  -webkit-appearance: radio; }
+
+.wp-block-uagb-gf-styler input[type="checkbox"] {
+  -webkit-appearance: checkbox; }
+
+.wp-block-uagb-gf-styler input[type="checkbox"]:checked:before,
+.wp-block-uagb-gf-styler input[type="radio"]:checked:before {
+  content: ''; }
+
+.wp-block-uagb-gf-styler input[type="radio"]:focus,
+.wp-block-uagb-gf-styler input[type="checkbox"]:focus,
+.wp-block-uagb-gf-styler input[type="radio"]:checked:focus,
+.wp-block-uagb-gf-styler input[type="checkbox"]:checked:focus {
+  box-shadow: none; }
+
+.wp-block-uagb-gf-styler input[type="radio"]:checked:before,
+.wp-block-uagb-gf-styler input[type="checkbox"]:checked:before {
+  float: unset;
+  display: inline; }
+
+.wp-block-uagb-gf-styler input[type=number] {
+  height: auto; }
+
+.block-editor-page #wpwrap .edit-post-visual-editor .wp-block-uagb-gf-styler .button,
+.block-editor-page #wpwrap .edit-post-visual-editor .wp-block-uagb-gf-styler button,
+.block-editor-page #wpwrap .edit-post-visual-editor .wp-block-uagb-gf-styler input,
+.block-editor-page #wpwrap .edit-post-visual-editor .wp-block-uagb-gf-styler select,
+.block-editor-page #wpwrap .edit-post-visual-editor .wp-block-uagb-gf-styler textarea {
+  font-size: 100%;
+  color: inherit; }
+
+.block-editor-page #wpwrap .edit-post-visual-editor .wp-block-uagb-gf-styler select,
+.block-editor-page #wpwrap .edit-post-visual-editor .wp-block-uagb-gf-styler .gform_button.button {
+  height: auto; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * Editor styles for the admin
+ */
+#wpwrap .edit-post-visual-editor .uagb-blockquote__skin-quotation blockquote.uagb-blockquote {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  font-size: 100%;
+  vertical-align: baseline;
+  background: transparent;
+  quotes: none;
+  border-left: 0 none;
+  border-right: 0 none;
+  border-top: 0 none;
+  border-bottom: 0 none;
+  font-style: normal; }
+
+#wpwrap .edit-post-visual-editor blockquote.uagb-blockquote {
+  margin: 0;
+  padding: 0; }
+
+#wpwrap .edit-post-visual-editor .uagb-blockquote__skin-border blockquote {
+  padding-left: 10px; }
+
+#wpwrap .edit-post-visual-editor .uagb-blockquote__content,
+#wpwrap .edit-post-visual-editor cite.uagb-blockquote__author,
+#wpwrap .edit-post-visual-editor .uagb-blockquote__author {
+  font-style: normal; }
+
+#wpwrap .edit-post-visual-editor .uagb-blockquote a {
+  color: #1DA1F2;
+  box-shadow: none;
+  text-decoration: none; }
+
+#wpwrap .edit-post-visual-editor .uagb-blockquote__tweet-style-classic a.uagb-blockquote__tweet-button,
+#wpwrap .edit-post-visual-editor .uagb-blockquote__tweet-style-bubble a.uagb-blockquote__tweet-button {
+  color: #fff; }
+
+#wpwrap .edit-post-visual-editor .uagb-blockquote__align-center a.uagb-blockquote__tweet-button {
+  margin: 0 auto; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * Editor styles for the admin
+ */
+p.uagb-marketing-btn__prefix.block-editor-rich-text__editable {
+  margin: 0 !important; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * Editor styles for the admin
+ */
+.uagb-toc__list > p {
+  font-size: 13px;
+  font-style: italic;
+  color: #666; }
+
+.block-editor-page .uagb-toc__scroll-top.dashicons {
+  right: 300px; }
+
+.block-editor-page .uagb-toc__scroll-top.uagb-toc__show-scroll {
+  display: block; }
+
+.uagb-light-font-weight {
+  font-weight: 400; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+.editor-styles-wrapper [data-type="uagb/how-to"] .how-to-schema-notices {
+  background-color: #FFF8E5;
+  border-left: 5px solid #FFB901;
+  padding: 8px 10px;
+  font-size: 13px;
+  line-height: 20px;
+  color: #32373c; }
+  .editor-styles-wrapper [data-type="uagb/how-to"] .how-to-schema-notices ul {
+    margin: 0;
+    padding-bottom: 0; }
+  .editor-styles-wrapper [data-type="uagb/how-to"] .how-to-schema-notices h6 {
+    margin: 0;
+    font-size: inherit;
+    line-height: inherit; }
+  .editor-styles-wrapper [data-type="uagb/how-to"] .how-to-schema-notices p {
+    margin: 0;
+    margin-top: 15px;
+    font-size: inherit;
+    color: #555d66; }
+
+.wp-block-uagb-how-to .block-editor-button-block-appender {
+  margin-top: 0px;
+  margin-left: 20px;
+  width: 10%; }
+
+.editor-styles-wrapper .uagb-howto__time-wrap h3,
+.editor-styles-wrapper .uagb-howto__cost-wrap h3,
+.editor-styles-wrapper .uagb-how-to-tools__wrap h3,
+.editor-styles-wrapper .uagb-how-to-steps__wrap h3 {
+  margin-bottom: 20px;
+  margin-top: 20px; }
+
+.editor-styles-wrapper .uagb-howto__time-wrap p,
+.editor-styles-wrapper .uagb-howto__cost-wrap p,
+.editor-styles-wrapper .uagb-how-to-tools__wrap p,
+.editor-styles-wrapper .uagb-how-to-steps__wrap p {
+  margin-top: 25px; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+[data-type="uagb/faq"] .block-editor-inner-blocks > .block-editor-block-list__layout > .wp-block {
+  width: auto;
+  padding-left: 0;
+  padding-right: 0;
+  margin-top: 0px;
+  margin-bottom: 0px; }
+
+[data-type="uagb/faq"] .block-editor-inner-blocks > .block-editor-block-list__layout {
+  display: block; }
+
+[data-type="uagb/faq"] .uagb-faq-layout-grid .block-editor-inner-blocks > .block-editor-block-list__layout {
+  display: grid; }
+
+[data-type="uagb/faq"] .uagb-faq-layout-grid.uagb-faq-equal-height .block-editor-inner-blocks > .block-editor-block-list__layout .block-editor-block-list__block,
+[data-type="uagb/faq"] .uagb-faq-layout-grid.uagb-faq-equal-height .block-editor-inner-blocks > .block-editor-block-list__layout .uagb-faq-child__outer-wrap,
+[data-type="uagb/faq"] .uagb-faq-layout-grid.uagb-faq-equal-height .block-editor-inner-blocks > .block-editor-block-list__layout .uagb-faq-child__wrapper,
+[data-type="uagb/faq"] .uagb-faq-layout-grid.uagb-faq-equal-height .block-editor-inner-blocks > .block-editor-block-list__layout .uagb-faq-item {
+  height: 100%; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+.uagb-faq-layout-accordion .uagb-faq-child__outer-wrap .uagb-faq-questions-button {
+  cursor: pointer; }
+
+[data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap .uagb-faq-questions-button {
+  display: flex;
+  align-items: center;
+  width: 100%; }
+  [data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap .uagb-faq-questions-button .uagb-faq-icon-wrap {
+    display: inline-block;
+    vertical-align: middle; }
+  [data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap .uagb-faq-questions-button .uagb-question {
+    width: 100%;
+    margin-top: 0px;
+    margin-bottom: 0px; }
+
+[data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap .uagb-faq-content p {
+  margin: 0; }
+
+[data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap .uagb-faq-content {
+  border-width: 0px; }
+  [data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap .uagb-faq-content span {
+    display: inline-block; }
+
+[data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap .uagb-faq-item .uagb-icon-active,
+[data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap .uagb-faq-item.uagb-faq-item-active .uagb-icon {
+  display: none; }
+
+[data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap .uagb-faq-item .uagb-icon,
+[data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap .uagb-faq-item.uagb-faq-item-active .uagb-icon-active {
+  display: inline-block; }
+
+[data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap.uagb-faq__active .uagb-faq-child__wrapper .uagb-faq-item .uagb-faq-content {
+  display: block; }
+
+[data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap.uagb-faq__active .uagb-faq-child__wrapper .uagb-faq-item .uagb-icon {
+  display: none; }
+
+[data-type="uagb/faq-child"] .uagb-faq-child__outer-wrap.uagb-faq__active .uagb-faq-child__wrapper .uagb-faq-item .uagb-icon-active {
+  display: inline-block; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+.editor-styles-wrapper [data-type="uagb/inline-notice"] h4 {
+  margin: 0; }
+
+.block-editor-rich-text__editable.uagb-notice-title.keep-placeholder-on-focus {
+  font-size: inherit; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+[data-type="uagb/wp-search"] .uagb-layout-input-button .uagb-search-submit {
+  color: #fff;
+  border: none;
+  border-radius: 0; }
+
+[data-type="uagb/wp-search"] .uagb-layout-input-button svg {
+  fill: currentColor; }
+
+[data-type="uagb/wp-search"] .uagb-layout-input .uagb-wp-search-icon-wrap {
+  display: flex;
+  align-items: center; }
+
+[data-type="uagb/wp-search"] .uagb-layout-input svg {
+  fill: currentColor;
+  opacity: 0.6; }
+
+[data-type="uagb/wp-search"] .uagb-wp-search__outer-wrap {
+  min-height: 20px;
+  width: 100%; }
+  [data-type="uagb/wp-search"] .uagb-wp-search__outer-wrap .uagb-search-wrapper .uagb-search-form__container {
+    display: flex;
+    overflow: hidden; }
+    [data-type="uagb/wp-search"] .uagb-wp-search__outer-wrap .uagb-search-wrapper .uagb-search-form__container .uagb-search-form__input {
+      width: 100%; }

--- a/dist/blocks.style.build.css
+++ b/dist/blocks.style.build.css
@@ -1,28 +1,3997 @@
-.wp-block-uagb-advanced-heading{padding:0;margin:0 auto}.wp-block-uagb-advanced-heading .uagb-heading-text{margin:0;text-align:center}.wp-block-uagb-advanced-heading .uagb-separator-wrap{font-size:0;text-align:center}.wp-block-uagb-advanced-heading .uagb-separator{border-top-style:solid;display:inline-block;border-top-width:2px;width:5%;margin:0px 0px 10px 0px}.wp-block-uagb-advanced-heading .uagb-desc-text{margin:0;text-align:center}
-.uagb-post-grid{margin:0;position:relative}.uagb-post-grid .uagb-post__load-more-wrap{width:100%}.uagb-post-grid .uagb-post__load-more-wrap .uagb-post-pagination-button{cursor:pointer}.uagb-post-grid .uagb-post__load-more-wrap a{color:inherit}.uagb-post-grid .is-grid article{float:left;display:inline-block}.uagb-post-grid .uagb-post__items{display:flex;flex-wrap:wrap}.uagb-post-grid .is-grid.uagb-post__equal-height .uagb-post__inner-wrap{height:100%}.uagb-post-grid .is-masonry .uagb-post__inner-wrap{height:auto}.uagb-post-grid .uagb-post__inner-wrap>p{display:none}.uagb-post-grid .uagb-post__author span,.uagb-post-grid .uagb-post__comment span,.uagb-post-grid .uagb-post__taxonomy span,.uagb-post-grid .uagb-post__date span{font-size:inherit;line-height:inherit;width:inherit;height:inherit;margin-right:4px}.uagb-post-grid .uagb-post__columns-8 article{width:12.5%}.uagb-post-grid .uagb-post__columns-7 article{width:14.28%}.uagb-post-grid .uagb-post__columns-6 article{width:16.66%}.uagb-post-grid .uagb-post__columns-5 article{width:20%}.uagb-post-grid .uagb-post__columns-4 article{width:25%}.uagb-post-grid .uagb-post__columns-3 article{width:33.2%}.uagb-post-grid .uagb-post__columns-2 article{width:50%}.uagb-post-grid .uagb-post__columns-1 article{width:100%}@media only screen and (max-width: 600px){.uagb-post-grid div[class*="columns"].is-grid{grid-template-columns:1fr}}.uagb-post-grid .uagb-post__image img{display:block;width:100%}.uagb-post-grid .uagb-post__text{text-align:left;box-sizing:border-box}.uagb-post-grid .uagb-post__title{margin-top:0;margin-bottom:15px;word-break:break-word}.uagb-post-grid .uagb-post__title a{color:inherit;box-shadow:none;transition:.3s ease;text-decoration:none}.uagb-post-grid .uagb-post__title a:hover{text-decoration:none}.uagb-post-grid .uagb-post__title a:focus{text-decoration:none}.uagb-post-grid .uagb-post__title a:active{text-decoration:none}.uagb-post-grid .uagb-post-grid-byline{text-transform:uppercase;font-size:11px;letter-spacing:1px;margin-bottom:15px}.uagb-post-grid .uagb-post__text .uagb-post-grid-byline>*{margin-right:10px}.uagb-post-grid .uagb-post-grid-byline a,.uagb-post-grid .uagb-post-grid-byline a:focus,.uagb-post-grid .uagb-post-grid-byline a:active{color:inherit;font-size:inherit}.uagb-post-grid .uagb-post__title a,.uagb-post-grid .uagb-post__title a:focus,.uagb-post-grid .uagb-post__title a:active{color:inherit;font-size:inherit}.uagb-post-grid .uagb-post__author,.uagb-post-grid .uagb-post__date{display:inline-block;word-break:break-all}.uagb-post-grid .uagb-post__author:not(:last-child):after,.uagb-post-grid .uagb-post__date:not(:last-child):after{content:"\B7";vertical-align:middle;margin:0 5px;line-height:1}.uagb-post-grid .uagb-post__comment,.uagb-post-grid .uagb-post__taxonomy{display:inline-block}.uagb-post-grid .uagb-post__author a{box-shadow:none}.uagb-post-grid .uagb-post__author a:hover{color:inherit;box-shadow:0 -1px 0 inset}.uagb-post-grid .uagb-post__excerpt{margin-bottom:25px;word-break:break-word}.uagb-post-grid .uagb-post__text p{margin:0 0 15px 0}.uagb-post-grid .uagb-post__text p:last-of-type{margin-bottom:0}.uagb-post-grid .uagb-post__cta{border:none;display:inline-block}.uagb-post-grid .uagb-post__link{display:inline-block;box-shadow:none;transition:.3s ease;font-weight:bold;color:inherit;text-decoration:none;padding:5px 10px}.uagb-post-grid .uagb-post__excerpt div+p{margin-top:15px}.uagb-post-grid .uagb-post__excerpt p{color:inherit}.uagb-post-grid .uagb-post__link-complete-box{position:absolute;top:0;left:0;width:100%;height:100%;z-index:11}.uagb-post__image-position-background .uagb-post__text{opacity:1;position:relative;z-index:10;overflow:hidden;width:100%}.uagb-post__image-position-background .uagb-post__inner-wrap{position:relative;width:100%}.uagb-post__image-position-background .uagb-post__image img{position:absolute;width:auto;height:auto;min-width:100%;max-width:none;left:50%;top:50%;transform:translate(-50%, -50%);min-height:100%}.uagb-post__image-position-background .uagb-post__image{background-size:cover;background-repeat:no-repeat;background-position:center;overflow:hidden;text-align:center;position:relative}.uagb-post__image-position-background .uagb-post__image{position:absolute;left:0;top:0;width:100%;height:100%;z-index:2}.uagb-post__image-position-background .uagb-post__image::before{content:'';position:absolute;left:0;top:0;width:100%;height:100%;z-index:1;background-color:rgba(255,255,255,0.5)}.uagb-post-grid[data-equal-height="yes"] .uagb-post__inner-wrap{display:inline-block;height:100%}.uagb-post__arrow-outside.uagb-post-grid .slick-prev{left:-45px;z-index:1}[dir="rtl"] .uagb-post__arrow-outside.uagb-post-grid .slick-prev{left:auto;right:-45px}.uagb-post__arrow-outside.uagb-post-grid .slick-next{right:-45px}[dir="rtl"] .uagb-post__arrow-outside.uagb-post-grid .slick-next{left:-45px;right:auto}.uagb-post__arrow-inside.uagb-post-grid .slick-prev{left:25px;z-index:1}[dir="rtl"] .uagb-post__arrow-inside.uagb-post-grid .slick-prev{left:auto;right:25px}.uagb-post__arrow-inside.uagb-post-grid .slick-next{right:25px}[dir="rtl"] .uagb-post__arrow-inside.uagb-post-grid .slick-next{left:25px;right:auto}.uagb-post-grid .is-grid article,.uagb-post-grid .is-masonry article,.uagb-post-grid .is-carousel article{box-sizing:border-box}@media (max-width: 976px){.uagb-post__arrow-outside.uagb-post-grid .slick-prev{left:15px;z-index:1}[dir="rtl"] .uagb-post__arrow-outside.uagb-post-grid .slick-prev{left:auto;right:15px}.uagb-post__arrow-outside.uagb-post-grid .slick-next{right:15px}[dir="rtl"] .uagb-post__arrow-outside.uagb-post-grid .slick-next{left:15px;right:auto}.uagb-post-grid .uagb-post__columns-tablet-1 article{width:100%}.uagb-post-grid .uagb-post__columns-tablet-2 article{width:50%}.uagb-post-grid .uagb-post__columns-tablet-3 article{width:33.2%}.uagb-post-grid .uagb-post__columns-tablet-4 article{width:25%}.uagb-post-grid .uagb-post__columns-tablet-5 article{width:20%}.uagb-post-grid .uagb-post__columns-tablet-6 article{width:16.66%}.uagb-post-grid .uagb-post__columns-tablet-7 article{width:14.28%}.uagb-post-grid .uagb-post__columns-tablet-8 article{width:12.5%}}@media (max-width: 767px){.uagb-post-grid .uagb-post__columns-mobile-1 article{width:100%}.uagb-post-grid .uagb-post__columns-mobile-2 article{width:50%}.uagb-post-grid .uagb-post__columns-mobile-3 article{width:33.2%}.uagb-post-grid .uagb-post__columns-mobile-4 article{width:25%}.uagb-post-grid .uagb-post__columns-mobile-5 article{width:20%}.uagb-post-grid .uagb-post__columns-mobile-6 article{width:16.66%}.uagb-post-grid .uagb-post__columns-tablet-7 article{width:14.28%}.uagb-post-grid .uagb-post__columns-tablet-8 article{width:12.5%}}.entry .entry-content .uagb-post-grid a{text-decoration:none}.uagb-post-pagination-wrap a.page-numbers,.uagb-post-pagination-wrap span.page-numbers.current{padding:5px 10px;margin:0;display:inline-block}.uagb-post-grid .uagb-post-inf-loader{margin:0 auto;min-height:58px;line-height:58px;width:160px;text-align:center}.uagb-post-grid .uagb-post-inf-loader div{width:18px;height:18px;background-color:#0085ba;border-radius:100%;display:inline-block;animation:sk-bouncedelay 1.4s infinite ease-in-out both}.uagb-post-grid .uagb-post-inf-loader .uagb-post-loader-1{animation-delay:-0.32s}.uagb-post-grid .uagb-post-inf-loader .uagb-post-loader-2{animation-delay:-0.16s}@keyframes sk-bouncedelay{0%,80%,100%{transform:scale(0)}40%{transform:scale(1)}}
-.uagb-section__wrap{position:relative}.uagb-section__wrap .uagb-section__inner-wrap{margin-left:auto;margin-right:auto;position:relative;z-index:2}.uagb-section__wrap .uagb-section__overlay{height:100%;width:100%;top:0;left:0;position:absolute}.uagb-section__wrap .uagb-section__video-wrap{height:100%;width:100%;top:0;left:0;position:absolute;overflow:hidden;z-index:0;transition:opacity 1s}.uagb-section__wrap .uagb-section__video-wrap video{max-width:100%;width:100%;height:100%;margin:0;line-height:1;border:none;display:inline-block;vertical-align:baseline;-o-object-fit:cover;object-fit:cover;background-size:cover}@media (min-width: 768px) and (max-width: 1024px){.wp-block-uagb-section.uagb-section__wrap.uagb-section__background-image{background-attachment:scroll}}
-.uagb-buttons__outer-wrap .uagb-buttons__wrap{display:flex;align-items:center;justify-content:center}.uagb-buttons__outer-wrap a{color:inherit}
-.uagb-buttons-repeater{display:flex;justify-content:center;align-items:center}.uagb-buttons-repeater a.uagb-button__link{display:flex;justify-content:center}.uagb-buttons-repeater .uagb-button__icon{font-size:inherit;display:flex;align-items:center;width:15px}.uagb-buttons-repeater .uagb-button__icon svg{fill:currentColor;width:inherit;height:inherit}
-.uagb-ifb-icon-wrap,.uagb-ifb-icon-wrap *{transition:all 0.2s}.uagb-ifb-icon-wrap .uagb-ifb-icon,.uagb-ifb-content{display:inline-block}.uagb-ifb-icon svg{width:inherit;height:inherit;vertical-align:middle}.infobox-icon-above-title .uagb-ifb-left-right-wrap{text-align:center}a.uagb-infobox-cta-link span{font-size:inherit}.uagb-ifb-cta.uagb-infobox-cta-link-style:empty{display:none}a.uagb-infobox-cta-link,.entry .entry-content a.uagb-infobox-cta-link,a.uagb-infobox-link-wrap,.entry .entry-content a.uagb-infobox-link-wrap{text-decoration:none}a.uagb-infobox-cta-link:hover,.entry .entry-content a.uagb-infobox-cta-link:hover,a.uagb-infobox-link-wrap:hover,.entry .entry-content a.uagb-infobox-link-wrap:hover .entry .entry-content a.uagb-infobox-cta-link:hover{color:inherit}.uagb-infobox-icon-left-title.uagb-infobox-image-valign-middle .uagb-ifb-title-wrap,.uagb-infobox-icon-right-title.uagb-infobox-image-valign-middle .uagb-ifb-title-wrap,.uagb-infobox-image-valign-middle .uagb-ifb-imgicon-wrap,.uagb-infobox-icon-left.uagb-infobox-image-valign-middle .uagb-ifb-content,.uagb-infobox-icon-right.uagb-infobox-image-valign-middle .uagb-ifb-content{align-self:center}.uagb-infobox-left{text-align:left;justify-content:flex-start}.uagb-infobox-center{text-align:center;justify-content:center}.uagb-infobox-right{text-align:right;justify-content:flex-end}.uagb-ifb-left-right-wrap{width:100%;word-break:break-word}.uagb-infobox-icon-above-title .uagb-ifb-left-right-wrap,.uagb-infobox-icon-below-title .uagb-ifb-left-right-wrap{display:block;min-width:100%;width:100%}.uagb-infobox-icon-left-title .uagb-ifb-icon-wrap,.uagb-infobox-icon-left .uagb-ifb-icon-wrap{margin-right:10px}.uagb-infobox-icon-right-title .uagb-ifb-icon-wrap,.uagb-infobox-icon-right .uagb-ifb-icon-wrap{margin-left:10px}.uagb-infobox-icon-left .uagb-ifb-left-right-wrap,.uagb-infobox-icon-right .uagb-ifb-left-right-wrap,.uagb-infobox-icon-left-title .uagb-ifb-left-title-image,.uagb-infobox-icon-right-title .uagb-ifb-right-title-image{-js-display:flex;display:flex}.uagb-infobox-icon-right .uagb-ifb-left-right-wrap,.uagb-infobox-icon-right-title .uagb-ifb-right-title-image{justify-content:flex-end}.uagb-ifb-icon-wrap .uagb-ifb-icon span{font-style:initial;height:auto;width:auto}.uagb-ifb-imgicon-wrap .uagb-ifb-image-content{display:inline-block;line-height:0;position:relative;max-width:100%}.uagb-ifb-imgicon-wrap .uagb-ifb-image-content img{display:inline;height:auto !important;max-width:100%;width:auto;box-sizing:content-box;border-radius:inherit}.uagb-ifb-imgicon-wrap .uagb-image-crop-circle img{border-radius:100%}.uagb-ifb-imgicon-wrap .uagb-image-crop-square img{border-radius:0}.uagb-infobox-module-link{position:absolute;width:100%;height:100%;left:0;top:0;bottom:0;right:0;z-index:4}.uagb-edit-mode .uagb-infobox-module-link{z-index:2}.uagb-infobox-link-icon-after{margin-left:5px;margin-right:0}.uagb-infobox-link-icon-before{margin-left:0;margin-right:5px}.uagb-infobox-link-icon{transition:all 200ms linear}.uagb-infobox{position:relative}.uagb-ifb-separator{width:30%;border-top-width:2px;border-top-color:#333;border-top-style:solid;display:inline-block;margin:0}.uagb-ifb-separator-parent{line-height:0em;margin-left:0;margin-right:0;margin-bottom:10px}.uagb-ifb-cta-button{display:inline-block;line-height:1;background-color:#818a91;color:#fff;text-align:center}.uagb-ifb-button-wrapper .wp-block-button__link svg{fill:currentColor}.uagb-ifb-cta a{box-shadow:none;text-decoration:none}.uagb-ifb-title-wrap{width:100%}.uagb-ifb-title-wrap .uagb-ifb-title,.uagb-ifb-title-wrap .uagb-ifb-title-prefix{padding:0;margin:0;display:block}.uagb-infobox__content-wrap.uagb-infobox{position:relative}.uagb-ifb-icon span{font-size:40px;height:40px;color:#333;width:40px}.uagb-ifb-icon svg{fill:#333}.uagb-ifb-content{width:100%}.uagb-infobox__content-wrap.uagb-infobox,.uagb-ifb-content,.uagb-ifb-title-wrap,.uagb-ifb-title-prefix *,svg.dashicon.dashicons-upload{z-index:1}.uagb-ifb-left-right-wrap,button.components-button{z-index:1}.uagb-infobox-cta-link{cursor:pointer}a.uagb-infobox-link-wrap{color:inherit}.uagb-ifb-content p:empty{display:none}.uagb-infobox .uagb-ifb-icon,.uagb-infobox .uagb-ifb-image-content img{display:inline-block;box-sizing:content-box}.uagb-ifb-align-icon-after{margin-left:5px}.uagb-ifb-align-icon-before{margin-right:5px}span.uagb-ifb-button-icon.uagb-ifb-align-icon-after{float:right}.uagb-ifb-button-icon{height:15px;width:15px;font-size:15px;vertical-align:middle}.uagb-ifb-text-icon{height:15px;width:15px;font-size:15px;line-height:15px;vertical-align:middle;display:inline-block}.uagb-ifb-button-icon svg,.uagb-ifb-text-icon svg{height:inherit;width:inherit;display:inline-block}.block-editor-page #wpwrap .uagb-infobox-cta-link svg,.uagb-infobox-cta-link svg{font-style:normal}.uagb-infobox__outer-wrap{position:relative}a.uagb-infbox__link-to-all{height:100%;width:100%;top:0;left:0;position:absolute;z-index:3;box-shadow:none;text-decoration:none}@media only screen and (max-width: 976px){.uagb-infobox-stacked-tablet .uagb-ifb-left-right-wrap .uagb-ifb-imgicon-wrap{padding:0;margin-bottom:20px}.uagb-infobox-stacked-tablet.uagb-reverse-order-tablet .uagb-ifb-left-right-wrap{-js-display:inline-flex;display:inline-flex;flex-direction:column-reverse}.uagb-infobox.uagb-infobox-stacked-tablet .uagb-ifb-left-right-wrap .uagb-ifb-content,.uagb-infobox.uagb-infobox-stacked-tablet .uagb-ifb-left-right-wrap .uagb-ifb-imgicon-wrap{display:block;width:100%;text-align:center}.uagb-infobox.uagb-infobox-stacked-tablet .uagb-ifb-left-right-wrap .uagb-ifb-imgicon-wrap{margin-left:0px;margin-right:0px}.uagb-infobox-stacked-tablet .uagb-ifb-left-right-wrap{display:inline-block}.uagb-infobox-icon-left-title.uagb-infobox-stacked-tablet .uagb-ifb-imgicon-wrap,.uagb-infobox-icon-left.uagb-infobox-stacked-tablet .uagb-ifb-imgicon-wrap{margin-right:0px}.uagb-infobox-icon-right-title.uagb-infobox-stacked-tablet .uagb-ifb-imgicon-wrap,.uagb-infobox-icon-right.uagb-infobox-stacked-tablet .uagb-ifb-imgicon-wrap{margin-left:0px}.uagb-infobox-icon-left-title .uagb-ifb-separator-parent{margin:10px 0}}@media screen and (max-width: 767px){.uagb-infobox-stacked-mobile .uagb-ifb-left-right-wrap .uagb-ifb-imgicon-wrap{padding:0;margin-bottom:20px}.uagb-infobox-stacked-mobile.uagb-reverse-order-mobile .uagb-ifb-left-right-wrap{-js-display:inline-flex;display:inline-flex;flex-direction:column-reverse}.uagb-infobox.uagb-infobox-stacked-mobile .uagb-ifb-left-right-wrap .uagb-ifb-content,.uagb-infobox.uagb-infobox-stacked-mobile .uagb-ifb-left-right-wrap .uagb-ifb-imgicon-wrap{display:block;width:100%;text-align:center}.uagb-infobox.uagb-infobox-stacked-mobile .uagb-ifb-left-right-wrap .uagb-ifb-imgicon-wrap{margin-left:0px;margin-right:0px}.uagb-infobox-stacked-mobile .uagb-ifb-left-right-wrap{display:inline-block}.uagb-infobox-icon-left-title.uagb-infobox-stacked-mobile .uagb-ifb-imgicon-wrap,.uagb-infobox-icon-left.uagb-infobox-stacked-mobile .uagb-ifb-imgicon-wrap{margin-right:0px}.uagb-infobox-icon-right-title.uagb-infobox-stacked-mobile .uagb-ifb-imgicon-wrap,.uagb-infobox-icon-right.uagb-infobox-stacked-mobile .uagb-ifb-imgicon-wrap{margin-left:0px}.uagb-infobox-icon-left-title .uagb-ifb-separator-parent{margin:10px 0}}
-.uagb-testimonial__wrap{position:relative;box-sizing:border-box}.uagb-testimonial__wrap,.uagb-testimonial__wrap *{transition:all 0.2s}.uagb-icon-wrap .uagb-icon{display:inline-block}.uagb-tm__image{position:relative}.uagb-tm__imgicon-style-circle .uagb-tm__image img{border-radius:100%}.uagb-tm__imgicon-style-square .uagb-tm__image img{border-radius:0%}.uagb-tm__image img,.slick-slide .uagb-tm__image img{display:inline-block;box-sizing:content-box}.uagb-tm__author-name,.uagb-tm__company{display:inline-block}.uagb-tm__content{overflow:hidden;text-align:center;word-break:break-word;padding:15px;border-radius:inherit;position:relative}.uagb-tm__image-position-left .uagb-tm__content,.uagb-tm__image-position-right .uagb-tm__content{display:flex}.uagb-tm__meta-inner{display:inline-block}.uagb-tm__image-position-bottom .uagb-tm__image-content,.uagb-tm__image-position-bottom .uagb-testimonial-details{display:table-cell;vertical-align:middle}.uagb-tm__meta{width:100%;line-height:1}.uagb-tm__image-position-bottom .uagb-tm__image-content{padding-right:10px}.uagb-tm__author-name,.uagb-tm__company{display:block}.uagb-tm__image-aligned-middle .uagb-tm__image-content{align-self:center}.uagb-tm__desc{margin-bottom:15px}.uagb-tm__author-name{margin-bottom:5px;font-size:30px;line-height:1em}.uagb-tm__company{font-size:15px;font-style:italic;line-height:1em;color:#888888}.is-carousel .uagb-testomonial__outer-wrap{padding-left:10px;padding-right:10px}.uagb-tm__overlay{height:100%;width:100%;top:0;left:0;position:absolute;background:transparent}.uagb-tm__text-wrap{position:relative}.uagb-tm__items{visibility:hidden}.uagb-tm__items.slick-initialized{visibility:visible}.uagb-tm__image-position-top .uagb-tm__image-content{display:flex;justify-content:center}.uagb-slick-carousel.uagb-tm__arrow-outside .slick-next{right:-45px}.uagb-slick-carousel.uagb-tm__arrow-inside .slick-prev{left:25px;z-index:1}.uagb-slick-carousel.uagb-tm__arrow-inside .slick-next{right:25px}[dir="rtl"] .uagb-tm__arrow-inside.uagb-slick-carousel .slick-prev{left:auto;right:25px}[dir="rtl"] .uagb-tm__arrow-inside.uagb-slick-carousel .slick-next{left:25px;right:auto}[dir="rtl"] .uagb-tm__arrow-outside.uagb-slick-carousel .slick-next{left:-45px;right:auto}@media (max-width: 976px){.uagb-tm-stacked-tablet.uagb-tm__image-position-bottom .uagb-tm__image-content,.uagb-tm-stacked-tablet.uagb-tm__image-position-bottom .uagb-testimonial-details{display:block;vertical-align:middle}.uagb-tm-stacked-tablet.uagb-tm__image-position-left .uagb-tm__content,.uagb-tm-stacked-tablet.uagb-tm__image-position-right .uagb-tm__content{display:block}.uagb-tm-stacked-tablet.uagb-tm__image-position-right.uagb-tm-reverse-order-tablet .uagb-tm__content{display:inline-flex;flex-direction:column-reverse}.uagb-tm-stacked-tablet.uagb-tm__image-aligned-top .uagb-tm__image-content{display:inline-flex;align-self:center}.uagb-slick-carousel.uagb-tm__arrow-outside .slick-prev{left:15px;z-index:1}.uagb-slick-carousel.uagb-tm__arrow-outside .slick-next{right:15px}[dir="rtl"] .uagb-slick-carousel.uagb-tm__arrow-outside .slick-prev{left:auto;right:15px}[dir="rtl"] .uagb-slick-carousel.uagb-tm__arrow-outside .slick-next{left:15px;right:auto}}@media (max-width: 768px){.uagb-tm-stacked-mobile.uagb-tm__image-position-bottom .uagb-tm__image-content,.uagb-tm-stacked-mobile.uagb-tm__image-position-bottom .uagb-testimonial-details{display:block;vertical-align:middle}.uagb-tm-stacked-mobile.uagb-tm__image-position-left .uagb-tm__content,.uagb-tm-stacked-mobile.uagb-tm__image-position-right .uagb-tm__content{display:block}.uagb-tm-stacked-mobile.uagb-tm__image-position-right.uagb-tm-reverse-order-mobile .uagb-tm__content{display:inline-flex;flex-direction:column-reverse}.uagb-tm-stacked-mobile.uagb-tm__image-aligned-top .uagb-tm__image-content{display:inline-flex;align-self:center}}
-.uagb-team__outer-wrap .uagb-team__prefix{font-size:15px;font-style:italic;color:#888}.uagb-team__outer-wrap .uagb-team__image-wrap img{display:inline;height:auto !important;max-width:100%;width:inherit;box-sizing:content-box;border-radius:inherit}.uagb-team__outer-wrap .uagb-team__image-wrap.uagb-team__image-crop-circle img{border-radius:100%}.uagb-team__outer-wrap .uagb-team__image-wrap.uagb-team__image-crop-square img{border-radius:0}.uagb-team__outer-wrap .uagb-team__social-icon-wrap ul{list-style:none;display:flex}.uagb-team__outer-wrap .uagb-team__social-icon a span,.uagb-team__outer-wrap .uagb-team__social-icon a span:before{color:inherit;font-size:inherit;height:inherit;width:inherit}.uagb-team__outer-wrap .uagb-team__social-icon a{font-size:20px;width:20px;height:20px;color:#333;display:block}.uagb-team__outer-wrap .uagb-team__social-icon{margin-right:20px;margin-left:0}.uagb-team__outer-wrap .uagb-team__social-list{margin:0;padding:0}.uagb-team__image-position-above.uagb-team__align-center{text-align:center}.uagb-team__image-position-above.uagb-team__align-left{text-align:left}.uagb-team__image-position-above.uagb-team__align-right{text-align:right}.uagb-team__image-position-left .uagb-team__wrap,.uagb-team__image-position-right .uagb-team__wrap{-js-display:flex;display:flex}.uagb-team__image-position-left .uagb-team__content{text-align:left}.uagb-team__image-position-right .uagb-team__content{text-align:right}.uagb-team__image-position-left .uagb-team__social-icon-wrap ul{justify-content:flex-start;margin:0;padding:0}.uagb-team__image-position-right .uagb-team__social-icon-wrap ul{justify-content:flex-end;margin:0;padding:0}.uagb-team__image-position-left li{margin-right:5px}.uagb-team__image-position-right li{margin-left:5px}.uagb-team__image-position-above .uagb-team__social-icon-wrap{display:inline-block}.uagb-team__image-position-above.uagb-team__align-center .uagb-team__content{text-align:center}.uagb-team__image-position-above.uagb-team__align-left .uagb-team__content{text-align:left}.uagb-team__image-position-above.uagb-team__align-right .uagb-team__content{text-align:right}@media only screen and (max-width: 976px){.uagb-team__stack-tablet,.uagb-team__stack-tablet .uagb-team__content{text-align:center}.uagb-team__stack-tablet .uagb-team__wrap{display:inline-block}.uagb-team__stack-tablet .uagb-team__image-wrap{margin-left:auto !important;margin-right:auto !important}.uagb-team__stack-tablet .uagb-team__social-icon-wrap ul{justify-content:center}}@media screen and (max-width: 767px){.uagb-team__stack-mobile,.uagb-team__stack-mobile .uagb-team__content{text-align:center}.uagb-team__stack-mobile .uagb-team__wrap{display:inline-block}.uagb-team__stack-mobile .uagb-team__image-wrap{margin-left:auto !important;margin-right:auto !important}.uagb-team__stack-mobile .uagb-team__social-icon-wrap ul{justify-content:center}}
-.uagb-social-share__outer-wrap .uagb-social-share__wrap{display:flex;align-items:center;justify-content:center}.uagb-social-share__outer-wrap a.uagb-button__link:focus{box-shadow:none}.uagb-social-share__outer-wrap .uagb-ss__wrapper{padding:0;margin-left:5px;margin-right:5px;transition:all 0.2s;display:inline-flex;text-align:center}.uagb-social-share__outer-wrap .uagb-ss__source-wrap{display:inline-block}.uagb-social-share__outer-wrap .uagb-ss__link{color:#3a3a3a;display:inline-table;line-height:0;cursor:pointer}.uagb-social-share__outer-wrap .uagb-ss__source-icon{font-size:40px;width:40px;height:40px}.uagb-social-share__outer-wrap .uagb-ss__source-image{width:40px}.uagb-social-share__outer-wrap .uagb-ss__wrapper:first-child{margin-left:0}.uagb-social-share__outer-wrap .uagb-ss__wrapper:last-child{margin-right:0}.uagb-social-share__layout-vertical .uagb-social-share__wrap{flex-direction:column}@media (max-width: 976px){.uagb-social-share__layout-horizontal .uagb-ss__wrapper{margin-left:0;margin-right:0}}
-.wp-block-uagb-social-share .uagb-social-share__wrap .uagb-social-share__wrapper{text-decoration:none}.uagb-social-share__wrap .uagb-social-share__wrapper{box-shadow:none}.uagb-social-share__outer-wrap:not(.uagb-social-share__no-label) .uagb-social-share__source-wrap{margin-right:15px}.uagb-social-share__outer-wrap.uagb-social-share__icon-at-top .uagb-social-share__source-wrap{align-self:flex-start;margin-top:5px}
-.uagb-google-map__wrap{display:flex}.uagb-google-map__wrap .uagb-google-map__iframe{width:100%;box-shadow:none;border:none;padding:0;margin:0}
-.uagb-icon-list__outer-wrap .uagb-icon-list__wrap{display:flex;align-items:flex-start;justify-content:flex-start}.uagb-icon-list__outer-wrap.wp-block-uagb-icon-list .uagb-icon-list__wrap a.uagb-icon-list__wrapper,.uagb-icon-list__outer-wrap.wp-block-uagb-icon-list .uagb-icon-list__wrap a.uagb-icon-list__wrapper:focus,.uagb-icon-list__outer-wrap.wp-block-uagb-icon-list .uagb-icon-list__wrap a.uagb-icon-list__wrapper:active,.uagb-icon-list__outer-wrap.wp-block-uagb-icon-list .uagb-icon-list__wrap a.uagb-icon-list__wrapper:visited{text-decoration:none}.uagb-icon-list__outer-wrap a.uagb-button__link:focus{box-shadow:none}.uagb-icon-list__outer-wrap .uagb-icon-list__wrapper>p{display:none}.uagb-icon-list__outer-wrap .uagb-icon-list__wrapper{padding:0;margin-left:5px;margin-right:5px;transition:all 0.2s;display:inline-flex;text-align:center}.uagb-icon-list__outer-wrap .uagb-icon-list__content-wrap,.uagb-icon-list__outer-wrap .uagb-icon-list__source-wrap{width:inherit;display:inline-block}.uagb-icon-list__outer-wrap .uagb-icon-list__source-wrap{display:inherit;align-items:center}.uagb-icon-list__outer-wrap .uagb-icon-list__content-wrap{color:#3a3a3a;display:flex;align-items:center}.uagb-icon-list__outer-wrap .uagb-icon-list__source-icon,.uagb-icon-list__outer-wrap .uagb-icon-list__source-icon:before{font-size:40px;width:40px;height:40px}.uagb-icon-list__outer-wrap .uagb-icon-list__source-icon svg{display:block}.uagb-icon-list__outer-wrap .uagb-icon-list__source-image{width:40px}.uagb-icon-list__outer-wrap .uagb-icon-list__wrapper:first-child{margin-left:0}.uagb-icon-list__outer-wrap .uagb-icon-list__wrapper:last-child{margin-right:0}.uagb-icon-list__outer-wrap .uagb-icon-list__wrap>p{display:none}.uagb-icon-list__outer-wrap .uagb-icon-list__wrapper[href="/"]{pointer-events:none;cursor:text}.uagb-icon-list__outer-wrap.wp-block-uagb-icon-list .uagb-icon-list__wrap .uagb-icon-list__wrapper{text-decoration:none}.uagb-icon-list__outer-wrap .uagb-icon-list__wrap .uagb-icon-list__wrapper{box-shadow:none}.uagb-icon-list__outer-wrap.uagb-icon-list__icon-at-top .uagb-icon-list__source-wrap{align-self:flex-start}.uagb-icon-list__outer-wrap:not(.uagb-icon-list__no-label) .uagb-icon-list__source-wrap{margin-right:15px}.uagb-icon-list__no-label .uagb-icon-list__label-wrap{display:none}
-.wp-block-uagb-icon-list-child{position:relative}.wp-block-uagb-icon-list-child>a{position:absolute;top:0;left:0;width:100%;height:100%}img.uagb-icon-list__source-image{max-width:unset}
-.uagb-rest_menu__wrap{position:relative;padding-left:5px;padding-right:5px;box-sizing:border-box}.uagb-rest_menu__wrap,.uagb-rest_menu__wrap *{transition:all 0.2s}.uagb-rm__image img,.slick-slide .uagb-rm__image img{display:inline-block;box-sizing:content-box}.uagb-rm__title,.uagb-rm__price{display:inline-block}.uagb-rm__desc{margin-bottom:15px;font-style:italic}.uagb-rm__content{overflow:hidden;text-align:left;word-break:break-word;padding:15px;border-radius:inherit;position:relative;padding:5px}.uagb-rm__image-position-left .uagb-rm__content,.uagb-rm__image-position-right .uagb-rm__content{-js-display:flex;display:flex}.uagb-rm-details{display:table;width:100%}.uagb-rm__title-wrap,.uagb-rm__price-wrap{display:table-cell}.uagb-rm__title-wrap,.uagb-rm__image-position-left.uagb-rm__align-center .uagb-rm__price-wrap,.uagb-rm__image-position-right.uagb-rm__align-center .uagb-rm__price-wrap{width:85%}.uagb-rm__price-wrap,.uagb-rm__image-position-left.uagb-rm__align-center .uagb-rm__price-wrap,.uagb-rm__image-position-right.uagb-rm__align-center .uagb-rm__price-wrap{width:15%}.uagb-rm__title,.uagb-rm__price{display:block}.uagb-rm__align-center .uagb-rm-details,.uagb-rm__align-center .uagb-rm__title-wrap,.uagb-rm__align-center .uagb-rm__price-wrap{display:block;width:100%}.uagb-rm__image-aligned-middle .uagb-rm__image-content{align-self:center}.uagb-rm__image{overflow:hidden}.uagb-rm__title{margin-bottom:5px;font-size:20px}.uagb-rm__price{font-style:italic;text-align:right}.uagb-rm__image-position-center.uagb-rm__align-center .uagb-rm-details,.uagb-rm__image-position-center.uagb-rm__align-center .uagb-rm__title-wrap,.uagb-rm__image-position-center.uagb-rm__align-center .uagb-rm__price-wrap{display:block;width:100%;text-align:center}.uagb-rm__align-center .uagb-rm__price{text-align:center}.uagb-rm__align-right .uagb-rm-details{display:flex;width:100%;flex-direction:row-reverse}.uagb-rm__align-right .uagb-rm__price{text-align:left}.uagb-rm__align-left .uagb-rm__price{text-align:right}.uagb-rm__image-position-left.uagb-rm__align-left .uagb-rm__price,.uagb-rm__image-position-left.uagb-rm__align-right .uagb-rm__price,.uagb-rm__image-position-left.uagb-rm__align-center .uagb-rm__price{text-align:right}.uagb-rm__image-position-left.uagb-rm__align-left .uagb-rm-details,.uagb-rm__image-position-left.uagb-rm__align-right .uagb-rm-details,.uagb-rm__image-position-left.uagb-rm__align-center .uagb-rm-details{display:flex;flex-direction:unset;text-align:left}.uagb-rm__image-position-left.uagb-rm__align-left .uagb-rm__title-wrap,.uagb-rm__image-position-left.uagb-rm__align-right .uagb-rm__title-wrap,.uagb-rm__image-position-left.uagb-rm__align-center .uagb-rm__title-wrap,.uagb-rm__image-position-left.uagb-rm__align-left .uagb-rm__image-content,.uagb-rm__image-position-left.uagb-rm__align-right .uagb-rm__image-content,.uagb-rm__image-position-left.uagb-rm__align-center .uagb-rm__image-content{text-align:left}.uagb-rm__image-position-right.uagb-rm__align-left .uagb-rm-details,.uagb-rm__image-position-right.uagb-rm__align-right .uagb-rm-details,.uagb-rm__image-position-right.uagb-rm__align-center .uagb-rm-details{display:flex;flex-direction:row-reverse;text-align:right}.uagb-rm__image-position-right.uagb-rm__align-left .uagb-rm__price,.uagb-rm__image-position-right.uagb-rm__align-right .uagb-rm__price,.uagb-rm__image-position-right.uagb-rm__align-center .uagb-rm__price{text-align:left}.uagb-rm__image-position-right.uagb-rm__align-left .uagb-rm__title-wrap,.uagb-rm__image-position-right.uagb-rm__align-right .uagb-rm__title-wrap,.uagb-rm__image-position-right.uagb-rm__align-center .uagb-rm__title-wrap,.uagb-rm__image-position-right.uagb-rm__align-left .uagb-rm__image-content,.uagb-rm__image-position-right.uagb-rm__align-right .uagb-rm__image-content,.uagb-rm__image-position-right.uagb-rm__align-center .uagb-rm__image-content{text-align:right}.uagb-rest_menu__outer-wrap{position:relative}.uagb-rm__overlay{height:100%;width:100%;top:0;left:0;position:absolute;background:transparent}.uagb-tm-parent{padding:30px}.uagb-rm__text-wrap{position:relative;display:block;width:100%}.uagb-rest_menu__wrap{position:relative}.uagb-rest_menu__outer-wrap:after{content:"";display:block;clear:both}.uagb-rest_menu__wrap.uagb-rm__desk-column-3{display:block;width:33%;float:left;width:calc(100% / 3);padding-left:10px;padding-right:10px}.uagb-rest_menu__wrap.uagb-rm__desk-column-2{display:block;width:49%;float:left;padding-left:10px;padding-right:10px}.uagb-rest_menu__wrap.uagb-rm__desk-column-1{display:block;width:100%;float:left;padding-left:10px;padding-right:10px}.uagb-rm__separator-parent{line-height:0em;margin-left:0;margin-right:0;margin-bottom:10px;-js-display:flex;display:-moz-flexbox;display:flex}.uagb-rm__separator{width:100%;border-top-width:1px;border-top-color:#b2b4b5;border-top-style:inherit}.uagb-rm__image-position-left .uagb-rm__image{margin-right:10px}.uagb-rm__image-position-right .uagb-rm__image{margin-left:10px}@media (max-width: 976px){.uagb-rm__image-position-left.uagb-rm-stacked-tablet .uagb-rm__content,.uagb-rm__image-position-right.uagb-rm-stacked-tablet .uagb-rm__content{display:block;-js-display:block;display:block}.uagb-rm__image-position-right.uagb-rm-stacked-tablet.uagb-rm-reverse-order-tablet .uagb-rm__content{-js-display:flex;display:-moz-flexbox;display:flex;flex-direction:column-reverse}.uagb-rest_menu__wrap.uagb-rm__tablet-column-3{width:33%;float:left;padding-left:10px;padding-right:10px}.uagb-rest_menu__wrap.uagb-rm__tablet-column-2{width:50%;float:left;padding-left:10px;padding-right:10px}.uagb-rest_menu__wrap.uagb-rm__tablet-column-1{width:100%;float:left;padding-left:10px;padding-right:10px}.uagb-rm__image-position-right.uagb-rm-stacked-tablet.uagb-rm__image-aligned-middle .uagb-rm__image-content{align-self:flex-end}.uagb-rm__image-position-left.uagb-rm-stacked-tablet.uagb-rm__image-aligned-middle .uagb-rm__image-content{align-self:flex-start}}@media (max-width: 767px){.uagb-rm__image-position-left.uagb-rm-stacked-mobile .uagb-rm__content,.uagb-rm__image-position-right.uagb-rm-stacked-mobile .uagb-rm__content{display:block;-js-display:block;display:block}.uagb-rm__image-position-right.uagb-rm-stacked-mobile.uagb-rm-reverse-order-mobile .uagb-rm__content{-js-display:flex;display:-moz-flexbox;display:flex;flex-direction:column-reverse}.uagb-rest_menu__wrap.uagb-rm__mobile-column-3{width:33%;float:left;padding-left:10px;padding-right:10px}.uagb-rest_menu__wrap.uagb-rm__mobile-column-2{width:50%;float:left;padding-left:10px;padding-right:10px}.uagb-rest_menu__wrap.uagb-rm__mobile-column-1{width:100%;float:left;padding-left:10px;padding-right:10px}.uagb-rm__image-position-right.uagb-rm-stacked-mobile.uagb-rm__image-aligned-middle .uagb-rm__image-content{align-self:flex-end}.uagb-rm__image-position-left.uagb-rm-stacked-mobile.uagb-rm__image-aligned-middle .uagb-rm__image-content{align-self:flex-start}}
-.uagb-timeline__widget{position:relative;display:flex;align-items:flex-start;font-size:inherit;color:inherit;margin-bottom:inherit}.uagb-timeline__widget a{text-decoration:none;color:inherit;font-size:inherit;margin-bottom:inherit}.uagb-timeline__image a{display:block;position:relative;max-width:100%}.uagb-timeline__image img{display:inline-block;box-sizing:content-box}.uagb-timeline__author{text-transform:uppercase}.uagb-timeline__main{position:relative}.uagb-content{word-break:break-word}a.uagb-timeline__link{padding:5px 10px;display:inline-block}.uagb-timeline__headingh1,.uagb-timeline__headingh2,.uagb-timeline__headingh3,.uagb-timeline__headingh4,.uagb-timeline__headingh5,.uagb-timeline__headingh6{margin-bottom:0px}.uagb-timeline__inner-date-new p,.uagb-timeline__date-inner .uagb-timeline__inner-date-new p{margin-bottom:0px}.uagb-timeline__line{background-color:#eeeeee}.uagb-timeline__line__inner{background-color:#5cb85c;width:100%}.uagb-timeline__main .uagb-timeline__icon-new{line-height:1em;display:inline-block;vertical-align:middle;font-style:normal}.uagb-timeline__center-block .uagb-timeline__date-hide{display:none}.uagb-timeline__field:not(:last-child){margin-bottom:20px}.uagb-timeline__center-block .uagb-timeline__widget.uagb-timeline__right,.uagb-timeline__right-block .uagb-timeline__widget{flex-direction:row-reverse}.uagb-timeline__left-block .uagb-timeline__day-left .uagb-timeline__events-inner-new,.uagb-timeline__left-block .uagb-timeline__day-right .uagb-timeline__events-inner-new{text-align:left}.uagb-timeline__right-block .uagb-timeline__center-block .uagb-timeline__date-new{display:block}.uagb-timeline__right-block .uagb-timeline__day-left .uagb-timeline__events-inner-new,.uagb-timeline__right-block .uagb-timeline__day-right .uagb-timeline__events-inner-new{text-align:inherit}.uagb-timeline__right-block .uagb-timeline__line{right:16px;left:auto}.uagb-timeline__right-block .uagb-timeline__right .uagb-timeline__arrow:after,.uagb-timeline__right-block .uagb-timeline__left .uagb-timeline__arrow:after{top:0}.uagb-timeline__right-block .uagb-timeline__right .uagb-timeline__arrow,.uagb-timeline__right-block .uagb-timeline__left .uagb-timeline__arrow{top:0;right:0;width:10px;height:40px;position:absolute}.uagb-timeline__right-block .uagb-timeline__right .uagb-timeline__arrow{right:-12px}.uagb-timeline__right-block .uagb-timeline__left .uagb-timeline__arrow{right:-10px}.uagb-timeline__right-block .uagb-timeline__marker,.uagb-timeline__right-block .uagb-timeline__day-new{max-width:100%;position:relative}.uagb-timeline__right-block .uagb-timeline__day-new{margin-right:14px}.uagb-timeline__right-block .uagb-timeline__marker{flex-shrink:0;flex-grow:0}.uagb-timeline__right-block .uagb-timeline__day-new{flex-grow:1}.uagb-timeline__left-block .uagb-timeline__marker,.uagb-timeline__left-block .uagb-timeline__day-new{max-width:100%;position:relative}.uagb-timeline__left-block .uagb-timeline__line{left:20px;right:auto}.uagb-timeline__left-block .uagb-timeline__day-new{margin-left:14px;flex-grow:1;order:1}.uagb-timeline__left-block .uagb-timeline__marker{order:0;flex-shrink:0;flex-grow:0}.uagb-timeline__left-block .uagb-timeline__right .uagb-timeline__arrow:after,.uagb-timeline__left-block .uagb-timeline__left .uagb-timeline__arrow:after{top:0}.uagb-timeline__left-block .uagb-timeline__right .uagb-timeline__arrow,.uagb-timeline__left-block .uagb-timeline__left .uagb-timeline__arrow{top:0;width:10px;height:40px;position:absolute}.uagb-timeline__left-block .uagb-timeline__right .uagb-timeline__arrow{left:-10px}.uagb-timeline__left-block .uagb-timeline__left .uagb-timeline__arrow{left:-12px}.uagb-timeline__left-block .uagb-timeline__right .uagb-timeline__arrow:after,.uagb-timeline__left-block .uagb-timeline__left .uagb-timeline__arrow:after,.uagb-timeline__right-block .uagb-timeline__right .uagb-timeline__arrow:after,.uagb-timeline__right-block .uagb-timeline__left .uagb-timeline__arrow:after{top:50%;transform:translateY(-50%)}.uagb-timeline__marker{background-color:#eeeeee;border-radius:999px;position:relative;display:flex;align-items:center;justify-content:center;z-index:1;transition:all .2s ease-in-out}.uagb-timeline__main .uagb-timeline__days .uagb-timeline__field-wrap:hover .uagb-timeline__marker{transition:all .2s ease-in-out}.uagb-timeline__center-block .uagb-timeline__marker{order:1;flex-shrink:0;flex-grow:0}.uagb-timeline__center-block .uagb-timeline__day-new,.uagb-timeline__center-block .uagb-timeline__date-new{flex-grow:1;flex-basis:50%;max-width:100%;position:relative}.uagb-timeline__center-block .uagb-timeline__right .uagb-timeline__day-new{order:2;padding-left:0;padding-right:12px}.uagb-timeline__center-block .uagb-timeline__left .uagb-timeline__day-new{order:2;padding-right:0;padding-left:12px}.uagb-timeline__events-inner-new{padding:40px}.uagb-timeline__center-block .uagb-timeline__left .uagb-timeline__date-new{display:flex;justify-content:flex-end}.uagb-timeline__center-block .uagb-timeline__right .uagb-timeline__date-new{display:flex;justify-content:flex-start}.uagb-timeline__left-block .uagb-timeline__date-new{margin-right:10px}.uagb-timeline__right-block .uagb-timeline__date-new{margin-left:10px}.uagb-timeline__right-block .uagb-timeline__date-new{display:flex;align-items:center}.uagb-timeline__center-block .uagb-timeline__right .uagb-timeline__arrow{right:0px;top:0;width:10px;height:40px;position:absolute}.uagb-timeline__center-block .uagb-timeline__right .uagb-timeline__arrow:after,.uagb-timeline__center-block .uagb-timeline__left .uagb-timeline__arrow:after{top:50%;transform:translateY(-50%)}.uagb-timeline__center-block .uagb-timeline__left .uagb-timeline__arrow{left:0px;top:0;width:10px;height:40px;position:absolute}.uagb-timeline__arrow-center .uagb-timeline__widget{align-items:center}.uagb-timeline__arrow-bottom .uagb-timeline__widget{align-items:flex-end}.uagb-timeline__arrow-center .uagb-timeline__left .uagb-timeline__arrow,.uagb-timeline__arrow-center .uagb-timeline__right .uagb-timeline__arrow{top:50%;transform:translateY(-50%)}.uagb-timeline__arrow-bottom .uagb-timeline__left .uagb-timeline__arrow,.uagb-timeline__arrow-bottom .uagb-timeline__right .uagb-timeline__arrow{top:100%;transform:translateY(-100%)}.uagb-timeline__day-right .uagb-timeline__events-inner{text-align:right}.uagb-timeline__day-left .uagb-timeline__events-inner{text-align:left}.uagb-timeline__arrow-top .uagb-timeline__date-new .uagb-timeline__date-new,.uagb-timeline__arrow-bottom .uagb-timeline__date-new .uagb-timeline__date-new{padding-top:8px;padding-bottom:8px}.uagb-timeline__events-inner-new,.uagb-timeline__arrow{transition:background .2s ease-in-out}.uagb-timeline__arrow:after{transition:border-color .2s ease-in-out}.uagb-timeline__date-new{transition:color .2s ease-in-out}.uagb-timeline__widget.uagb-timeline__left.hide-events .uagb-timeline__events-inner-new,.uagb-timeline__widget.uagb-timeline__left.hide-events .uagb-timeline__date-new{visibility:hidden}.uagb-timeline__widget.uagb-timeline__right.hide-events .uagb-timeline__events-inner-new,.uagb-timeline__widget.uagb-timeline__right.hide-events .uagb-timeline__date-new{visibility:hidden}.uagb-timeline__main .uagb-timeline__year{display:flex;position:relative}.uagb-timeline__main .uagb-timeline__year span{display:inline-block;padding-bottom:6px}.uagb-timeline__day-left .uagb-timeline__arrow:after{content:'';left:0px;position:absolute;display:inline;width:0;height:0;border-top:12px solid transparent;border-bottom:12px solid transparent}.uagb-timeline__right .uagb-timeline__day-left .uagb-timeline__arrow:after{right:0}.uagb-timeline__day-right .uagb-timeline__arrow:after{content:'';right:0px;position:absolute;display:inline;width:0;height:0;border-top:12px solid transparent;border-bottom:12px solid transparent}.uagb-timeline__icon{width:100px;height:100px;border-radius:50%;text-align:center;line-height:100px;vertical-align:middle;position:relative;z-index:1}.uagb-timeline__main .uagb-timeline__date .uagb-timeline__inner-date-new{white-space:nowrap;margin:0px}.uagb-timeline__main .uagb-timeline__line{position:absolute;transform:translateX(-50%)}.uagb-timeline__right-block .uagb-timeline__main .uagb-timeline__line{position:absolute;transform:translateX(50%)}.uagb-timeline__center-block .uagb-timeline__line{left:50%;right:auto}.uagb-timeline__main .in-view i.uagb-timeline__in-view-icon{transition:background 0.25s ease-out 0.25s, width 0.25s ease-in-out, height 0.25s ease-in-out, color 0.25s ease-in-out, font-size 0.25s ease-out}.uagb-timeline__left-block .uagb-timeline__days{text-align:left}.uagb-timeline__left-block .uagb-timeline__day-right .uagb-timeline__arrow:after{content:'';position:absolute;display:inline;width:0;height:0;border-top:12px solid transparent;border-bottom:12px solid transparent}.uagb-timeline__center-block .uagb-timeline__days{text-align:center}.uagb-timeline__center-block .uagb-timeline__day-right .uagb-timeline__arrow:after{content:'';right:0px;top:50%;transform:translateY(-50%);position:absolute;display:inline;width:0;height:0;border-top:12px solid transparent;border-bottom:12px solid transparent}.uagb-timeline__right .uagb-timeline__days{text-align:right}.uagb-timeline__outer-wrap span.dashicons-admin-users.dashicons{display:inline;vertical-align:baseline;margin-right:4px}@media screen and (max-width: 1023px){.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__line{position:absolute;transform:translateX(50%)}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__date-hide{display:block}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-left .uagb-timeline__events-inner-new,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-right .uagb-timeline__events-inner-new{text-align:left}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__line{right:20px;left:auto}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__marker,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-new{max-width:100%;position:relative}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__line{left:20px;right:auto}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-new{margin-left:16px}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__marker{order:0;flex-shrink:0;flex-grow:0}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-new{flex-grow:1;order:1}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__right .uagb-timeline__arrow:after,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__left .uagb-timeline__arrow:after{top:0}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__right .uagb-timeline__arrow,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__left .uagb-timeline__arrow{width:10px;height:40px;position:absolute}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__right .uagb-timeline__arrow{left:-10px}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__left .uagb-timeline__arrow{left:-12px}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__right .uagb-timeline__arrow:after,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__left .uagb-timeline__arrow:after{top:50%;transform:translateY(-50%)}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__days{text-align:left}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-right .uagb-timeline__arrow:after{content:'';position:absolute;display:inline;width:0;height:0;border-top:12px solid transparent;border-bottom:12px solid transparent}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__widget.uagb-timeline__right{flex-direction:unset}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__date-new{display:none}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-new,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__date-new{flex-grow:unset;flex-basis:unset;max-width:100%;width:100%;position:relative}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__right .uagb-timeline__day-new{order:unset;padding-left:0;padding-right:0}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__left .uagb-timeline__day-new{order:unset;padding-right:0;padding-left:0}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__left .uagb-timeline__date-new{display:none}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__right .uagb-timeline__date-new{display:none}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__widget{flex-direction:row-reverse}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__day-left .uagb-timeline__events-inner-new,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__day-right .uagb-timeline__events-inner-new{text-align:right}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__line{right:16px;left:auto}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__arrow:after,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__arrow:after{top:0}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__arrow,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__arrow{left:auto;right:0;width:10px;height:40px;position:absolute}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__arrow{right:-12px}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__arrow{right:-10px}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__marker,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__day-new{max-width:100%;position:relative}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__day-new{margin-right:16px}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__marker{flex-shrink:0;flex-grow:0}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__day-new{flex-grow:1}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__arrow:after,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__arrow:after{top:50%;transform:translateY(-50%)}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__days{text-align:right}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__day-new,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__date-new{flex-grow:unset;flex-basis:unset;max-width:100%;position:relative}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__day-new{order:unset;padding-left:0;padding-right:0}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__day-new{order:unset;padding-right:0;padding-left:0}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__date-new{display:none}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__date-new{display:none}}@media screen and (max-width: 767px){.uagb-timeline-responsive-none .uagb-timeline__events-inner-new{padding:15px}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__date-hide{display:block}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__day-left .uagb-timeline__events-inner-new,.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__day-right .uagb-timeline__events-inner-new{text-align:left}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__line{right:20px;left:auto}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__marker,.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__day-new{max-width:100%;position:relative}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__line{left:20px;right:auto}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__day-new{margin-left:16px}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__marker{order:0;flex-shrink:0;flex-grow:0}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__day-new{flex-grow:1;order:1}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__right .uagb-timeline__arrow:after,.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__left .uagb-timeline__arrow:after{top:0}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__right .uagb-timeline__arrow,.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__left .uagb-timeline__arrow{width:10px;height:40px;position:absolute}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__right .uagb-timeline__arrow{left:-10px}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__left .uagb-timeline__arrow{left:-12px}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__right .uagb-timeline__arrow:after,.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__left .uagb-timeline__arrow:after{top:50%;transform:translateY(-50%)}.uagb-timeline__day-left .uagb-timeline__events-inner-new{text-align:left}.uagb-timeline__left-block .uagb-timeline__date-new{margin-right:10px}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__days{text-align:left}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__day-right .uagb-timeline__arrow:after{content:'';position:absolute;display:inline;width:0;height:0;border-top:12px solid transparent;border-bottom:12px solid transparent}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__widget.uagb-timeline__right{flex-direction:unset}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__date-new{display:none}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__day-new,.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__date-new{flex-grow:unset;flex-basis:unset;max-width:100%;position:relative}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__right .uagb-timeline__day-new{order:unset;padding-left:0;padding-right:0}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__left .uagb-timeline__day-new{order:unset;padding-right:0;padding-left:0}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__left .uagb-timeline__date-new{display:none}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__right .uagb-timeline__date-new{display:none}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__widget{flex-direction:row-reverse}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__day-left .uagb-timeline__events-inner-new,.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__day-right .uagb-timeline__events-inner-new{text-align:right}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__line{right:16px;left:auto}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__arrow:after,.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__arrow:after{top:0}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__arrow,.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__arrow{left:auto;right:0;width:10px;height:40px;position:absolute}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__arrow{right:-12px}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__arrow{right:-10px}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__marker,.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__day-new{max-width:100%;position:relative}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__day-new{margin-right:16px}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__marker{flex-shrink:0;flex-grow:0}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__day-new{flex-grow:1}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__arrow:after,.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__arrow:after{top:50%;transform:translateY(-50%)}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__line{position:absolute;transform:translateX(50%)}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__days{text-align:right}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__day-new,.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__date-new{flex-grow:unset;flex-basis:unset;max-width:100%;position:relative}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__day-new{order:unset;padding-left:0;padding-right:0}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__day-new{order:unset;padding-right:0;padding-left:0}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__date-new{display:none}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__date-new{display:none}}.uagb-timeline__line__inner{background-color:#61ce70;width:100%}.uagb-timeline__center-block .uagb-timeline__day-right .uagb-timeline__arrow:after{border-left:13px solid #eeeeee}.uagb-timeline__right-block .uagb-timeline__day-right .uagb-timeline__arrow:after{border-left:13px solid #eeeeee}.uagb-timeline__right-block .uagb-timeline__day-left .uagb-timeline__arrow:after{border-left:13px solid #eeeeee}.rtl .uagb-timeline__center-block .uagb-timeline__day-right .uagb-timeline__arrow:after{border-right:13px solid #eeeeee;border-left:none}.rtl .uagb-timeline__right-block .uagb-timeline__day-right .uagb-timeline__arrow:after{border-right:13px solid #eeeeee;border-left:none}.rtl .uagb-timeline__right-block .uagb-timeline__day-left .uagb-timeline__arrow:after{border-right:13px solid #eeeeee;border-left:none}.uagb-timeline__left-block .uagb-timeline__day-right .uagb-timeline__arrow:after{border-right:13px solid #eeeeee}.uagb-timeline__center-block .uagb-timeline__day-left .uagb-timeline__arrow:after{border-right:13px solid #eeeeee}.uagb-timeline__left-block .uagb-timeline__day-left .uagb-timeline__arrow:after{border-right:13px solid #eeeeee}.rtl .uagb-timeline__left-block .uagb-timeline__day-right .uagb-timeline__arrow:after{border-left:13px solid #eeeeee;border-right:none}.rtl .uagb-timeline__center-block .uagb-timeline__day-left .uagb-timeline__arrow:after{border-left:13px solid #eeeeee;border-right:none}.rtl .uagb-timeline__left-block .uagb-timeline__day-left .uagb-timeline__arrow:after{border-left:13px solid #eeeeee;border-right:none}.uagb-timeline__day-right .uagb-timeline__events-inner-new{border-radius:4px 4px 4px 4px}.uagb-timeline__day-left .uagb-timeline__events-inner-new{border-radius:4px 4px 4px 4px}.uagb-timeline__line{width:3px}.uagb-timeline__main .uagb-timeline__icon-new{font-size:16px}.uagb-timeline__marker{min-height:3em;min-width:3em;line-height:3em}.uagb-timeline__arrow{height:3em}.uagb-timeline__left-block .uagb-timeline__line{left:calc(3em / 2)}.uagb-timeline__right-block .uagb-timeline__line{right:calc(3em / 2)}.rtl .uagb-timeline__left-block .uagb-timeline__line{right:calc(3em / 2);left:auto}.rtl .uagb-timeline__right-block .uagb-timeline__line{left:calc(3em / 2);right:auto}.uagb-timeline-desc-content p{font-size:inherit}.uagb-timeline__main p:empty{display:none}@media (max-width: 976px){.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__line{position:absolute;transform:translateX(50%)}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__line{position:absolute;transform:translateX(50%)}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__date-hide{display:block}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-left .uagb-timeline__events-inner-new,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-right .uagb-timeline__events-inner-new{text-align:left}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__line{right:20px;left:auto}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__marker,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-new{max-width:100%;position:relative}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__line{left:20px;right:auto}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-new{margin-left:16px}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__marker{order:0;flex-shrink:0;flex-grow:0}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-new{flex-grow:1;order:1}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__right .uagb-timeline__arrow:after,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__left .uagb-timeline__arrow:after{top:0}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__right .uagb-timeline__arrow,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__left .uagb-timeline__arrow{width:10px;height:40px;position:absolute}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__right .uagb-timeline__arrow{left:-10px}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__left .uagb-timeline__arrow{left:-12px}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__right .uagb-timeline__arrow:after,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__left .uagb-timeline__arrow:after{top:50%;transform:translateY(-50%)}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__days{text-align:left}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-right .uagb-timeline__arrow:after{content:'';position:absolute;display:inline;width:0;height:0;border-top:12px solid transparent;border-bottom:12px solid transparent}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__widget.uagb-timeline__right{flex-direction:unset}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__date-new{display:none}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-new,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__date-new{flex-grow:unset;flex-basis:unset;max-width:100%;width:100%;position:relative}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__right .uagb-timeline__day-new{order:unset;padding-left:0;padding-right:0}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__left .uagb-timeline__day-new{order:unset;padding-right:0;padding-left:0}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__left .uagb-timeline__date-new{display:none}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__right .uagb-timeline__date-new{display:none}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__widget{flex-direction:row-reverse}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__day-left .uagb-timeline__events-inner-new,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__day-right .uagb-timeline__events-inner-new{text-align:right}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__line{right:16px;left:auto}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__arrow:after,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__arrow:after{top:0}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__arrow,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__arrow{left:auto;right:0;width:10px;height:40px;position:absolute}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__arrow{right:-12px}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__arrow{right:-10px}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__marker,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__day-new{max-width:100%;position:relative}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__day-new{margin-right:16px}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__marker{flex-shrink:0;flex-grow:0}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__day-new{flex-grow:1}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__arrow:after,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__arrow:after{top:50%;transform:translateY(-50%)}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__days{text-align:right}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__day-new,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__date-new{flex-grow:unset;flex-basis:unset;max-width:100%;position:relative}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__day-new{order:unset;padding-left:0;padding-right:0}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__day-new{order:unset;padding-right:0;padding-left:0}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__date-new,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__date-new{display:none}.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-right .uagb-timeline__arrow:after,.uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-left .uagb-timeline__arrow:after{border-right:13px solid #eeeeee;border-left:none}.uagb-timeline__responsive-tablet.uagb-timeline__center-block .uagb-timeline__author,.uagb-timeline__responsive-tablet.uagb-timeline__center-block .uagb-timeline__link_parent,.uagb-timeline__responsive-tablet.uagb-timeline__center-block .uagb-timeline__image a,.uagb-timeline__responsive-tablet.uagb-timeline__center-block .uagb-timeline__heading,.uagb-timeline__responsive-tablet.uagb-timeline__center-block .uagb-timeline-desc-content,.uagb-timeline__responsive-tablet.uagb-timeline__center-block .uagb-timeline__date-inner{text-align:left}.uagb-timeline__responsive-tablet.uagb-timeline__center-block .uagb-timeline__date-hide.uagb-timeline__date-inner{text-align:left}}@media (max-width: 767px){.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__day-right .uagb-timeline__arrow:after,.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__day-left .uagb-timeline__arrow:after,.rtl .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__day-right .uagb-timeline__arrow:after,.rtl .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__day-left .uagb-timeline__arrow:after{border-right:13px solid #eeeeee;border-left:none}.rtl .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__day-right .uagb-timeline__arrow:after,.rtl .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__day-left .uagb-timeline__arrow:after,.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__day-right .uagb-timeline__arrow:after,.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__day-left .uagb-timeline__arrow:after{border-left:13px solid #eeeeee;border-right:none}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__line,.rtl .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__line{left:calc(3em / 2);right:auto}.uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__line,.rtl .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__line{right:calc(3em / 2);left:auto}.uagb-timeline__responsive-mobile.uagb-timeline__center-block .uagb-timeline__author,.uagb-timeline__responsive-mobile.uagb-timeline__center-block .uagb-timeline__link_parent,.uagb-timeline__responsive-mobile.uagb-timeline__center-block .uagb-timeline__image a,.uagb-timeline__responsive-mobile.uagb-timeline__center-block .uagb-timeline__heading,.uagb-timeline__responsive-mobile.uagb-timeline__center-block .uagb-timeline-desc-content,.uagb-timeline__responsive-mobile.uagb-timeline__center-block .uagb-timeline__date-inner{text-align:left}.uagb-timeline__responsive-mobile.uagb-timeline__center-block .uagb-timeline__date-hide.uagb-timeline__date-inner{text-align:left}}
-.uagb-cta__outer-wrap{position:relative}.uagb-cta__outer-wrap .wp-block-button__link svg{fill:currentColor}.uagb-cta__outer-wrap .uagb-cta__content{display:inline-block}.uagb-cta__outer-wrap a.uagb-cta__block-link span{font-size:inherit;vertical-align:middle;display:inline-block;float:left}.uagb-cta__outer-wrap .uagb-cta__content-right .uagb-cta__link-wrapper{width:30%}.uagb-cta__outer-wrap .uagb-cta__content-right .uagb-cta__content{width:70%}.uagb-cta__outer-wrap .uagb-cta__content-right .uagb-cta__button-wrapper{display:inline-block;float:right}.uagb-cta__outer-wrap .uagb-cta__link-wrapper.uagb-cta__block-link-style:empty{display:none}.uagb-cta__outer-wrap a.uagb-cta__block-link,.uagb-cta__outer-wrap .entry .entry-content a.uagb-cta__block-link,.uagb-cta__outer-wrap a.uagb-cta__block-link-wrap,.uagb-cta__outer-wrap .entry .entry-content a.uagb-cta__block-link-wrap{text-decoration:none}.uagb-cta__outer-wrap a.uagb-cta__block-link:hover,.uagb-cta__outer-wrap .entry .entry-content a.uagb-cta__block-link:hover,.uagb-cta__outer-wrap a.uagb-cta__block-link-wrap:hover,.uagb-cta__outer-wrap .entry .entry-content a.uagb-cta__block-link-wrap:hover .entry .entry-content a.uagb-cta__block-link:hover{color:inherit}.uagb-cta__outer-wrap .uagb-cta__content-right{text-align:right;justify-content:flex-end}.uagb-cta__outer-wrap .uagb-cta__left-right-wrap{width:100%;word-break:break-word}.uagb-cta__outer-wrap .uagb-cta__icon-position-below-title .uagb-cta__left-right-wrap{display:block;min-width:100%;width:100%}.uagb-cta__outer-wrap .uagb-cta__icon-position-left .uagb-cta__left-right-wrap,.uagb-cta__outer-wrap .uagb-cta__icon-position-right .uagb-cta__left-right-wrap{display:flex}.uagb-cta__outer-wrap .uagb-cta__icon-position-right .uagb-cta__left-right-wrap{justify-content:flex-end}.uagb-cta__outer-wrap .uagb-cta__block-link-icon-after{margin-left:5px;margin-right:0}.uagb-cta__outer-wrap .uagb-cta__block-link-icon-before{margin-left:0;margin-right:5px}.uagb-cta__outer-wrap .uagb-cta__block-link-icon,.uagb-cta__outer-wrap .uagb-cta__block svg{transition:all 200ms linear}.uagb-cta__outer-wrap .uagb-cta__block{position:relative}.uagb-cta__outer-wrap .uagb-cta-typeof-button{display:inline-block;line-height:1;background-color:transparent;color:#333;text-align:center}.uagb-cta__outer-wrap .uagb-cta__content-right .uagb-cta__button-link-wrapper,.uagb-cta__outer-wrap .uagb-cta__content-right .uagb-cta__block-link,.uagb-cta__outer-wrap .uagb-cta__content-right.uagb-cta__button-valign-middle .uagb-cta__left-right-wrap{display:flex;align-items:center}.uagb-cta__outer-wrap .uagb-cta__content-right .uagb-cta__button-link-wrapper,.uagb-cta__outer-wrap .uagb-cta__content-right .uagb-cta__block-link{justify-content:center}.uagb-cta__outer-wrap .uagb-cta__link-wrapper a{box-shadow:none;text-decoration:none}.uagb-cta__outer-wrap .uagb-cta__title{padding:0;margin:0;display:block}.uagb-cta__outer-wrap .uagb-cta__block,.uagb-cta__outer-wrap .uagb-cta__content{z-index:1}.uagb-cta__outer-wrap .uagb-cta__left-right-wrap{z-index:1}.uagb-cta__outer-wrap .uagb-cta__block-link{cursor:pointer}.uagb-cta__outer-wrap .uagb-cta__content-right .uagb-cta__block-link{display:inline-block;float:right;padding:10px 14px}.uagb-cta__outer-wrap a.uagb-cta__block-link-wrap{color:inherit}.uagb-cta__outer-wrap .uagb-cta__content p:empty{display:none}.uagb-cta__outer-wrap .uagb-cta__button-type-none .uagb-cta__content{width:100%}.uagb-cta__outer-wrap .uagb-cta-with-svg{height:14px;width:14px;line-height:14px;display:inline-block;vertical-align:middle}.uagb-cta__outer-wrap .uagb-cta__block svg{display:block;height:inherit;width:inherit}.uagb-cta__outer-wrap .uagb-cta__align-button-after{margin-left:5px}.uagb-cta__outer-wrap .uagb-cta__align-button-before{margin-right:5px}.uagb-cta__outer-wrap .uagb-cta__block-link i{font-style:normal}.uagb-cta__outer-wrap a.uagb-cta__link-to-all{position:absolute;top:0;left:0;width:100%;height:100%;z-index:11}@media only screen and (max-width: 976px){.uagb-cta__content-stacked-tablet .uagb-cta__left-right-wrap{flex-direction:column;text-align:center}.uagb-cta__content-stacked-tablet.uagb-cta__content-right .uagb-cta__button-wrapper{display:inline-block;float:none;margin:0 auto}.uagb-cta__content-stacked-tablet .uagb-cta__left-right-wrap .uagb-cta__content{margin-left:0;margin-right:0}.uagb-cta__content-stacked-tablet.uagb-cta__content-right .uagb-cta__left-right-wrap .uagb-cta__content,.uagb-cta__content-stacked-tablet.uagb-cta__content-right .uagb-cta__left-right-wrap .uagb-cta__link-wrapper{width:100% !important}}@media screen and (max-width: 767px){.uagb-cta__content-stacked-mobile .uagb-cta__left-right-wrap{flex-direction:column;text-align:center}.uagb-cta__content-stacked-mobile.uagb-cta__content-right .uagb-cta__button-wrapper{display:inline-block;float:none;margin:0 auto}.uagb-cta__content-stacked-mobile .uagb-cta__left-right-wrap .uagb-cta__content{margin-left:0;margin-right:0}.uagb-cta__content-stacked-mobile.uagb-cta__content-right .uagb-cta__left-right-wrap .uagb-cta__content,.uagb-cta__content-stacked-mobile.uagb-cta__content-right .uagb-cta__left-right-wrap .uagb-cta__link-wrapper{width:100% !important}}
-.uagb-column__wrap{position:relative;overflow:hidden}.uagb-column__wrap .uagb-column__inner-wrap{margin-left:auto;margin-right:auto;position:relative;z-index:2;width:100%}.uagb-column__wrap.uagb-column__align-left .uagb-column__inner-wrap{margin-left:0;margin-right:auto}.uagb-column__wrap.uagb-column__align-right .uagb-column__inner-wrap{margin-left:auto;margin-right:0}.uagb-column__wrap .uagb-column__overlay{height:100%;width:100%;top:0;left:0;position:absolute}.uagb-column__wrap .uagb-column__video-wrap{height:100%;width:100%;top:0;left:0;position:absolute;overflow:hidden;z-index:0;transition:opacity 1s}.uagb-column__wrap .uagb-column__video-wrap video{max-width:100%;width:100%;height:100%;margin:0;line-height:1;border:none;display:inline-block;vertical-align:baseline;-o-object-fit:cover;object-fit:cover;background-size:cover}.wp-block-uagb-columns>.editor-inner-blocks>.editor-block-list__layout>[data-type="uagb/column"]{display:flex;flex-direction:column;flex:1;padding-left:0;padding-right:0;margin-left:-14px;margin-right:-14px;min-width:0;word-break:break-word;overflow-wrap:break-word;flex-basis:100%}@media (max-width: 976px){.uagb-column__align-tablet-left .uagb-column__inner-wrap{margin-left:0;margin-right:auto}.uagb-column__align-tablet-right .uagb-column__inner-wrap{margin-left:auto;margin-right:0}}@media (max-width: 767px){.uagb-column__align-mobile-left .uagb-column__inner-wrap{margin-left:0;margin-right:auto}.uagb-column__align-mobile-right .uagb-column__inner-wrap{margin-left:auto;margin-right:0}}@media (max-width: 449px){.uagb-columns__wrap.uagb-columns__background-image{background-attachment:scroll !important}}
-.uagb-columns__wrap{position:relative}.uagb-columns__wrap .uagb-columns__inner-wrap{margin-left:auto;margin-right:auto;position:relative;z-index:2}.uagb-columns__wrap .uagb-columns__overlay{height:100%;width:100%;top:0;left:0;position:absolute}.uagb-columns__wrap .uagb-columns__video-wrap{height:100%;width:100%;top:0;left:0;position:absolute;overflow:hidden;z-index:0;transition:opacity 1s}.uagb-columns__wrap .uagb-columns__video-wrap video{max-width:100%;width:100%;height:100%;margin:0;line-height:1;border:none;display:inline-block;vertical-align:baseline;-o-object-fit:cover;object-fit:cover;background-size:cover}.uagb-columns__wrap .uagb-column__wrap{display:flex}.uagb-columns__wrap .uagb-columns__shape{overflow:hidden;position:absolute;left:0;width:100%;line-height:0;direction:ltr;z-index:1}.uagb-columns__wrap .uagb-columns__shape-top{top:-3px}.uagb-columns__wrap .uagb-columns__shape-bottom{bottom:-3px}.uagb-columns__wrap .uagb-columns__shape[data-negative="false"].uagb-columns__shape-bottom{transform:rotate(180deg)}.uagb-columns__wrap .uagb-columns__shape[data-negative="true"].uagb-columns__shape-top{transform:rotate(180deg)}.uagb-columns__wrap .uagb-columns__shape.uagb-columns__shape-flip svg{transform:translateX(-50%) rotateY(180deg)}.uagb-columns__wrap .uagb-columns__shape svg{display:block;width:calc(100% + 1.3px);position:relative;left:50%;transform:translateX(-50%)}.uagb-columns__wrap .uagb-columns__shape .uagb-columns__shape-fill{fill:#333;transform-origin:center;transform:rotateY(0deg)}.uagb-columns__wrap .uagb-columns__shape.uagb-columns__shape-above-content{z-index:9;pointer-events:none}.uagb-columns__valign-center .uagb-column__wrap,.uagb-columns__valign-middle .uagb-column__wrap{align-items:center}.uagb-columns__valign-top .uagb-column__wrap{align-items:flex-start}.uagb-columns__valign-bottom .uagb-column__wrap{align-items:flex-end}.uagb-columns__inner-wrap{display:flex;flex-wrap:nowrap}.uagb-columns__columns-1>.uagb-column__wrap{width:100%}.uagb-columns__columns-2>.uagb-column__wrap{width:50%}.uagb-columns__columns-3>.uagb-column__wrap{width:33.33%}.uagb-columns__columns-4>.uagb-column__wrap{width:25%}.uagb-columns__columns-5>.uagb-column__wrap{width:20%}.uagb-columns__columns-6>.uagb-column__wrap{width:16.66%}.uagb-columns__gap-nogap>.wp-block[data-type="uagb/column"] .uagb-column__inner-wrap{padding:0}.uagb-columns__gap-default>.wp-block[data-type="uagb/column"] .uagb-column__inner-wrap{padding:10px}.uagb-columns__gap-narrow>.wp-block[data-type="uagb/column"] .uagb-column__inner-wrap{padding:5px}.uagb-columns__gap-extended>.wp-block[data-type="uagb/column"] .uagb-column__inner-wrap{padding:15px}.uagb-columns__gap-wide>.wp-block[data-type="uagb/column"] .uagb-column__inner-wrap{padding:20px}.uagb-columns__gap-wider>.wp-block[data-type="uagb/column"] .uagb-column__inner-wrap{padding:30px}@media (max-width: 976px){.uagb-columns__stack-tablet>.uagb-columns__columns-1>.uagb-column__wrap,.uagb-columns__stack-tablet>.uagb-columns__columns-2>.uagb-column__wrap,.uagb-columns__stack-tablet>.uagb-columns__columns-3>.uagb-column__wrap,.uagb-columns__stack-tablet>.uagb-columns__columns-4>.uagb-column__wrap,.uagb-columns__stack-tablet>.uagb-columns__columns-5>.uagb-column__wrap,.uagb-columns__stack-tablet>.uagb-columns__columns-6>.uagb-column__wrap{width:100% !important}.uagb-columns__stack-tablet>.uagb-columns__inner-wrap{display:block}.uagb-columns__reverse-tablet .uagb-columns__inner-wrap{display:flex;flex-direction:column-reverse}}@media (max-width: 767px){.uagb-columns__stack-mobile>.uagb-columns__columns-1>.uagb-column__wrap,.uagb-columns__stack-mobile>.uagb-columns__columns-2>.uagb-column__wrap,.uagb-columns__stack-mobile>.uagb-columns__columns-3>.uagb-column__wrap,.uagb-columns__stack-mobile>.uagb-columns__columns-4>.uagb-column__wrap,.uagb-columns__stack-mobile>.uagb-columns__columns-5>.uagb-column__wrap,.uagb-columns__stack-mobile>.uagb-columns__columns-6>.uagb-column__wrap{width:100% !important}.uagb-columns__stack-mobile>.uagb-columns__inner-wrap{display:block}.uagb-columns__reverse-mobile .uagb-columns__inner-wrap{display:flex;flex-direction:column-reverse}}@media (min-width: 768px) and (max-width: 1024px){.wp-block-uagb-columns.uagb-columns__wrap.uagb-columns__background-image{background-attachment:scroll}}@media (max-width: 449px){.uagb-columns__wrap .uagb-column__wrap.uagb-column__background-image{background-attachment:scroll !important}}
-.wp-block-uagb-cf7-styler .wpcf7 *,.wp-block-uagb-cf7-styler .wpcf7 :after,.wp-block-uagb-cf7-styler .wpcf7 :before{box-sizing:border-box}.wp-block-uagb-cf7-styler span.wpcf7-list-item-label::before,.wp-block-uagb-cf7-styler span.wpcf7-list-item-label::after{content:" "}.wp-block-uagb-cf7-styler .wpcf7-acceptance input[type=checkbox]+span:before,.wp-block-uagb-cf7-styler .wpcf7-checkbox input[type=checkbox]+span:before,.wp-block-uagb-cf7-styler .wpcf7-radio input[type=radio]+span:before{content:'';display:inline-block;vertical-align:middle;margin-right:10px;text-align:center;height:15px;width:15px;border-style:solid;border-color:#eaeaea;border-width:1px 1px 1px 1px}.wp-block-uagb-cf7-styler span.wpcf7-list-item{display:inline-block;margin:0 1em 0 0}.wp-block-uagb-cf7-styler .wpcf7-acceptance input[type=checkbox]:checked+span:before,.wp-block-uagb-cf7-styler .wpcf7-checkbox input[type=checkbox]:checked+span:before{content:"\2714";line-height:1.2}.wp-block-uagb-cf7-styler .wpcf7-acceptance input[type=checkbox]+span:before,.wp-block-uagb-cf7-styler .wpcf7-acceptance input[type=checkbox]:checked+span:before,.wp-block-uagb-cf7-styler .wpcf7-checkbox input[type=checkbox]+span:before,.wp-block-uagb-cf7-styler .wpcf7-checkbox input[type=checkbox]:checked+span:before,.wp-block-uagb-cf7-styler .wpcf7-radio input[type=radio]+span:before{box-sizing:content-box}.wp-block-uagb-cf7-styler input[type=checkbox]:checked+span:before{font-size:calc(12px / 1.2)}.wp-block-uagb-cf7-styler .wpcf7-radio input[type=radio]+span:before{border-radius:100%}.wp-block-uagb-cf7-styler .uagb-cf7-styler__field-style-box .wpcf7-radio input[type="radio"]:checked+span:before,.wp-block-uagb-cf7-styler .uagb-cf7-styler__field-style-underline .wpcf7-radio input[type="radio"]:checked+span:before{background-color:#545454;box-shadow:inset 0px 0px 0px 4px #fafafa}.wp-block-uagb-cf7-styler .uagb-cf7-styler__btn-align-justify input.wpcf7-form-control.wpcf7-submit,.wp-block-uagb-cf7-styler .uagb-cf7-styler__btn-align-left input.wpcf7-form-control.wpcf7-submit,.wp-block-uagb-cf7-styler .uagb-cf7-styler__btn-align-right input.wpcf7-form-control.wpcf7-submit,.wp-block-uagb-cf7-styler .uagb-cf7-styler__btn-align-center input.wpcf7-form-control.wpcf7-submit{-js-display:flex;display:flex;width:auto;line-height:1em;background:transparent;border-color:#333;border-width:1px;padding:10px 25px}.wp-block-uagb-cf7-styler .uagb-cf7-styler__btn-align-right input.wpcf7-form-control.wpcf7-submit{margin-left:auto;margin-right:0}.wp-block-uagb-cf7-styler .uagb-cf7-styler__btn-align-left input.wpcf7-form-control.wpcf7-submit{margin-right:auto;margin-left:0}.wp-block-uagb-cf7-styler .uagb-cf7-styler__btn-align-center input.wpcf7-form-control.wpcf7-submit{margin-right:auto;margin-left:auto}.wp-block-uagb-cf7-styler .uagb-cf7-styler__btn-align-justify input.wpcf7-form-control.wpcf7-submit{justify-content:center;width:100%}.wp-block-uagb-cf7-styler .wpcf7 input[type=checkbox],.wp-block-uagb-cf7-styler .wpcf7 input[type=radio]{display:none}.wp-block-uagb-cf7-styler .wpcf7 select{height:auto;padding:10px;-webkit-appearance:menulist-button;-moz-appearance:menulist-button;-webkit-appearance:menulist-button}.wp-block-uagb-cf7-styler select.wpcf7-form-control.wpcf7-select[multiple="multiple"]{padding:0}.wp-block-uagb-cf7-styler .wpcf7 select option{padding:10px}.wp-block-uagb-cf7-styler .uagb-cf7-styler__highlight-style-bottom_right span.wpcf7-not-valid-tip{display:inline-block;right:0;top:100%;padding:.1em .8em;border-radius:2px;color:#ffffff;background-color:rgba(255,0,0,0.6);padding:5px 10px;font-size:15px;float:right;margin-top:5px}.wp-block-uagb-cf7-styler .wpcf7 input[type="number"]{height:auto}.wp-block-uagb-cf7-styler .wpcf7 input.wpcf7-date{-webkit-appearance:none}@media (min-width: 769px){.wp-block-uagb-cf7-styler .uagb-cf7_styler-col{-js-display:flex;display:flex}.wp-block-uagb-cf7-styler .uagb-cf7_styler-col label,.wp-block-uagb-cf7-styler .uagb-cf7_styler-col>span{flex-grow:1;flex-basis:100%}.wp-block-uagb-cf7-styler .uagb-cf7_styler-col br{display:none}.wp-block-uagb-cf7-styler .uagb-cf7_styler-col>span.uagb-cf7_styler-col-1{padding-left:0;padding-right:15px}.wp-block-uagb-cf7-styler .uagb-cf7_styler-col>span.uagb-cf7_styler-col-3{padding-left:15px;padding-right:0}.wp-block-uagb-cf7-styler .wpcf7 .uagb-cf7_styler-col span.wpcf7-form-control-wrap{height:100%}.wp-block-uagb-cf7-styler .wpcf7 .uagb-cf7_styler-col select{height:100%}}
-.uagb-gf-styler__check-style-enabled .gform_wrapper .chosen-container-multi .chosen-choices,.uagb-gf-styler__check-style-enabled .gform_wrapper .chosen-container-single .chosen-single{position:relative;display:block;overflow:hidden;padding:0;height:auto;border:1px solid #AAA;border-radius:0;background:#FFF;box-shadow:none;color:#444;text-decoration:none;white-space:nowrap}.uagb-gf-styler__gform-heading-none .gform_wrapper .gform_heading,.uagb-gf-styler__gform-heading-no .gform_wrapper .gform_heading,.uagb-gf-styler__gform-heading-yes .gform_wrapper .gform_heading.custom_gform_heading{display:none}.uagb-gf-styler__gform-heading-no .gform_wrapper .gform_heading.custom_gform_heading,.uagb-gf-styler__gform-heading-yes .gform_wrapper .gform_heading{display:block}.uagb-gf-styler__check-style-enabled .gform_wrapper .chosen-container-single .chosen-single span{line-height:1}.uagb-gf-styler__check-style-enabled .gform_wrapper .chosen-container-active.chosen-with-drop .chosen-single{background:#FFF}.uagb-gf-styler__check-style-enabled .gform_page .gform_page_footer input[type=button],.uagb-gf-styler__check-style-enabled .gform_page .gform_page_footer input[type=submit]{display:inline-block}.uagb-gf-styler__check-style-enabled .gform_wrapper .gf_progressbar_wrapper h3.gf_progressbar_title,.uagb-gf-styler__check-style-enabled .gform_wrapper .gf_progressbar_wrapper .gf_progressbar_title{opacity:1}.uagb-gf-styler__check-style-enabled .uag-gf-select-custom{position:relative}.uagb-gf-styler__check-style-enabled .uag-gf-select-custom:after{content:"\f078";font-family:'FontAwesome' !important;font-size:0.7em;line-height:1;position:absolute;top:45%;transform:translateY(-45%);right:0.5em;pointer-events:none;z-index:5}.uagb-gf-styler__check-style-enabled span.name_prefix_select .uag-gf-select-custom{display:inline;vertical-align:middle}.uagb-gf-styler__check-style-enabled .gfield_radio input[type="radio"]:checked+label:before{box-shadow:inset 0px 0px 0px 4px #fafafa}.uagb-gf-styler__check-style-enabled .gfield_checkbox input[type="checkbox"]+label:before,.uagb-gf-styler__check-style-enabled .gfield_radio input[type="radio"]+label:before,.uagb-gf-styler__check-style-enabled .ginput_container_consent input[type="checkbox"]+label:before{box-sizing:content-box}.uagb-gf-styler__check-style-enabled .ginput_container_consent input[type="checkbox"]:checked+label:before{font-weight:700}.uagb-gf-styler__check-style-enabled select,.uagb-gf-styler__check-style-enabled .chosen-single{-webkit-appearance:none;-moz-appearance:none;appearance:none}.uagb-gf-styler__check-style-enabled .gform_wrapper div.validation_error{border-top:none;border-bottom:none}.uagb-gf-styler__check-style-enabled .gform_wrapper .gfield_radio li label{margin:0 0 0 0}.uagb-gf-styler__check-style-enabled .gform_wrapper .gform_body{width:100% !important}.uagb-gf-styler__check-style-enabled .gform_wrapper input[type="checkbox"]:checked+label:before,.uagb-gf-styler__check-style-enabled .gform_wrapper input[type="radio"]:checked+label:before,.uagb-gf-styler__check-style-enabled .gform_wrapper input[type="checkbox"]+label:before,.uagb-gf-styler__check-style-enabled .gform_wrapper input[type="radio"]+label:before{box-sizing:content-box !important}.uagb-gf-styler__check-style-enabled .gform_wrapper .gsection{margin-right:0}.uag-gf-btn-size-xs .uagb-gf-styler__check-style-enabled input[type=submit],.uag-gf-btn-size-xs .uagb-gf-styler__check-style-enabled input[type=button]{font-size:13px;padding:10px 20px;border-radius:2px}.uag-gf-input-size-xs .uagb-gf-styler__check-style-enabled .gform_body input:not([type="radio"]):not([type="checkbox"]):not([type="submit"]):not([type="button"]):not([type="image"]):not([type="file"]),.uag-gf-input-size-xs .uagb-gf-styler__check-style-enabled .ginput_container textarea,.uag-gf-input-size-xs .uagb-gf-styler__check-style-enabled .ginput_container .chosen-single,.uag-gf-input-size-xs .uagb-gf-styler__check-style-enabled .ginput_container .chosen-choices{font-size:13px;padding:8px 10px}.uag-gf-input-size-xs .uagb-gf-styler__check-style-enabled .ginput_container select{font-size:13px;padding:6px 10px}.ginput_container select{height:100%;line-height:inherit}.uag-gf-input-size-xs .uagb-gf-styler__check-style-enabled .uag-gf-select-custom{font-size:13px}.uag-gf-input-size-xs .uagb-gf-styler__check-style-enabled .gfield_checkbox input[type="checkbox"]+label:before,.uag-gf-input-size-xs .uagb-gf-styler__check-style-enabled .gfield_radio input[type="radio"]+label:before,.uag-gf-input-size-xs .uagb-gf-styler__check-style-enabled .ginput_container_consent input[type="checkbox"]+label:before{height:10px;width:10px}.uag-gf-input-size-xs .uagb-gf-styler__check-style-enabled .gfield_checkbox input[type="checkbox"]:checked+label:before,.uag-gf-input-size-xs .uagb-gf-styler__check-style-enabled .ginput_container_consent input[type="checkbox"]+label:before{font-size:calc( 10px / 1.2)}.uag-gf-btn-size-sm .uagb-gf-styler__check-style-enabled input[type=submit],.uag-gf-btn-size-sm .uagb-gf-styler__check-style-enabled input[type=button]{font-size:15px;padding:12px 24px;border-radius:3px}.uag-gf-input-size-sm .uagb-gf-styler__check-style-enabled .gform_body input:not([type="radio"]):not([type="checkbox"]):not([type="submit"]):not([type="button"]):not([type="image"]):not([type="file"]),.uag-gf-input-size-sm .uagb-gf-styler__check-style-enabled .ginput_container textarea,.uag-gf-input-size-sm .uagb-gf-styler__check-style-enabled .ginput_container .chosen-single,.uag-gf-input-size-sm .uagb-gf-styler__check-style-enabled .ginput_container .chosen-choices{font-size:15px;padding:12px 10px}.uag-gf-input-size-sm .uagb-gf-styler__check-style-enabled .ginput_container select{font-size:15px;padding:10px 10px}.uag-gf-input-size-sm .uagb-gf-styler__check-style-enabled .uag-gf-select-custom{font-size:15px}.uag-gf-input-size-sm .uagb-gf-styler__check-style-enabled .gfield_checkbox input[type="checkbox"]+label:before,.uag-gf-input-size-sm .uagb-gf-styler__check-style-enabled .gfield_radio input[type="radio"]+label:before,.uag-gf-input-size-sm .uagb-gf-styler__check-style-enabled .ginput_container_consent input[type="checkbox"]+label:before{height:12px;width:12px}.uag-gf-input-size-sm .uagb-gf-styler__check-style-enabled .gfield_checkbox input[type="checkbox"]:checked+label:before,.uag-gf-input-size-sm .uagb-gf-styler__check-style-enabled .ginput_container_consent input[type="checkbox"]+label:before{font-size:calc( 12px / 1.2)}.uag-gf-btn-size-md .uagb-gf-styler__check-style-enabled input[type=submit],.uag-gf-btn-size-md .uagb-gf-styler__check-style-enabled input[type=button]{font-size:16px;padding:15px 30px;border-radius:4px}.uag-gf-input-size-md .uagb-gf-styler__check-style-enabled .gform_body input:not([type="radio"]):not([type="checkbox"]):not([type="submit"]):not([type="button"]):not([type="image"]):not([type="file"]),.uag-gf-input-size-md .uagb-gf-styler__check-style-enabled .ginput_container textarea,.uag-gf-input-size-md .uagb-gf-styler__check-style-enabled .ginput_container .chosen-single,.uag-gf-input-size-md .uagb-gf-styler__check-style-enabled .ginput_container .chosen-choices{font-size:16px;padding:15px 10px}.uag-gf-input-size-md .uagb-gf-styler__check-style-enabled .ginput_container select{font-size:16px;padding:13px 10px}.uag-gf-input-size-md .uagb-gf-styler__check-style-enabled .uag-gf-select-custom{font-size:16px}.uag-gf-input-size-md .uagb-gf-styler__check-style-enabled .gfield_checkbox input[type="checkbox"]+label:before,.uag-gf-input-size-md .uagb-gf-styler__check-style-enabled .gfield_radio input[type="radio"]+label:before,.uag-gf-input-size-md .uagb-gf-styler__check-style-enabled .ginput_container_consent input[type="checkbox"]+label:before{height:15px;width:15px}.uag-gf-input-size-md .uagb-gf-styler__check-style-enabled .gfield_checkbox input[type="checkbox"]:checked+label:before,.uag-gf-input-size-md .uagb-gf-styler__check-style-enabled .ginput_container_consent input[type="checkbox"]+label:before{font-size:calc( 15px / 1.2)}.uag-gf-btn-size-lg .uagb-gf-styler__check-style-enabled input[type=submit],.uag-gf-btn-size-lg .uagb-gf-styler__check-style-enabled input[type=button]{font-size:18px;padding:20px 40px;border-radius:5px}.uag-gf-input-size-lg .uagb-gf-styler__check-style-enabled .gform_body input:not([type="radio"]):not([type="checkbox"]):not([type="submit"]):not([type="button"]):not([type="image"]):not([type="file"]),.uag-gf-input-size-lg .uagb-gf-styler__check-style-enabled .ginput_container textarea,.uag-gf-input-size-lg .uagb-gf-styler__check-style-enabled .ginput_container .chosen-single,.uag-gf-input-size-lg .uagb-gf-styler__check-style-enabled .ginput_container .chosen-choices{font-size:18px;padding:20px 10px}.uag-gf-input-size-lg .uagb-gf-styler__check-style-enabled .ginput_container select{font-size:18px;padding:18px 10px}.uag-gf-input-size-lg .uagb-gf-styler__check-style-enabled .uag-gf-select-custom{font-size:18px}.uag-gf-input-size-lg .uagb-gf-styler__check-style-enabled .gfield_checkbox input[type="checkbox"]+label:before,.uag-gf-input-size-lg .uagb-gf-styler__check-style-enabled .gfield_radio input[type="radio"]+label:before,.uag-gf-input-size-lg .uagb-gf-styler__check-style-enabled .ginput_container_consent input[type="checkbox"]+label:before{height:20px;width:20px}.uag-gf-input-size-lg .uagb-gf-styler__check-style-enabled .gfield_checkbox input[type="checkbox"]:checked+label:before,.uag-gf-input-size-lg .uagb-gf-styler__check-style-enabled .ginput_container_consent input[type="checkbox"]+label:before{font-size:calc( 20px / 1.2)}.uag-gf-btn-size-xl .uagb-gf-styler__check-style-enabled input[type=submit],.uag-gf-btn-size-xl .uagb-gf-styler__check-style-enabled input[type=button]{font-size:20px;padding:25px 50px;border-radius:6px}.uag-gf-input-size-xl .uagb-gf-styler__check-style-enabled .gform_body input:not([type="radio"]):not([type="checkbox"]):not([type="submit"]):not([type="button"]):not([type="image"]):not([type="file"]),.uag-gf-input-size-xl .uagb-gf-styler__check-style-enabled .ginput_container textarea,.uag-gf-input-size-xl .uagb-gf-styler__check-style-enabled .ginput_container .chosen-single,.uag-gf-input-size-xl .uagb-gf-styler__check-style-enabled .ginput_container .chosen-choices{font-size:20px;padding:25px 10px}.uag-gf-input-size-xl .uagb-gf-styler__check-style-enabled .ginput_container select{font-size:20px;padding:23px 10px}.uag-gf-input-size-xl .uagb-gf-styler__check-style-enabled .uag-gf-select-custom{font-size:20px}.uag-gf-input-size-xl .uagb-gf-styler__check-style-enabled .gfield_checkbox input[type="checkbox"]+label:before,.uag-gf-input-size-xl .uagb-gf-styler__check-style-enabled .gfield_radio input[type="radio"]+label:before,.uag-gf-input-size-xl .uagb-gf-styler__check-style-enabled .ginput_container_consent input[type="checkbox"]+label:before{height:25px;width:25px}.uag-gf-input-size-xl .uagb-gf-styler__check-style-enabled .gfield_checkbox input[type="checkbox"]:checked+label:before,.uag-gf-input-size-xl .uagb-gf-styler__check-style-enabled .ginput_container_consent input[type="checkbox"]:checked+label:before{font-size:calc( 25px / 1.2)}.uagb-gf-styler__btn-align-right .gform_next_button,.uagb-gf-styler__btn-align-right .gform_previous_button{margin-right:5px !important}.uagb-gf-styler__check-style-enabled .gform_wrapper .gform_footer:not(.top_label){padding:0 0 0 0;margin-right:0;margin-left:0;width:100%}.uagb-gf-styler__check-style-enabled .gform_wrapper .gform_page_footer.left_label,.uagb-gf-styler__check-style-enabled .gform_wrapper .gform_page_footer.right_label{padding:0 0 0 0}.uagb-gf-styler__check-style-enabled .gfield_radio input[type="radio"]+label:before{border-radius:100%}.uagb-gf-styler__check-style-enabled .gform_wrapper .top_label .gfield_error{width:100% !important}.uagb-gf-styler__check-style-enabled .gform_wrapper.gform_validation_error .gform_body ul li.gfield.gfield_error:not(.gf_left_half):not(.gf_right_half){max-width:100% !important}.uagb-gf-styler__btn-align-center .gform_wrapper .gform_footer input[type=submit],.uagb-gf-styler__btn-align-center .gform_page .gform_page_footer input[type=button],.uagb-gf-styler__btn-align-center .gform_page .gform_page_footer input[type=submit],.uagb-gf-styler__btn-align-left .gform_wrapper .gform_footer input[type=submit],.uagb-gf-styler__btn-align-left .gform_page .gform_page_footer input[type=button],.uagb-gf-styler__btn-align-left .gform_page .gform_page_footer input[type=submit],.uagb-gf-styler__btn-align-right .gform_wrapper .gform_footer input[type=submit],.uagb-gf-styler__btn-align-right .gform_page .gform_page_footer input[type=button],.uagb-gf-styler__btn-align-right .gform_page .gform_page_footer input[type=submit],.uagb-gf-styler__btn-align-justify .gform_wrapper .gform_footer input[type=submit],.uagb-gf-styler__btn-align-justify .gform_page .gform_page_footer input[type=button],.uagb-gf-styler__btn-align-justify .gform_page .gform_page_footer input[type=submit]{-js-display:flex;display:flex;width:auto}.uagb-gf-styler__btn-align-center .gform_wrapper .gform_footer input[type=submit],.uagb-gf-styler__btn-align-center .gform_page .gform_page_footer input[type=button],.uagb-gf-styler__btn-align-center .gform_page .gform_page_footer input[type=submit],html[dir=rtl] .uagb-gf-styler__btn-align-center .gform_wrapper .gform_footer input[type=submit],html[dir=rtl] .uagb-gf-styler__btn-align-center .gform_page .gform_page_footer input[type=button],html[dir=rtl] .uagb-gf-styler__btn-align-center .gform_page .gform_page_footer input[type=submit]{margin-left:auto;margin-right:auto}.uagb-gf-styler__btn-align-center .gform_page .gform_page_footer{text-align:center}.uagb-gf-styler__btn-align-right .gform_page .gform_page_footer{text-align:right}.uagb-gf-styler__btn-align-left .gform_wrapper .gform_footer input[type=submit],.uagb-gf-styler__btn-align-left .gform_page .gform_page_footer input[type=button],.uagb-gf-styler__btn-align-left .gform_page .gform_page_footer input[type=submit],html[dir=rtl] .uagb-gf-styler__btn-align-right .gform_wrapper .gform_footer input[type=submit],html[dir=rtl] .uagb-gf-styler__btn-align-right .gform_page .gform_page_footer input[type=button],html[dir=rtl] .uagb-gf-styler__btn-align-right .gform_page .gform_page_footer input[type=submit]{margin-left:0;margin-right:auto}.uagb-gf-styler__btn-align-right .gform_wrapper .gform_footer input[type=submit],.uagb-gf-styler__btn-align-right .gform_page .gform_page_footer input[type=button],.uagb-gf-styler__btn-align-right .gform_page .gform_page_footer input[type=submit],html[dir=rtl] .uagb-gf-styler__btn-align-left .gform_wrapper .gform_footer input[type=submit],html[dir=rtl] .uagb-gf-styler__btn-align-left .gform_page .gform_page_footer input[type=button],html[dir=rtl] .uagb-gf-styler__btn-align-left .gform_page .gform_page_footer input[type=submit]{margin-left:auto;margin-right:0}.uagb-gf-styler__btn-align-justify .gform_wrapper .gform_footer input[type=submit],.uagb-gf-styler__btn-align-justify .gform_page .gform_page_footer input[type=button],.uagb-gf-styler__btn-align-justify .gform_page .gform_page_footer input[type=submit]{justify-content:center;width:100%}.uagb-gf-styler__check-style-enabled .gform_body .ginput_container_checkbox .gfield_checkbox input[type='checkbox'],.uagb-gf-styler__check-style-enabled .gform_body .ginput_container_radio .gfield_radio input[type='radio'],.uagb-gf-styler__check-style-enabled .gform_body .ginput_container_consent input[type='checkbox']{display:none}.uagb-gf-styler__check-style-enabled .gform_body .ginput_container_checkbox .gfield_checkbox input[type='checkbox']+label:before,.uagb-gf-styler__check-style-enabled .gform_body .ginput_container_radio .gfield_radio input[type='radio']+label:before,.uagb-gf-styler__check-style-enabled .gform_body .ginput_container_consent input[type='checkbox']+label:before{content:'';display:inline-block;vertical-align:middle;margin-right:10px;text-align:center}.uagb-gf-styler__check-style-enabled .gform_body .ginput_container_checkbox .gfield_checkbox input[type='checkbox']:checked+label:before,.uagb-gf-styler__check-style-enabled .gform_body .ginput_container_consent input[type='checkbox']:checked+label:before{content:"\2714";line-height:1.2}.uagb-gf-styler__check-style-enabled .gform_wrapper ul.gform_fields li.gfield:not(.gf_left_half):not(.gf_left_third):not(.gf_middle_third){padding-right:0}.uagb-gf-styler__btn-align-width-full_width .gform_footer input[type=submit]{display:block;text-align:center;width:100%}.uagb-gf-styler__check-style-enabled .gform_body ul{margin-left:0;list-style:none}.uagb-gf-styler__check-style-enabled .gform_wrapper .gfield .ginput_container select,.uagb-gf-styler__check-style-enabled .gform_wrapper .gfield .ginput_container .chosen-single,.uagb-gf-styler__check-style-enabled .gform_wrapper .gfield .ginput_container .chosen-choices,.uagb-gf-styler__check-style-enabled .gform_wrapper .chosen-choices li.search-field input[type="text"],.uagb-gf-styler__check-style-enabled .gform_wrapper .chosen-choices li.search-field input.default{height:auto}.elementor-widget-uag-gf-styler .uagb-gf-styler__check-style-enabled .gform_wrapper .chosen-choices li.search-field input[type="text"]{padding:0px 0px 0px 0px}.uagb-gf-styler__check-style-enabled .gform_page .gform_page_footer input[type=button]{margin-bottom:20px}.uagb-gf-styler__check-style-enabled .gform_wrapper .chosen-container-single .chosen-single div{display:none}.uagb-gf-styler__hide-label .gform_wrapper .gform_fields .gfield_label,.uagb-gf-styler__hide-label .gform_wrapper .gform_fields .gfield_required{display:none}.wp-block-uagb-gf-styler .gform_wrapper .chosen-container-single .chosen-single span{margin-bottom:0;width:100%}.wp-block-uagb-gf-styler .gform_wrapper .chosen-container-single .chosen-single{border:none}.wp-block-uagb-gf-styler .gform_wrapper .chosen-container-single.chosen-container-active .chosen-single{border:none}@media only screen and (max-width: 976px){.uagb-gf-styler__btn-align-center .gform_page .gform_page_footer{text-align:center}.uagb-gf-styler__btn-align-right .gform_page .gform_page_footer{text-align:right}.uag-tablet-gf-button-center .gform_wrapper .gform_footer input[type=submit],.uag-tablet-gf-button-center .gform_page .gform_page_footer input[type="button"],.uag-tablet-gf-button-center .gform_page .gform_page_footer input[type=submit]{margin-left:auto;margin-right:auto;width:auto}.uag-tablet-gf-button-left .gform_wrapper .gform_footer input[type=submit],.uag-tablet-gf-button-left .gform_page .gform_page_footer input[type=button],.uag-tablet-gf-button-left .gform_page .gform_page_footer input[type=submit]{margin-left:0;margin-right:auto;width:auto}.uag-tablet-gf-button-right .gform_wrapper .gform_footer input[type=submit],.uag-tablet-gf-button-right .gform_page .gform_page_footer input[type=button],.uag-tablet-gf-button-right .gform_page .gform_page_footer input[type=submit]{margin-left:auto;margin-right:0;width:auto}.uag-tablet-gf-button-justify .gform_wrapper .gform_footer input[type=submit],.uag-tablet-gf-button-justify .gform_page .gform_page_footer input[type=button],.uag-tablet-gf-button-justify .gform_page .gform_page_footer input[type=submit]{justify-content:center;width:100%}}@media only screen and (max-width: 767px){.uagb-gf-styler__btn-align-center .gform_page .gform_page_footer{text-align:center}.uagb-gf-styler__btn-align-right .gform_page .gform_page_footer{text-align:right}.uag-mobile-gf-button-center .gform_wrapper .gform_footer input[type=submit],.uag-mobile-gf-button-center .gform_page .gform_page_footer input[type=button],.uag-mobile-gf-button-center .gform_page .gform_page_footer input[type=submit]{margin-left:auto;margin-right:auto;width:auto}.uag-mobile-gf-button-left .gform_wrapper .gform_footer input[type=submit],.uag-mobile-gf-button-left .gform_page .gform_page_footer input[type=button],.uag-mobile-gf-button-left .gform_page .gform_page_footer input[type=submit]{margin-left:0;margin-right:auto;width:auto}.uag-mobile-gf-button-right .gform_wrapper .gform_footer input[type=submit],.uag-mobile-gf-button-right .gform_page .gform_page_footer input[type=button],.uag-mobile-gf-button-right .gform_page .gform_page_footer input[type=submit]{margin-left:auto;margin-right:0;width:auto}.uag-mobile-gf-button-justify .gform_wrapper .gform_footer input[type=submit],.uag-mobile-gf-button-justify .gform_page .gform_page_footer input[type=button],.uag-mobile-gf-button-justify .gform_page .gform_page_footer input[type=submit]{justify-content:center;width:100%}}
-.wp-block-uagb-blockquote{padding:0;margin:0 auto}.wp-block-uagb-blockquote .uagb-blockquote__content,.wp-block-uagb-blockquote cite.uagb-blockquote__author{font-style:normal;display:block}.wp-block-uagb-blockquote cite.uagb-blockquote__author,.wp-block-uagb-blockquote .uagb-blockquote__author{align-self:center}.wp-block-uagb-blockquote .uagb-blockquote__skin-quotation blockquote.uagb-blockquote{margin:0;padding:0;border:0;outline:0;font-size:100%;vertical-align:baseline;background:transparent;quotes:none;border-left:0 none;border-right:0 none;border-top:0 none;border-bottom:0 none;font-style:normal}.wp-block-uagb-blockquote .uagb-blockquote__skin-quotation .uagb-blockquote__icon-wrap{position:relative;display:inline-block;padding:0px;z-index:1;background:#333;padding:10px;border-radius:100%;margin-right:10px}.wp-block-uagb-blockquote .uagb-blockquote__skin-quotation .uagb-blockquote__icon{height:25px;width:25px;display:inline-block;float:left}.wp-block-uagb-blockquote .uagb-blockquote__skin-quotation .uagb-blockquote__icon svg{height:inherit;width:inherit;display:inherit}.wp-block-uagb-blockquote .uagb-blockquote__skin-quotation.uagb-blockquote__style-style_2 .uagb-blockquote__icon-wrap{display:inline-block;float:left}.wp-block-uagb-blockquote blockquote.uagb-blockquote{margin:0;padding:0}.wp-block-uagb-blockquote .uagb-blockquote__wrap,.wp-block-uagb-blockquote .uagb-blockquote__wrap *{box-sizing:border-box}.wp-block-uagb-blockquote .uagb-blockquote__style-style_2 .uagb-blockquote__icon-wrap{display:inline-block;float:left;text-align:left}.wp-block-uagb-blockquote .uagb-blockquote__separator-parent{-js-display:flex;display:flex;justify-content:flex-start}.wp-block-uagb-blockquote .uagb-blockquote__with-tweet .uagb-blockquote footer{display:flex;justify-content:space-between}.wp-block-uagb-blockquote .uagb-blockquote a{box-shadow:none;text-decoration:none}.wp-block-uagb-blockquote .uagb-blockquote a.uagb-blockquote__tweet-button{display:flex;transition:0.2s;align-self:flex-end;line-height:1;position:relative;width:-webkit-max-content;width:-moz-max-content;width:max-content;padding:0;color:#1DA1F2;background-color:transparent;align-self:center}.wp-block-uagb-blockquote a.uagb-blockquote__tweet-button svg{height:15px;width:15px;margin-right:5px;fill:#fff;vertical-align:middle;align-self:center}.wp-block-uagb-blockquote a.uagb-blockquote__tweet-button,.wp-block-uagb-blockquote a.uagb-blockquote__tweet-button svg{font-style:normal}.wp-block-uagb-blockquote .uagb-blockquote__tweet-icon a.uagb-blockquote__tweet-button svg{margin-right:0}.wp-block-uagb-blockquote .uagb-blockquote__tweet-icon_text svg{margin-right:10px}.wp-block-uagb-blockquote .uagb-blockquote__tweet-icon a.uagb-blockquote__tweet-button{padding:8px}.wp-block-uagb-blockquote .uagb-blockquote__tweet-icon_text a.uagb-blockquote__tweet-button,.wp-block-uagb-blockquote .uagb-blockquote__tweet-text a.uagb-blockquote__tweet-button{padding:10px 14px}.wp-block-uagb-blockquote .uagb-blockquote__tweet-style-link a.uagb-blockquote__tweet-button{padding:10px 0}.wp-block-uagb-blockquote .uagb-blockquote__tweet-style-classic a.uagb-blockquote__tweet-button,.wp-block-uagb-blockquote .uagb-blockquote__tweet-style-bubble a.uagb-blockquote__tweet-button{background-color:#1DA1F2;border-radius:100em;color:#fff}.wp-block-uagb-blockquote .uagb-blockquote__tweet-style-bubble a.uagb-blockquote__tweet-button:before{content:'';border:solid 0.5em transparent;border-right-color:#1DA1F2;position:absolute;left:-0.8em;top:50%;transform:translateY(-50%) scale(1, 0.65);transition:0.2s}.wp-block-uagb-blockquote .uagb-blockquote__align-right.uagb-blockquote__tweet-style-bubble a.uagb-blockquote__tweet-button:before{left:auto;right:-0.8em;transform:translateY(-50%) scale(1, 0.65) rotate(180deg)}.wp-block-uagb-blockquote .uagb-blockquote__align-center.uagb-blockquote__tweet-style-bubble a.uagb-blockquote__tweet-button:before{left:50%;top:-0.8em;right:auto;transform:translate(-50%, 10%) scale(1, 0.85) rotate(90deg)}.wp-block-uagb-blockquote .uagb-blockquote__with-tweet.uagb-blockquote__align-center .uagb-blockquote footer,.wp-block-uagb-blockquote .uagb-blockquote__align-center .uagb-blockquote footer{display:block;text-align:center}.wp-block-uagb-blockquote .uagb-blockquote__align-center a.uagb-blockquote__tweet-button{display:block;text-align:center;margin:0 auto;align-self:center}.wp-block-uagb-blockquote .uagb-blockquote__with-tweet.uagb-blockquote__align-right .uagb-blockquote footer,.wp-block-uagb-blockquote .uagb-blockquote__align-right .uagb-blockquote footer{flex-direction:row-reverse}.wp-block-uagb-blockquote .uagb-blockquote__author-image{align-self:center}.wp-block-uagb-blockquote .uagb-blockquote__author-image img{width:50px;height:50px;border-radius:100%;margin-right:10px}.wp-block-uagb-blockquote .uagb-blockquote__author-wrap{display:flex;flex-direction:row}.wp-block-uagb-blockquote .uagb-blockquote__align-right .uagb-blockquote__author-wrap,.wp-block-uagb-blockquote .uagb-blockquote__align-left .uagb-blockquote__author-wrap.uagb-blockquote__author-at-right{justify-content:flex-end;-webkit-box-pack:flex-end;-ms-flex-pack:flex-end;-webkit-justify-content:flex-end;-moz-box-pack:flex-end}.wp-block-uagb-blockquote .uagb-blockquote__align-left .uagb-blockquote__author-wrap,.wp-block-uagb-blockquote .uagb-blockquote__align-right .uagb-blockquote__author-wrap.uagb-blockquote__author-at-right{justify-content:flex-start;-webkit-box-pack:flex-start;-ms-flex-pack:flex-start;-webkit-justify-content:flex-start;-moz-box-pack:flex-start}.wp-block-uagb-blockquote .uagb-blockquote__with-tweet .uagb-blockquote__author-wrap{justify-content:unset;-webkit-box-pack:unset;-ms-flex-pack:unset;-webkit-justify-content:unset;-moz-box-pack:unset}.wp-block-uagb-blockquote .uagb-blockquote__align-center .uagb-blockquote__author-wrap,.wp-block-uagb-blockquote .uagb-blockquote__align-center.uagb-blockquote__with-tweet .uagb-blockquote__author-wrap{justify-content:center;-webkit-box-pack:center;-ms-flex-pack:center;-webkit-justify-content:center;-moz-box-pack:center}.wp-block-uagb-blockquote .uagb-blockquote__author-wrap.uagb-blockquote__author-at-top{width:100%}.wp-block-uagb-blockquote .uagb-blockquote__author-wrap.uagb-blockquote__author-at-top .uagb-blockquote__author-image,.wp-block-uagb-blockquote .uagb-blockquote__author-wrap.uagb-blockquote__author-at-top .uagb-blockquote__author{width:inherit}.wp-block-uagb-blockquote .uagb-blockquote__with-tweet .uagb-blockquote__author-wrap.uagb-blockquote__author-at-top{width:auto}.wp-block-uagb-blockquote .uagb-blockquote__author-wrap.uagb-blockquote__author-at-right{flex-direction:row-reverse}.wp-block-uagb-blockquote .uagb-blockquote__align-right .uagb-blockquote__author-wrap.uagb-blockquote__author-at-top{text-align:right}.wp-block-uagb-blockquote .uagb-blockquote__author-wrap.uagb-blockquote__author-at-right .uagb-blockquote__author-image img{margin-left:10px;margin-right:0}.wp-block-uagb-blockquote .uagb-blockquote__author-wrap.uagb-blockquote__author-at-top{flex-direction:column}@media only screen and (max-width: 976px){.wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet .uagb-blockquote__author{width:100%}.wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet .uagb-blockquote__author-wrap.uagb-blockquote__author-at-right,.wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet .uagb-blockquote__author-wrap.uagb-blockquote__author-at-left{flex-direction:column}.wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet .uagb-blockquote__author-wrap.uagb-blockquote__author-at-right .uagb-blockquote__author-image img,.wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet .uagb-blockquote__author-wrap.uagb-blockquote__author-at-left .uagb-blockquote__author-image img{margin-left:0;margin-right:0;margin-bottom:10px}.wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet.uagb-blockquote__with-tweet .uagb-blockquote footer{flex-direction:column;align-self:flex-start}.wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet .uagb-blockquote__author-wrap.uagb-blockquote__author-at-left,.wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet a.uagb-blockquote__tweet-button{align-self:flex-start}.wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet.uagb-blockquote__align-right.uagb-blockquote__with-tweet .uagb-blockquote footer,.wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet.uagb-blockquote__align-right .uagb-blockquote__author-wrap.uagb-blockquote__author-at-left,.wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet.uagb-blockquote__align-right a.uagb-blockquote__tweet-button{align-self:flex-end}.wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet a.uagb-blockquote__tweet-button{margin-top:10px}.wp-block-uagb-blockquote .uagb-blockquote__align-right.uagb-blockquote__stack-img-tablet .uagb-blockquote__author-image{align-self:flex-end}.wp-block-uagb-blockquote .uagb-blockquote__align-left.uagb-blockquote__stack-img-tablet .uagb-blockquote__author-image,.wp-block-uagb-blockquote .uagb-blockquote__align-left.uagb-blockquote__stack-img-tablet .uagb-blockquote__author{align-self:flex-start}.wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet.uagb-blockquote__align-right.uagb-blockquote__tweet-style-bubble a.uagb-blockquote__tweet-button:before,.wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet.uagb-blockquote__align-left.uagb-blockquote__tweet-style-bubble a.uagb-blockquote__tweet-button:before{left:50%;top:-0.8em;right:auto;transform:translate(-50%, 10%) scale(1, 0.85) rotate(90deg)}}@media screen and (max-width: 767px){.wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile .uagb-blockquote__author{width:100%}.wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile .uagb-blockquote__author-wrap.uagb-blockquote__author-at-right,.wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile .uagb-blockquote__author-wrap.uagb-blockquote__author-at-left{flex-direction:column}.wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile .uagb-blockquote__author-wrap.uagb-blockquote__author-at-right .uagb-blockquote__author-image img,.wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile .uagb-blockquote__author-wrap.uagb-blockquote__author-at-left .uagb-blockquote__author-image img{margin-left:0;margin-right:0;margin-bottom:10px}.wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile.uagb-blockquote__with-tweet .uagb-blockquote footer{flex-direction:column;align-self:flex-start}.wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile .uagb-blockquote__author-wrap.uagb-blockquote__author-at-left,.wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile a.uagb-blockquote__tweet-button{align-self:flex-start}.wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile.uagb-blockquote__align-right.uagb-blockquote__with-tweet .uagb-blockquote footer,.wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile.uagb-blockquote__align-right .uagb-blockquote__author-wrap.uagb-blockquote__author-at-left,.wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile.uagb-blockquote__align-right a.uagb-blockquote__tweet-button{align-self:flex-end}.wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile a.uagb-blockquote__tweet-button{margin-top:10px}.wp-block-uagb-blockquote .uagb-blockquote__align-right.uagb-blockquote__stack-img-mobile .uagb-blockquote__author-image{align-self:flex-end}.wp-block-uagb-blockquote .uagb-blockquote__align-left.uagb-blockquote__stack-img-mobile .uagb-blockquote__author-image,.wp-block-uagb-blockquote .uagb-blockquote__align-left.uagb-blockquote__stack-img-tablet .uagb-blockquote__author{align-self:flex-start}.wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile.uagb-blockquote__align-right.uagb-blockquote__tweet-style-bubble a.uagb-blockquote__tweet-button:before,.wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile.uagb-blockquote__align-left.uagb-blockquote__tweet-style-bubble a.uagb-blockquote__tweet-button:before{left:50%;top:-0.8em;right:auto;transform:translate(-50%, 10%) scale(1, 0.85) rotate(90deg)}}
-.wp-block-uagb-marketing-button .uagb-marketing-btn__wrap>p,.wp-block-uagb-marketing-button p:empty{display:none}.wp-block-uagb-marketing-button .uagb-marketing-btn__title,.wp-block-uagb-marketing-button p.uagb-marketing-btn__prefix{margin:0}.wp-block-uagb-marketing-button .uagb-marketing-btn__wrap{display:flex}.wp-block-uagb-marketing-button .uagb-marketing-btn__link{z-index:1}.wp-block-uagb-marketing-button .uagb-marketing-btn__link{display:inline-block;position:relative;transition:all 0.2s}.wp-block-uagb-marketing-button .uagb-marketing-btn__icon-wrap{width:20px;height:20px;display:flex;z-index:1}.wp-block-uagb-marketing-button .uagb-marketing-btn__icon-wrap svg{width:inherit;height:inherit}.wp-block-uagb-marketing-button .uagb-marketing-btn__title-wrap{display:flex;align-items:center}.wp-block-uagb-marketing-button.uagb-marketing-btn__align-center .uagb-marketing-btn__wrap,.wp-block-uagb-marketing-button.uagb-marketing-btn__align-text-center .uagb-marketing-btn__title-wrap{justify-content:center}.wp-block-uagb-marketing-button.uagb-marketing-btn__align-left .uagb-marketing-btn__wrap,.wp-block-uagb-marketing-button.uagb-marketing-btn__align-text-left .uagb-marketing-btn__title-wrap{justify-content:flex-start}.wp-block-uagb-marketing-button.uagb-marketing-btn__align-right .uagb-marketing-btn__wrap,.wp-block-uagb-marketing-button.uagb-marketing-btn__align-text-right .uagb-marketing-btn__title-wrap{justify-content:flex-end}.wp-block-uagb-marketing-button.uagb-marketing-btn__align-full .uagb-marketing-btn__link{width:100%}.wp-block-uagb-marketing-button.uagb-marketing-btn__align-text-center .uagb-marketing-btn__prefix-wrap{text-align:center}.wp-block-uagb-marketing-button.uagb-marketing-btn__align-text-left .uagb-marketing-btn__prefix-wrap{text-align:left}.wp-block-uagb-marketing-button.uagb-marketing-btn__align-text-right .uagb-marketing-btn__prefix-wrap{text-align:right}.wp-block-uagb-marketing-button.uagb-marketing-btn__icon-after .uagb-marketing-btn__title-wrap{flex-direction:row-reverse}.entry-content .wp-block-uagb-marketing-button .uagb-marketing-btn__link{text-decoration:none}
-.wp-block-uagb-table-of-contents .uagb-toc__wrap{display:inline-block}.wp-block-uagb-table-of-contents ul.uagb-toc__list{margin-left:1.2em;padding-left:0px;margin-bottom:0}.wp-block-uagb-table-of-contents ul.uagb-toc__list li{margin:0}.wp-block-uagb-table-of-contents .uagb-toc__list-wrap ul li a{color:inherit;line-height:inherit;font-size:inherit}.wp-block-uagb-table-of-contents.uagb-toc__align-left{text-align:left}.wp-block-uagb-table-of-contents.uagb-toc__align-center{text-align:center}.wp-block-uagb-table-of-contents.uagb-toc__align-right{text-align:right}.wp-block-uagb-table-of-contents ul li:empty{display:none}.wp-block-uagb-table-of-contents .uagb-toc__title-wrap{display:flex;align-items:center;justify-content:space-between}.wp-block-uagb-table-of-contents .uagb-toc__is-collapsible.uagb-toc__title-wrap{cursor:pointer}.wp-block-uagb-table-of-contents .uag-toc__collapsible-wrap svg{width:20px;height:20px}.wp-block-uagb-table-of-contents .uag-toc__collapsible-wrap{margin-left:10px;display:flex;cursor:pointer}.wp-block-uagb-table-of-contents.uagb-toc__collapse .uagb-toc__list-wrap{display:none}.uagb-toc__list .uagb-toc__list{list-style-type:circle}.uagb-toc__scroll-top.dashicons{display:none;position:fixed;bottom:50px;right:50px;padding:10px;background:#ccd0d4;cursor:pointer}.uagb-toc__scroll-top.uagb-toc__show-scroll{display:inline-table}
-.uagb-howto__cost-wrap{display:block}.uagb-howto__cost-wrap .uagb-howto-estcost-text,.uagb-howto__cost-wrap .uagb-howto-estcost-value,.uagb-howto__cost-wrap .uagb-howto-estcost-type{display:inline-flex}.uagb-howto__time-wrap{display:block}.uagb-howto__time-wrap .uagb-howto-timeNeeded-text,.uagb-howto__time-wrap .uagb-howto-timeNeeded-value,.uagb-howto__time-wrap .uagb-howto-timeINmin-text{display:inline-flex}
-.wp-block-uagb-faq.uagb-faq-layout-accordion .uagb-faq-child__outer-wrap .uagb-faq-questions-button{cursor:pointer}.uagb-faq-layout-grid.uagb-faq-equal-height .uagb-faq__wrap .uagb-faq-child__outer-wrap,.uagb-faq-layout-grid.uagb-faq-equal-height .uagb-faq__wrap .uagb-faq-child__wrapper,.uagb-faq-layout-grid.uagb-faq-equal-height .uagb-faq__wrap .uagb-faq-item{height:100%}
-.wp-block-uagb-faq-child.uagb-faq-child__outer-wrap .uagb-faq-item:focus,.wp-block-uagb-faq-child.uagb-faq-child__outer-wrap .uagb-faq-item:active{outline:thin dotted}.wp-block-uagb-faq-child .uagb-faq-questions-button{display:flex;align-items:center;width:100%}.wp-block-uagb-faq-child .uagb-faq-questions-button .uagb-faq-icon-wrap{display:inline-block;vertical-align:middle}.wp-block-uagb-faq-child .uagb-faq-questions-button .uagb-question{width:100%;margin-top:0px;margin-bottom:0px}.wp-block-uagb-faq-child .uagb-icon svg,.wp-block-uagb-faq-child .uagb-icon-active svg{width:15px;height:15px;font-size:15px}.wp-block-uagb-faq-child .uagb-faq-content span{display:inline-block}.wp-block-uagb-faq-child .uagb-faq-content p{margin:0}.wp-block-uagb-faq-child.uagb-faq-child__outer-wrap .uagb-faq-item .uagb-icon-active,.wp-block-uagb-faq-child.uagb-faq-child__outer-wrap .uagb-faq-item.uagb-faq-item-active .uagb-icon{display:none;width:0;padding:0;height:0;margin:0}.wp-block-uagb-faq-child.uagb-faq-child__outer-wrap .uagb-faq-item .uagb-icon,.wp-block-uagb-faq-child.uagb-faq-child__outer-wrap .uagb-faq-item.uagb-faq-item-active .uagb-icon-active{display:inline-block;width:auto;height:auto}
-.uagb-inline_notice__outer-wrap.uagb-inline_notice__align-right{text-align:right}.uagb-inline_notice__outer-wrap.uagb-inline_notice__align-right span.uagb-notice-dismiss{left:13px}.uagb-inline_notice__outer-wrap.uagb-inline_notice__align-center{text-align:center}.uagb-inline_notice__outer-wrap.uagb-inline_notice__align-center span.uagb-notice-dismiss{right:13px}.uagb-inline_notice__outer-wrap.uagb-inline_notice__align-left{text-align:left}.uagb-inline_notice__outer-wrap.uagb-inline_notice__align-left span.uagb-notice-dismiss{right:13px}.wp-block-uagb-inline-notice{position:relative}.wp-block-uagb-inline-notice.uagb-notice__active{display:none}.wp-block-uagb-inline-notice h4{margin:0;border-top-right-radius:3px;border-top-left-radius:3px;width:100%;display:inline-block}.wp-block-uagb-inline-notice .uagb-notice-text{border:solid 2px #000;border-bottom-right-radius:3px;border-bottom-left-radius:3px}.wp-block-uagb-inline-notice span.uagb-notice-dismiss svg{width:16px;height:16px}.wp-block-uagb-inline-notice span.uagb-notice-dismiss{position:absolute;cursor:pointer;top:13px;opacity:.8;padding:0;background:none;transition:.3s ease}
-.wp-block-uagb-wp-search.uagb-wp-search__outer-wrap{min-height:20px;width:100%}.wp-block-uagb-wp-search.uagb-wp-search__outer-wrap.uagb-layout-input-button .uagb-search-submit{color:#fff;border:none;border-radius:0}.wp-block-uagb-wp-search.uagb-wp-search__outer-wrap.uagb-layout-input-button svg{fill:currentColor}.wp-block-uagb-wp-search.uagb-wp-search__outer-wrap.uagb-layout-input .uagb-wp-search-icon-wrap{display:flex;align-items:center}.wp-block-uagb-wp-search.uagb-wp-search__outer-wrap.uagb-layout-input svg{fill:currentColor;opacity:0.6}.wp-block-uagb-wp-search.uagb-wp-search__outer-wrap .uagb-search-wrapper .uagb-search-form__container{display:flex;overflow:hidden}.wp-block-uagb-wp-search.uagb-wp-search__outer-wrap .uagb-search-wrapper .uagb-search-form__container .uagb-search-form__input{width:100%}
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.wp-block-uagb-advanced-heading {
+  padding: 0;
+  margin: 0 auto; }
+  .wp-block-uagb-advanced-heading .uagb-heading-text {
+    margin: 0;
+    text-align: center; }
+  .wp-block-uagb-advanced-heading .uagb-separator-wrap {
+    font-size: 0;
+    text-align: center; }
+  .wp-block-uagb-advanced-heading .uagb-separator {
+    border-top-style: solid;
+    display: inline-block;
+    border-top-width: 2px;
+    width: 5%;
+    margin: 0px 0px 10px 0px; }
+  .wp-block-uagb-advanced-heading .uagb-desc-text {
+    margin: 0;
+    text-align: center; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * Post grid styles
+ * Loads on front end and back end
+ */
+.uagb-post-grid {
+  margin: 0;
+  position: relative; }
+  .uagb-post-grid .uagb-post__load-more-wrap {
+    width: 100%; }
+    .uagb-post-grid .uagb-post__load-more-wrap .uagb-post-pagination-button {
+      cursor: pointer; }
+    .uagb-post-grid .uagb-post__load-more-wrap a {
+      color: inherit; }
+  .uagb-post-grid .is-grid article {
+    float: left;
+    display: inline-block; }
+  .uagb-post-grid .uagb-post__items {
+    display: flex;
+    flex-wrap: wrap; }
+  .uagb-post-grid .is-grid.uagb-post__equal-height .uagb-post__inner-wrap {
+    height: 100%; }
+  .uagb-post-grid .is-masonry .uagb-post__inner-wrap {
+    height: auto; }
+  .uagb-post-grid .uagb-post__inner-wrap > p {
+    display: none; }
+  .uagb-post-grid .uagb-post__author span,
+  .uagb-post-grid .uagb-post__comment span,
+  .uagb-post-grid .uagb-post__taxonomy span,
+  .uagb-post-grid .uagb-post__date span {
+    font-size: inherit;
+    line-height: inherit;
+    width: inherit;
+    height: inherit;
+    margin-right: 4px; }
+  .uagb-post-grid .uagb-post__columns-8 article {
+    width: 12.5%; }
+  .uagb-post-grid .uagb-post__columns-7 article {
+    width: 14.28%; }
+  .uagb-post-grid .uagb-post__columns-6 article {
+    width: 16.66%; }
+  .uagb-post-grid .uagb-post__columns-5 article {
+    width: 20%; }
+  .uagb-post-grid .uagb-post__columns-4 article {
+    width: 25%; }
+  .uagb-post-grid .uagb-post__columns-3 article {
+    width: 33.2%; }
+  .uagb-post-grid .uagb-post__columns-2 article {
+    width: 50%; }
+  .uagb-post-grid .uagb-post__columns-1 article {
+    width: 100%; }
+  @media only screen and (max-width: 600px) {
+    .uagb-post-grid div[class*="columns"].is-grid {
+      grid-template-columns: 1fr; } }
+  .uagb-post-grid .uagb-post__image img {
+    display: block;
+    width: 100%; }
+  .uagb-post-grid .uagb-post__text {
+    text-align: left;
+    box-sizing: border-box; }
+  .uagb-post-grid .uagb-post__title {
+    margin-top: 0;
+    margin-bottom: 15px;
+    word-break: break-word; }
+    .uagb-post-grid .uagb-post__title a {
+      color: inherit;
+      box-shadow: none;
+      transition: .3s ease;
+      text-decoration: none; }
+      .uagb-post-grid .uagb-post__title a:hover {
+        text-decoration: none; }
+      .uagb-post-grid .uagb-post__title a:focus {
+        text-decoration: none; }
+      .uagb-post-grid .uagb-post__title a:active {
+        text-decoration: none; }
+  .uagb-post-grid .uagb-post-grid-byline {
+    text-transform: uppercase;
+    font-size: 11px;
+    letter-spacing: 1px;
+    margin-bottom: 15px; }
+  .uagb-post-grid .uagb-post__text .uagb-post-grid-byline > * {
+    margin-right: 10px; }
+  .uagb-post-grid .uagb-post-grid-byline a,
+  .uagb-post-grid .uagb-post-grid-byline a:focus,
+  .uagb-post-grid .uagb-post-grid-byline a:active {
+    color: inherit;
+    font-size: inherit; }
+  .uagb-post-grid .uagb-post__title a,
+  .uagb-post-grid .uagb-post__title a:focus,
+  .uagb-post-grid .uagb-post__title a:active {
+    color: inherit;
+    font-size: inherit; }
+  .uagb-post-grid .uagb-post__author,
+  .uagb-post-grid .uagb-post__date {
+    display: inline-block;
+    word-break: break-all; }
+    .uagb-post-grid .uagb-post__author:not(:last-child):after,
+    .uagb-post-grid .uagb-post__date:not(:last-child):after {
+      content: "\B7";
+      vertical-align: middle;
+      margin: 0 5px;
+      line-height: 1; }
+  .uagb-post-grid .uagb-post__comment,
+  .uagb-post-grid .uagb-post__taxonomy {
+    display: inline-block; }
+  .uagb-post-grid .uagb-post__author a {
+    box-shadow: none; }
+    .uagb-post-grid .uagb-post__author a:hover {
+      color: inherit;
+      box-shadow: 0 -1px 0 inset; }
+  .uagb-post-grid .uagb-post__excerpt {
+    margin-bottom: 25px;
+    word-break: break-word; }
+  .uagb-post-grid .uagb-post__text p {
+    margin: 0 0 15px 0; }
+    .uagb-post-grid .uagb-post__text p:last-of-type {
+      margin-bottom: 0; }
+  .uagb-post-grid .uagb-post__cta {
+    border: none;
+    display: inline-block; }
+  .uagb-post-grid .uagb-post__link {
+    display: inline-block;
+    box-shadow: none;
+    transition: .3s ease;
+    font-weight: bold;
+    color: inherit;
+    text-decoration: none;
+    padding: 5px 10px; }
+  .uagb-post-grid .uagb-post__excerpt div + p {
+    margin-top: 15px; }
+  .uagb-post-grid .uagb-post__excerpt p {
+    color: inherit; }
+  .uagb-post-grid .uagb-post__link-complete-box {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 11; }
+
+.uagb-post__image-position-background .uagb-post__text {
+  opacity: 1;
+  position: relative;
+  z-index: 10;
+  overflow: hidden;
+  width: 100%; }
+
+.uagb-post__image-position-background .uagb-post__inner-wrap {
+  position: relative;
+  width: 100%; }
+
+.uagb-post__image-position-background .uagb-post__image img {
+  position: absolute;
+  width: auto;
+  height: auto;
+  min-width: 100%;
+  max-width: none;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  min-height: 100%; }
+
+.uagb-post__image-position-background .uagb-post__image {
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center;
+  overflow: hidden;
+  text-align: center;
+  position: relative; }
+
+.uagb-post__image-position-background .uagb-post__image {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 2; }
+
+.uagb-post__image-position-background .uagb-post__image::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1;
+  background-color: rgba(255, 255, 255, 0.5); }
+
+.uagb-post-grid[data-equal-height="yes"] .uagb-post__inner-wrap {
+  display: inline-block;
+  height: 100%; }
+
+.uagb-post__arrow-outside.uagb-post-grid .slick-prev {
+  left: -45px;
+  z-index: 1; }
+
+[dir="rtl"] .uagb-post__arrow-outside.uagb-post-grid .slick-prev {
+  left: auto;
+  right: -45px; }
+
+.uagb-post__arrow-outside.uagb-post-grid .slick-next {
+  right: -45px; }
+
+[dir="rtl"] .uagb-post__arrow-outside.uagb-post-grid .slick-next {
+  left: -45px;
+  right: auto; }
+
+.uagb-post__arrow-inside.uagb-post-grid .slick-prev {
+  left: 25px;
+  z-index: 1; }
+
+[dir="rtl"] .uagb-post__arrow-inside.uagb-post-grid .slick-prev {
+  left: auto;
+  right: 25px; }
+
+.uagb-post__arrow-inside.uagb-post-grid .slick-next {
+  right: 25px; }
+
+[dir="rtl"] .uagb-post__arrow-inside.uagb-post-grid .slick-next {
+  left: 25px;
+  right: auto; }
+
+.uagb-post-grid .is-grid article,
+.uagb-post-grid .is-masonry article,
+.uagb-post-grid .is-carousel article {
+  box-sizing: border-box; }
+
+/**
+ * Post grid styles
+ * Loads on front end and back end
+ */
+@media (max-width: 976px) {
+  .uagb-post__arrow-outside.uagb-post-grid .slick-prev {
+    left: 15px;
+    z-index: 1; }
+  [dir="rtl"] .uagb-post__arrow-outside.uagb-post-grid .slick-prev {
+    left: auto;
+    right: 15px; }
+  .uagb-post__arrow-outside.uagb-post-grid .slick-next {
+    right: 15px; }
+  [dir="rtl"] .uagb-post__arrow-outside.uagb-post-grid .slick-next {
+    left: 15px;
+    right: auto; }
+  .uagb-post-grid .uagb-post__columns-tablet-1 article {
+    width: 100%; }
+  .uagb-post-grid .uagb-post__columns-tablet-2 article {
+    width: 50%; }
+  .uagb-post-grid .uagb-post__columns-tablet-3 article {
+    width: 33.2%; }
+  .uagb-post-grid .uagb-post__columns-tablet-4 article {
+    width: 25%; }
+  .uagb-post-grid .uagb-post__columns-tablet-5 article {
+    width: 20%; }
+  .uagb-post-grid .uagb-post__columns-tablet-6 article {
+    width: 16.66%; }
+  .uagb-post-grid .uagb-post__columns-tablet-7 article {
+    width: 14.28%; }
+  .uagb-post-grid .uagb-post__columns-tablet-8 article {
+    width: 12.5%; } }
+
+@media (max-width: 767px) {
+  .uagb-post-grid .uagb-post__columns-mobile-1 article {
+    width: 100%; }
+  .uagb-post-grid .uagb-post__columns-mobile-2 article {
+    width: 50%; }
+  .uagb-post-grid .uagb-post__columns-mobile-3 article {
+    width: 33.2%; }
+  .uagb-post-grid .uagb-post__columns-mobile-4 article {
+    width: 25%; }
+  .uagb-post-grid .uagb-post__columns-mobile-5 article {
+    width: 20%; }
+  .uagb-post-grid .uagb-post__columns-mobile-6 article {
+    width: 16.66%; }
+  .uagb-post-grid .uagb-post__columns-tablet-7 article {
+    width: 14.28%; }
+  .uagb-post-grid .uagb-post__columns-tablet-8 article {
+    width: 12.5%; } }
+
+.entry .entry-content .uagb-post-grid a {
+  text-decoration: none; }
+
+.uagb-post-pagination-wrap a.page-numbers,
+.uagb-post-pagination-wrap span.page-numbers.current {
+  padding: 5px 10px;
+  margin: 0;
+  display: inline-block; }
+
+.uagb-post-grid .uagb-post-inf-loader {
+  margin: 0 auto;
+  min-height: 58px;
+  line-height: 58px;
+  width: 160px;
+  text-align: center; }
+  .uagb-post-grid .uagb-post-inf-loader div {
+    width: 18px;
+    height: 18px;
+    background-color: #0085ba;
+    border-radius: 100%;
+    display: inline-block;
+    animation: sk-bouncedelay 1.4s infinite ease-in-out both; }
+  .uagb-post-grid .uagb-post-inf-loader .uagb-post-loader-1 {
+    animation-delay: -0.32s; }
+  .uagb-post-grid .uagb-post-inf-loader .uagb-post-loader-2 {
+    animation-delay: -0.16s; }
+
+@keyframes sk-bouncedelay {
+  0%,
+  80%,
+  100% {
+    transform: scale(0); }
+  40% {
+    transform: scale(1); } }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.uagb-section__wrap {
+  position: relative; }
+  .uagb-section__wrap .uagb-section__inner-wrap {
+    margin-left: auto;
+    margin-right: auto;
+    position: relative;
+    z-index: 2; }
+  .uagb-section__wrap .uagb-section__overlay {
+    height: 100%;
+    width: 100%;
+    top: 0;
+    left: 0;
+    position: absolute; }
+  .uagb-section__wrap .uagb-section__video-wrap {
+    height: 100%;
+    width: 100%;
+    top: 0;
+    left: 0;
+    position: absolute;
+    overflow: hidden;
+    z-index: 0;
+    transition: opacity 1s; }
+  .uagb-section__wrap .uagb-section__video-wrap video {
+    max-width: 100%;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    line-height: 1;
+    border: none;
+    display: inline-block;
+    vertical-align: baseline;
+    -o-object-fit: cover;
+    object-fit: cover;
+    background-size: cover; }
+
+@media (min-width: 768px) and (max-width: 1024px) {
+  .wp-block-uagb-section.uagb-section__wrap.uagb-section__background-image {
+    background-attachment: scroll; } }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.uagb-buttons__outer-wrap .uagb-buttons__wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center; }
+
+.uagb-buttons__outer-wrap a {
+  color: inherit; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+.uagb-buttons-repeater {
+  display: flex;
+  justify-content: center;
+  align-items: center; }
+  .uagb-buttons-repeater a.uagb-button__link {
+    display: flex;
+    justify-content: center; }
+  .uagb-buttons-repeater .uagb-button__icon {
+    font-size: inherit;
+    display: flex;
+    align-items: center;
+    width: 15px; }
+    .uagb-buttons-repeater .uagb-button__icon svg {
+      fill: currentColor;
+      width: inherit;
+      height: inherit; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+/* Info Box */
+.uagb-ifb-icon-wrap, .uagb-ifb-icon-wrap * {
+  transition: all 0.2s; }
+
+.uagb-ifb-icon-wrap .uagb-ifb-icon,
+.uagb-ifb-content {
+  display: inline-block; }
+
+.uagb-ifb-icon svg {
+  width: inherit;
+  height: inherit;
+  vertical-align: middle; }
+
+.infobox-icon-above-title .uagb-ifb-left-right-wrap {
+  text-align: center; }
+
+a.uagb-infobox-cta-link span {
+  font-size: inherit; }
+
+.uagb-ifb-cta.uagb-infobox-cta-link-style:empty {
+  display: none; }
+
+a.uagb-infobox-cta-link,
+.entry .entry-content a.uagb-infobox-cta-link,
+a.uagb-infobox-link-wrap,
+.entry .entry-content a.uagb-infobox-link-wrap {
+  text-decoration: none; }
+
+a.uagb-infobox-cta-link:hover,
+.entry .entry-content a.uagb-infobox-cta-link:hover,
+a.uagb-infobox-link-wrap:hover,
+.entry .entry-content a.uagb-infobox-link-wrap:hover
+.entry .entry-content a.uagb-infobox-cta-link:hover {
+  color: inherit; }
+
+.uagb-infobox-icon-left-title.uagb-infobox-image-valign-middle .uagb-ifb-title-wrap,
+.uagb-infobox-icon-right-title.uagb-infobox-image-valign-middle .uagb-ifb-title-wrap,
+.uagb-infobox-image-valign-middle .uagb-ifb-imgicon-wrap,
+.uagb-infobox-icon-left.uagb-infobox-image-valign-middle .uagb-ifb-content,
+.uagb-infobox-icon-right.uagb-infobox-image-valign-middle .uagb-ifb-content {
+  align-self: center; }
+
+.uagb-infobox-left {
+  text-align: left;
+  justify-content: flex-start; }
+
+.uagb-infobox-center {
+  text-align: center;
+  justify-content: center; }
+
+.uagb-infobox-right {
+  text-align: right;
+  justify-content: flex-end; }
+
+.uagb-ifb-left-right-wrap {
+  width: 100%;
+  word-break: break-word; }
+
+.uagb-infobox-icon-above-title .uagb-ifb-left-right-wrap,
+.uagb-infobox-icon-below-title .uagb-ifb-left-right-wrap {
+  display: block;
+  min-width: 100%;
+  width: 100%; }
+
+/* Left/Right of Title */
+.uagb-infobox-icon-left-title .uagb-ifb-icon-wrap,
+.uagb-infobox-icon-left .uagb-ifb-icon-wrap {
+  margin-right: 10px; }
+
+.uagb-infobox-icon-right-title .uagb-ifb-icon-wrap,
+.uagb-infobox-icon-right .uagb-ifb-icon-wrap {
+  margin-left: 10px; }
+
+/* Left/Right */
+.uagb-infobox-icon-left .uagb-ifb-left-right-wrap,
+.uagb-infobox-icon-right .uagb-ifb-left-right-wrap,
+.uagb-infobox-icon-left-title .uagb-ifb-left-title-image,
+.uagb-infobox-icon-right-title .uagb-ifb-right-title-image {
+  -js-display: flex;
+  display: flex; }
+
+.uagb-infobox-icon-right .uagb-ifb-left-right-wrap,
+.uagb-infobox-icon-right-title .uagb-ifb-right-title-image {
+  justify-content: flex-end; }
+
+/* Above/Below Title */
+.uagb-ifb-icon-wrap .uagb-ifb-icon span {
+  font-style: initial;
+  height: auto;
+  width: auto; }
+
+/* Infobox image css */
+.uagb-ifb-imgicon-wrap .uagb-ifb-image-content {
+  display: inline-block;
+  line-height: 0;
+  position: relative;
+  max-width: 100%; }
+
+.uagb-ifb-imgicon-wrap .uagb-ifb-image-content img {
+  display: inline;
+  height: auto !important;
+  max-width: 100%;
+  width: auto;
+  box-sizing: content-box;
+  border-radius: inherit; }
+
+.uagb-ifb-imgicon-wrap .uagb-image-crop-circle img {
+  border-radius: 100%; }
+
+.uagb-ifb-imgicon-wrap .uagb-image-crop-square img {
+  border-radius: 0; }
+
+/* Info box complete box link css */
+.uagb-infobox-module-link {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  z-index: 4; }
+
+.uagb-edit-mode .uagb-infobox-module-link {
+  z-index: 2; }
+
+.uagb-infobox-link-icon-after {
+  margin-left: 5px;
+  margin-right: 0; }
+
+.uagb-infobox-link-icon-before {
+  margin-left: 0;
+  margin-right: 5px; }
+
+.uagb-infobox-link-icon {
+  transition: all 200ms linear; }
+
+.uagb-infobox {
+  position: relative; }
+
+.uagb-ifb-separator {
+  width: 30%;
+  border-top-width: 2px;
+  border-top-color: #333;
+  border-top-style: solid;
+  display: inline-block;
+  margin: 0; }
+
+.uagb-ifb-separator-parent {
+  line-height: 0em;
+  margin-left: 0;
+  margin-right: 0;
+  margin-bottom: 10px; }
+
+.uagb-ifb-cta-button {
+  display: inline-block;
+  line-height: 1;
+  background-color: #818a91;
+  color: #fff;
+  text-align: center; }
+
+.uagb-ifb-button-wrapper .wp-block-button__link svg {
+  fill: currentColor; }
+
+.uagb-ifb-cta a {
+  box-shadow: none;
+  text-decoration: none; }
+
+.uagb-ifb-title-wrap {
+  width: 100%; }
+
+.uagb-ifb-title-wrap .uagb-ifb-title,
+.uagb-ifb-title-wrap .uagb-ifb-title-prefix {
+  padding: 0;
+  margin: 0;
+  display: block; }
+
+.uagb-infobox__content-wrap.uagb-infobox {
+  position: relative; }
+
+.uagb-ifb-icon span {
+  font-size: 40px;
+  height: 40px;
+  color: #333;
+  width: 40px; }
+
+.uagb-ifb-icon svg {
+  fill: #333; }
+
+.uagb-ifb-content {
+  width: 100%; }
+
+.uagb-infobox__content-wrap.uagb-infobox,
+.uagb-ifb-content,
+.uagb-ifb-title-wrap,
+.uagb-ifb-title-prefix *,
+svg.dashicon.dashicons-upload {
+  z-index: 1; }
+
+.uagb-ifb-left-right-wrap,
+button.components-button {
+  z-index: 1; }
+
+.uagb-infobox-cta-link {
+  cursor: pointer; }
+
+a.uagb-infobox-link-wrap {
+  color: inherit; }
+
+.uagb-ifb-content p:empty {
+  display: none; }
+
+.uagb-infobox .uagb-ifb-icon,
+.uagb-infobox .uagb-ifb-image-content img {
+  display: inline-block;
+  box-sizing: content-box; }
+
+.uagb-ifb-align-icon-after {
+  margin-left: 5px; }
+
+.uagb-ifb-align-icon-before {
+  margin-right: 5px; }
+
+span.uagb-ifb-button-icon.uagb-ifb-align-icon-after {
+  float: right; }
+
+.uagb-ifb-button-icon {
+  height: 15px;
+  width: 15px;
+  font-size: 15px;
+  vertical-align: middle; }
+
+.uagb-ifb-text-icon {
+  height: 15px;
+  width: 15px;
+  font-size: 15px;
+  line-height: 15px;
+  vertical-align: middle;
+  display: inline-block; }
+
+.uagb-ifb-button-icon svg,
+.uagb-ifb-text-icon svg {
+  height: inherit;
+  width: inherit;
+  display: inline-block; }
+
+.block-editor-page #wpwrap .uagb-infobox-cta-link svg,
+.uagb-infobox-cta-link svg {
+  font-style: normal; }
+
+.uagb-infobox__outer-wrap {
+  position: relative; }
+
+a.uagb-infbox__link-to-all {
+  height: 100%;
+  width: 100%;
+  top: 0;
+  left: 0;
+  position: absolute;
+  z-index: 3;
+  box-shadow: none;
+  text-decoration: none; }
+
+@media only screen and (max-width: 976px) {
+  .uagb-infobox-stacked-tablet .uagb-ifb-left-right-wrap .uagb-ifb-imgicon-wrap {
+    padding: 0;
+    margin-bottom: 20px; }
+  .uagb-infobox-stacked-tablet.uagb-reverse-order-tablet .uagb-ifb-left-right-wrap {
+    -js-display: inline-flex;
+    display: inline-flex;
+    flex-direction: column-reverse; }
+  .uagb-infobox.uagb-infobox-stacked-tablet .uagb-ifb-left-right-wrap .uagb-ifb-content,
+  .uagb-infobox.uagb-infobox-stacked-tablet .uagb-ifb-left-right-wrap .uagb-ifb-imgicon-wrap {
+    display: block;
+    width: 100%;
+    text-align: center; }
+  .uagb-infobox.uagb-infobox-stacked-tablet .uagb-ifb-left-right-wrap .uagb-ifb-imgicon-wrap {
+    margin-left: 0px;
+    margin-right: 0px; }
+  .uagb-infobox-stacked-tablet .uagb-ifb-left-right-wrap {
+    display: inline-block; }
+  .uagb-infobox-icon-left-title.uagb-infobox-stacked-tablet .uagb-ifb-imgicon-wrap,
+  .uagb-infobox-icon-left.uagb-infobox-stacked-tablet .uagb-ifb-imgicon-wrap {
+    margin-right: 0px; }
+  .uagb-infobox-icon-right-title.uagb-infobox-stacked-tablet .uagb-ifb-imgicon-wrap,
+  .uagb-infobox-icon-right.uagb-infobox-stacked-tablet .uagb-ifb-imgicon-wrap {
+    margin-left: 0px; }
+  .uagb-infobox-icon-left-title .uagb-ifb-separator-parent {
+    margin: 10px 0; } }
+
+@media screen and (max-width: 767px) {
+  .uagb-infobox-stacked-mobile .uagb-ifb-left-right-wrap .uagb-ifb-imgicon-wrap {
+    padding: 0;
+    margin-bottom: 20px; }
+  .uagb-infobox-stacked-mobile.uagb-reverse-order-mobile .uagb-ifb-left-right-wrap {
+    -js-display: inline-flex;
+    display: inline-flex;
+    flex-direction: column-reverse; }
+  .uagb-infobox.uagb-infobox-stacked-mobile .uagb-ifb-left-right-wrap .uagb-ifb-content,
+  .uagb-infobox.uagb-infobox-stacked-mobile .uagb-ifb-left-right-wrap .uagb-ifb-imgicon-wrap {
+    display: block;
+    width: 100%;
+    text-align: center; }
+  .uagb-infobox.uagb-infobox-stacked-mobile .uagb-ifb-left-right-wrap .uagb-ifb-imgicon-wrap {
+    margin-left: 0px;
+    margin-right: 0px; }
+  .uagb-infobox-stacked-mobile .uagb-ifb-left-right-wrap {
+    display: inline-block; }
+  .uagb-infobox-icon-left-title.uagb-infobox-stacked-mobile .uagb-ifb-imgicon-wrap,
+  .uagb-infobox-icon-left.uagb-infobox-stacked-mobile .uagb-ifb-imgicon-wrap {
+    margin-right: 0px; }
+  .uagb-infobox-icon-right-title.uagb-infobox-stacked-mobile .uagb-ifb-imgicon-wrap,
+  .uagb-infobox-icon-right.uagb-infobox-stacked-mobile .uagb-ifb-imgicon-wrap {
+    margin-left: 0px; }
+  .uagb-infobox-icon-left-title .uagb-ifb-separator-parent {
+    margin: 10px 0; } }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.uagb-testimonial__wrap {
+  position: relative;
+  box-sizing: border-box; }
+
+.uagb-testimonial__wrap,
+.uagb-testimonial__wrap * {
+  transition: all 0.2s; }
+
+.uagb-icon-wrap .uagb-icon {
+  display: inline-block; }
+
+.uagb-tm__image {
+  position: relative; }
+
+.uagb-tm__imgicon-style-circle .uagb-tm__image img {
+  border-radius: 100%; }
+
+.uagb-tm__imgicon-style-square .uagb-tm__image img {
+  border-radius: 0%; }
+
+.uagb-tm__image img,
+.slick-slide .uagb-tm__image img {
+  display: inline-block;
+  box-sizing: content-box; }
+
+.uagb-tm__author-name,
+.uagb-tm__company {
+  display: inline-block; }
+
+.uagb-tm__content {
+  overflow: hidden;
+  text-align: center;
+  word-break: break-word;
+  padding: 15px;
+  border-radius: inherit;
+  position: relative; }
+
+.uagb-tm__image-position-left .uagb-tm__content,
+.uagb-tm__image-position-right .uagb-tm__content {
+  display: flex; }
+
+.uagb-tm__meta-inner {
+  display: inline-block; }
+
+.uagb-tm__image-position-bottom .uagb-tm__image-content,
+.uagb-tm__image-position-bottom .uagb-testimonial-details {
+  display: table-cell;
+  vertical-align: middle; }
+
+.uagb-tm__meta {
+  width: 100%;
+  line-height: 1; }
+
+.uagb-tm__image-position-bottom .uagb-tm__image-content {
+  padding-right: 10px; }
+
+.uagb-tm__author-name, .uagb-tm__company {
+  display: block; }
+
+.uagb-tm__image-aligned-middle .uagb-tm__image-content {
+  align-self: center; }
+
+.uagb-tm__desc {
+  margin-bottom: 15px; }
+
+.uagb-tm__author-name {
+  margin-bottom: 5px;
+  font-size: 30px;
+  line-height: 1em; }
+
+.uagb-tm__company {
+  font-size: 15px;
+  font-style: italic;
+  line-height: 1em;
+  color: #888888; }
+
+.is-carousel .uagb-testomonial__outer-wrap {
+  padding-left: 10px;
+  padding-right: 10px; }
+
+.uagb-tm__overlay {
+  height: 100%;
+  width: 100%;
+  top: 0;
+  left: 0;
+  position: absolute;
+  background: transparent; }
+
+.uagb-tm__text-wrap {
+  position: relative; }
+
+.uagb-tm__items {
+  visibility: hidden; }
+
+.uagb-tm__items.slick-initialized {
+  visibility: visible; }
+
+.uagb-tm__image-position-top .uagb-tm__image-content {
+  display: flex;
+  justify-content: center; }
+
+/* Slick CSS */
+.uagb-slick-carousel.uagb-tm__arrow-outside .slick-next {
+  right: -45px; }
+
+.uagb-slick-carousel.uagb-tm__arrow-inside .slick-prev {
+  left: 25px;
+  z-index: 1; }
+
+.uagb-slick-carousel.uagb-tm__arrow-inside .slick-next {
+  right: 25px; }
+
+[dir="rtl"] .uagb-tm__arrow-inside.uagb-slick-carousel .slick-prev {
+  left: auto;
+  right: 25px; }
+
+[dir="rtl"] .uagb-tm__arrow-inside.uagb-slick-carousel .slick-next {
+  left: 25px;
+  right: auto; }
+
+[dir="rtl"] .uagb-tm__arrow-outside.uagb-slick-carousel .slick-next {
+  left: -45px;
+  right: auto; }
+
+@media (max-width: 976px) {
+  .uagb-tm-stacked-tablet.uagb-tm__image-position-bottom .uagb-tm__image-content,
+  .uagb-tm-stacked-tablet.uagb-tm__image-position-bottom .uagb-testimonial-details {
+    display: block;
+    vertical-align: middle; }
+  .uagb-tm-stacked-tablet.uagb-tm__image-position-left .uagb-tm__content, .uagb-tm-stacked-tablet.uagb-tm__image-position-right .uagb-tm__content {
+    display: block; }
+  .uagb-tm-stacked-tablet.uagb-tm__image-position-right.uagb-tm-reverse-order-tablet .uagb-tm__content {
+    display: inline-flex;
+    flex-direction: column-reverse; }
+  .uagb-tm-stacked-tablet.uagb-tm__image-aligned-top .uagb-tm__image-content {
+    display: inline-flex;
+    align-self: center; }
+  .uagb-slick-carousel.uagb-tm__arrow-outside .slick-prev {
+    left: 15px;
+    z-index: 1; }
+  .uagb-slick-carousel.uagb-tm__arrow-outside .slick-next {
+    right: 15px; }
+  [dir="rtl"] .uagb-slick-carousel.uagb-tm__arrow-outside .slick-prev {
+    left: auto;
+    right: 15px; }
+  [dir="rtl"] .uagb-slick-carousel.uagb-tm__arrow-outside .slick-next {
+    left: 15px;
+    right: auto; } }
+
+@media (max-width: 768px) {
+  .uagb-tm-stacked-mobile.uagb-tm__image-position-bottom .uagb-tm__image-content,
+  .uagb-tm-stacked-mobile.uagb-tm__image-position-bottom .uagb-testimonial-details {
+    display: block;
+    vertical-align: middle; }
+  .uagb-tm-stacked-mobile.uagb-tm__image-position-left .uagb-tm__content, .uagb-tm-stacked-mobile.uagb-tm__image-position-right .uagb-tm__content {
+    display: block; }
+  .uagb-tm-stacked-mobile.uagb-tm__image-position-right.uagb-tm-reverse-order-mobile .uagb-tm__content {
+    display: inline-flex;
+    flex-direction: column-reverse; }
+  .uagb-tm-stacked-mobile.uagb-tm__image-aligned-top .uagb-tm__image-content {
+    display: inline-flex;
+    align-self: center; } }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.uagb-team__outer-wrap .uagb-team__prefix {
+  font-size: 15px;
+  font-style: italic;
+  color: #888; }
+
+.uagb-team__outer-wrap .uagb-team__image-wrap img {
+  display: inline;
+  height: auto !important;
+  max-width: 100%;
+  width: inherit;
+  box-sizing: content-box;
+  border-radius: inherit; }
+
+.uagb-team__outer-wrap .uagb-team__image-wrap.uagb-team__image-crop-circle img {
+  border-radius: 100%; }
+
+.uagb-team__outer-wrap .uagb-team__image-wrap.uagb-team__image-crop-square img {
+  border-radius: 0; }
+
+.uagb-team__outer-wrap .uagb-team__social-icon-wrap ul {
+  list-style: none;
+  display: flex; }
+
+.uagb-team__outer-wrap .uagb-team__social-icon a span,
+.uagb-team__outer-wrap .uagb-team__social-icon a span:before {
+  color: inherit;
+  font-size: inherit;
+  height: inherit;
+  width: inherit; }
+
+.uagb-team__outer-wrap .uagb-team__social-icon a {
+  font-size: 20px;
+  width: 20px;
+  height: 20px;
+  color: #333;
+  display: block; }
+
+.uagb-team__outer-wrap .uagb-team__social-icon {
+  margin-right: 20px;
+  margin-left: 0; }
+
+.uagb-team__outer-wrap .uagb-team__social-list {
+  margin: 0;
+  padding: 0; }
+
+.uagb-team__image-position-above.uagb-team__align-center {
+  text-align: center; }
+
+.uagb-team__image-position-above.uagb-team__align-left {
+  text-align: left; }
+
+.uagb-team__image-position-above.uagb-team__align-right {
+  text-align: right; }
+
+.uagb-team__image-position-left .uagb-team__wrap,
+.uagb-team__image-position-right .uagb-team__wrap {
+  -js-display: flex;
+  display: flex; }
+
+.uagb-team__image-position-left .uagb-team__content {
+  text-align: left; }
+
+.uagb-team__image-position-right .uagb-team__content {
+  text-align: right; }
+
+.uagb-team__image-position-left .uagb-team__social-icon-wrap ul {
+  justify-content: flex-start;
+  margin: 0;
+  padding: 0; }
+
+.uagb-team__image-position-right .uagb-team__social-icon-wrap ul {
+  justify-content: flex-end;
+  margin: 0;
+  padding: 0; }
+
+.uagb-team__image-position-left li {
+  margin-right: 5px; }
+
+.uagb-team__image-position-right li {
+  margin-left: 5px; }
+
+.uagb-team__image-position-above .uagb-team__social-icon-wrap {
+  display: inline-block; }
+
+.uagb-team__image-position-above.uagb-team__align-center .uagb-team__content {
+  text-align: center; }
+
+.uagb-team__image-position-above.uagb-team__align-left .uagb-team__content {
+  text-align: left; }
+
+.uagb-team__image-position-above.uagb-team__align-right .uagb-team__content {
+  text-align: right; }
+
+@media only screen and (max-width: 976px) {
+  .uagb-team__stack-tablet,
+  .uagb-team__stack-tablet .uagb-team__content {
+    text-align: center; }
+  .uagb-team__stack-tablet .uagb-team__wrap {
+    display: inline-block; }
+  .uagb-team__stack-tablet .uagb-team__image-wrap {
+    margin-left: auto !important;
+    margin-right: auto !important; }
+  .uagb-team__stack-tablet .uagb-team__social-icon-wrap ul {
+    justify-content: center; } }
+
+@media screen and (max-width: 767px) {
+  .uagb-team__stack-mobile,
+  .uagb-team__stack-mobile .uagb-team__content {
+    text-align: center; }
+  .uagb-team__stack-mobile .uagb-team__wrap {
+    display: inline-block; }
+  .uagb-team__stack-mobile .uagb-team__image-wrap {
+    margin-left: auto !important;
+    margin-right: auto !important; }
+  .uagb-team__stack-mobile .uagb-team__social-icon-wrap ul {
+    justify-content: center; } }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.uagb-social-share__outer-wrap .uagb-social-share__wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center; }
+
+.uagb-social-share__outer-wrap a.uagb-button__link:focus {
+  box-shadow: none; }
+
+.uagb-social-share__outer-wrap .uagb-ss__wrapper {
+  padding: 0;
+  margin-left: 5px;
+  margin-right: 5px;
+  transition: all 0.2s;
+  display: inline-flex;
+  text-align: center; }
+
+.uagb-social-share__outer-wrap .uagb-ss__source-wrap {
+  display: inline-block; }
+
+.uagb-social-share__outer-wrap .uagb-ss__link {
+  color: #3a3a3a;
+  display: inline-table;
+  line-height: 0;
+  cursor: pointer; }
+
+.uagb-social-share__outer-wrap .uagb-ss__source-icon {
+  font-size: 40px;
+  width: 40px;
+  height: 40px; }
+
+.uagb-social-share__outer-wrap .uagb-ss__source-image {
+  width: 40px; }
+
+.uagb-social-share__outer-wrap .uagb-ss__wrapper:first-child {
+  margin-left: 0; }
+
+.uagb-social-share__outer-wrap .uagb-ss__wrapper:last-child {
+  margin-right: 0; }
+
+.uagb-social-share__layout-vertical .uagb-social-share__wrap {
+  flex-direction: column; }
+
+@media (max-width: 976px) {
+  .uagb-social-share__layout-horizontal .uagb-ss__wrapper {
+    margin-left: 0;
+    margin-right: 0; } }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.wp-block-uagb-social-share .uagb-social-share__wrap .uagb-social-share__wrapper {
+  text-decoration: none; }
+
+.uagb-social-share__wrap .uagb-social-share__wrapper {
+  box-shadow: none; }
+
+.uagb-social-share__outer-wrap:not(.uagb-social-share__no-label) .uagb-social-share__source-wrap {
+  margin-right: 15px; }
+
+.uagb-social-share__outer-wrap.uagb-social-share__icon-at-top .uagb-social-share__source-wrap {
+  align-self: flex-start;
+  margin-top: 5px; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.uagb-google-map__wrap {
+  display: flex; }
+  .uagb-google-map__wrap .uagb-google-map__iframe {
+    width: 100%;
+    box-shadow: none;
+    border: none;
+    padding: 0;
+    margin: 0; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.uagb-icon-list__outer-wrap .uagb-icon-list__wrap {
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start; }
+
+.uagb-icon-list__outer-wrap.wp-block-uagb-icon-list .uagb-icon-list__wrap a.uagb-icon-list__wrapper,
+.uagb-icon-list__outer-wrap.wp-block-uagb-icon-list .uagb-icon-list__wrap a.uagb-icon-list__wrapper:focus,
+.uagb-icon-list__outer-wrap.wp-block-uagb-icon-list .uagb-icon-list__wrap a.uagb-icon-list__wrapper:active,
+.uagb-icon-list__outer-wrap.wp-block-uagb-icon-list .uagb-icon-list__wrap a.uagb-icon-list__wrapper:visited {
+  text-decoration: none; }
+
+.uagb-icon-list__outer-wrap a.uagb-button__link:focus {
+  box-shadow: none; }
+
+.uagb-icon-list__outer-wrap .uagb-icon-list__wrapper > p {
+  display: none; }
+
+.uagb-icon-list__outer-wrap .uagb-icon-list__wrapper {
+  padding: 0;
+  margin-left: 5px;
+  margin-right: 5px;
+  transition: all 0.2s;
+  display: inline-flex;
+  text-align: center; }
+
+.uagb-icon-list__outer-wrap .uagb-icon-list__content-wrap,
+.uagb-icon-list__outer-wrap .uagb-icon-list__source-wrap {
+  width: inherit;
+  display: inline-block; }
+
+.uagb-icon-list__outer-wrap .uagb-icon-list__source-wrap {
+  display: inherit;
+  align-items: center; }
+
+.uagb-icon-list__outer-wrap .uagb-icon-list__content-wrap {
+  color: #3a3a3a;
+  display: flex;
+  align-items: center; }
+
+.uagb-icon-list__outer-wrap .uagb-icon-list__source-icon,
+.uagb-icon-list__outer-wrap .uagb-icon-list__source-icon:before {
+  font-size: 40px;
+  width: 40px;
+  height: 40px; }
+
+.uagb-icon-list__outer-wrap .uagb-icon-list__source-icon svg {
+  display: block; }
+
+.uagb-icon-list__outer-wrap .uagb-icon-list__source-image {
+  width: 40px; }
+
+.uagb-icon-list__outer-wrap .uagb-icon-list__wrapper:first-child {
+  margin-left: 0; }
+
+.uagb-icon-list__outer-wrap .uagb-icon-list__wrapper:last-child {
+  margin-right: 0; }
+
+.uagb-icon-list__outer-wrap .uagb-icon-list__wrap > p {
+  display: none; }
+
+.uagb-icon-list__outer-wrap .uagb-icon-list__wrapper[href="/"] {
+  pointer-events: none;
+  cursor: text; }
+
+.uagb-icon-list__outer-wrap.wp-block-uagb-icon-list .uagb-icon-list__wrap .uagb-icon-list__wrapper {
+  text-decoration: none; }
+
+.uagb-icon-list__outer-wrap .uagb-icon-list__wrap .uagb-icon-list__wrapper {
+  box-shadow: none; }
+
+.uagb-icon-list__outer-wrap.uagb-icon-list__icon-at-top .uagb-icon-list__source-wrap {
+  align-self: flex-start; }
+
+.uagb-icon-list__outer-wrap:not(.uagb-icon-list__no-label) .uagb-icon-list__source-wrap {
+  margin-right: 15px; }
+
+.uagb-icon-list__no-label .uagb-icon-list__label-wrap {
+  display: none; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+.wp-block-uagb-icon-list-child {
+  position: relative; }
+  .wp-block-uagb-icon-list-child > a {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%; }
+
+img.uagb-icon-list__source-image {
+  max-width: unset; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.uagb-rest_menu__wrap {
+  position: relative;
+  padding-left: 5px;
+  padding-right: 5px;
+  box-sizing: border-box; }
+
+.uagb-rest_menu__wrap,
+.uagb-rest_menu__wrap * {
+  transition: all 0.2s; }
+
+.uagb-rm__image img,
+.slick-slide .uagb-rm__image img {
+  display: inline-block;
+  box-sizing: content-box; }
+
+.uagb-rm__title,
+.uagb-rm__price {
+  display: inline-block; }
+
+.uagb-rm__desc {
+  margin-bottom: 15px;
+  font-style: italic; }
+
+.uagb-rm__content {
+  overflow: hidden;
+  text-align: left;
+  word-break: break-word;
+  padding: 15px;
+  border-radius: inherit;
+  position: relative;
+  padding: 5px; }
+
+.uagb-rm__image-position-left .uagb-rm__content,
+.uagb-rm__image-position-right .uagb-rm__content {
+  -js-display: flex;
+  display: flex; }
+
+.uagb-rm-details {
+  display: table;
+  width: 100%; }
+
+.uagb-rm__title-wrap,
+.uagb-rm__price-wrap {
+  display: table-cell; }
+
+.uagb-rm__title-wrap,
+.uagb-rm__image-position-left.uagb-rm__align-center .uagb-rm__price-wrap,
+.uagb-rm__image-position-right.uagb-rm__align-center .uagb-rm__price-wrap {
+  width: 85%; }
+
+.uagb-rm__price-wrap,
+.uagb-rm__image-position-left.uagb-rm__align-center .uagb-rm__price-wrap,
+.uagb-rm__image-position-right.uagb-rm__align-center .uagb-rm__price-wrap {
+  width: 15%; }
+
+.uagb-rm__title, .uagb-rm__price {
+  display: block; }
+
+/*center aligned block without image*/
+.uagb-rm__align-center .uagb-rm-details,
+.uagb-rm__align-center .uagb-rm__title-wrap,
+.uagb-rm__align-center .uagb-rm__price-wrap {
+  display: block;
+  width: 100%; }
+
+/*end*/
+.uagb-rm__image-aligned-middle .uagb-rm__image-content {
+  align-self: center; }
+
+.uagb-rm__image {
+  overflow: hidden; }
+
+.uagb-rm__title {
+  margin-bottom: 5px;
+  font-size: 20px; }
+
+.uagb-rm__price {
+  font-style: italic;
+  text-align: right; }
+
+.uagb-rm__image-position-center.uagb-rm__align-center .uagb-rm-details,
+.uagb-rm__image-position-center.uagb-rm__align-center .uagb-rm__title-wrap,
+.uagb-rm__image-position-center.uagb-rm__align-center .uagb-rm__price-wrap {
+  display: block;
+  width: 100%;
+  text-align: center; }
+
+.uagb-rm__align-center .uagb-rm__price {
+  text-align: center; }
+
+.uagb-rm__align-right .uagb-rm-details {
+  display: flex;
+  width: 100%;
+  flex-direction: row-reverse; }
+
+.uagb-rm__align-right .uagb-rm__price {
+  text-align: left; }
+
+.uagb-rm__align-left .uagb-rm__price {
+  text-align: right; }
+
+/*CSS for image position left with all alignment*/
+.uagb-rm__image-position-left.uagb-rm__align-left .uagb-rm__price,
+.uagb-rm__image-position-left.uagb-rm__align-right .uagb-rm__price,
+.uagb-rm__image-position-left.uagb-rm__align-center .uagb-rm__price {
+  text-align: right; }
+
+.uagb-rm__image-position-left.uagb-rm__align-left .uagb-rm-details,
+.uagb-rm__image-position-left.uagb-rm__align-right .uagb-rm-details,
+.uagb-rm__image-position-left.uagb-rm__align-center .uagb-rm-details {
+  display: flex;
+  flex-direction: unset;
+  text-align: left; }
+
+.uagb-rm__image-position-left.uagb-rm__align-left .uagb-rm__title-wrap,
+.uagb-rm__image-position-left.uagb-rm__align-right .uagb-rm__title-wrap,
+.uagb-rm__image-position-left.uagb-rm__align-center .uagb-rm__title-wrap,
+.uagb-rm__image-position-left.uagb-rm__align-left .uagb-rm__image-content,
+.uagb-rm__image-position-left.uagb-rm__align-right .uagb-rm__image-content,
+.uagb-rm__image-position-left.uagb-rm__align-center .uagb-rm__image-content {
+  text-align: left; }
+
+/*CSS for image position right with all alignment*/
+.uagb-rm__image-position-right.uagb-rm__align-left .uagb-rm-details,
+.uagb-rm__image-position-right.uagb-rm__align-right .uagb-rm-details,
+.uagb-rm__image-position-right.uagb-rm__align-center .uagb-rm-details {
+  display: flex;
+  flex-direction: row-reverse;
+  text-align: right; }
+
+.uagb-rm__image-position-right.uagb-rm__align-left .uagb-rm__price,
+.uagb-rm__image-position-right.uagb-rm__align-right .uagb-rm__price,
+.uagb-rm__image-position-right.uagb-rm__align-center .uagb-rm__price {
+  text-align: left; }
+
+.uagb-rm__image-position-right.uagb-rm__align-left .uagb-rm__title-wrap,
+.uagb-rm__image-position-right.uagb-rm__align-right .uagb-rm__title-wrap,
+.uagb-rm__image-position-right.uagb-rm__align-center .uagb-rm__title-wrap,
+.uagb-rm__image-position-right.uagb-rm__align-left .uagb-rm__image-content,
+.uagb-rm__image-position-right.uagb-rm__align-right .uagb-rm__image-content,
+.uagb-rm__image-position-right.uagb-rm__align-center .uagb-rm__image-content {
+  text-align: right; }
+
+.uagb-rest_menu__outer-wrap {
+  position: relative; }
+
+.uagb-rm__overlay {
+  height: 100%;
+  width: 100%;
+  top: 0;
+  left: 0;
+  position: absolute;
+  background: transparent; }
+
+.uagb-tm-parent {
+  padding: 30px; }
+
+.uagb-rm__text-wrap {
+  position: relative;
+  display: block;
+  width: 100%; }
+
+.uagb-rest_menu__wrap {
+  position: relative; }
+
+.uagb-rest_menu__outer-wrap:after {
+  content: "";
+  display: block;
+  clear: both; }
+
+.uagb-rest_menu__wrap.uagb-rm__desk-column-3 {
+  display: block;
+  width: 33%;
+  float: left;
+  width: calc(100% / 3);
+  padding-left: 10px;
+  padding-right: 10px; }
+
+.uagb-rest_menu__wrap.uagb-rm__desk-column-2 {
+  display: block;
+  width: 49%;
+  float: left;
+  padding-left: 10px;
+  padding-right: 10px; }
+
+.uagb-rest_menu__wrap.uagb-rm__desk-column-1 {
+  display: block;
+  width: 100%;
+  float: left;
+  padding-left: 10px;
+  padding-right: 10px; }
+
+.uagb-rm__separator-parent {
+  line-height: 0em;
+  margin-left: 0;
+  margin-right: 0;
+  margin-bottom: 10px;
+  -js-display: flex;
+  display: -moz-flexbox;
+  display: flex; }
+
+.uagb-rm__separator {
+  width: 100%;
+  border-top-width: 1px;
+  border-top-color: #b2b4b5;
+  border-top-style: inherit; }
+
+.uagb-rm__image-position-left .uagb-rm__image {
+  margin-right: 10px; }
+
+.uagb-rm__image-position-right .uagb-rm__image {
+  margin-left: 10px; }
+
+@media (max-width: 976px) {
+  .uagb-rm__image-position-left.uagb-rm-stacked-tablet .uagb-rm__content,
+  .uagb-rm__image-position-right.uagb-rm-stacked-tablet .uagb-rm__content {
+    display: block;
+    -js-display: block;
+    display: block; }
+  .uagb-rm__image-position-right.uagb-rm-stacked-tablet.uagb-rm-reverse-order-tablet .uagb-rm__content {
+    -js-display: flex;
+    display: -moz-flexbox;
+    display: flex;
+    flex-direction: column-reverse; }
+  .uagb-rest_menu__wrap.uagb-rm__tablet-column-3 {
+    width: 33%;
+    float: left;
+    padding-left: 10px;
+    padding-right: 10px; }
+  .uagb-rest_menu__wrap.uagb-rm__tablet-column-2 {
+    width: 50%;
+    float: left;
+    padding-left: 10px;
+    padding-right: 10px; }
+  .uagb-rest_menu__wrap.uagb-rm__tablet-column-1 {
+    width: 100%;
+    float: left;
+    padding-left: 10px;
+    padding-right: 10px; }
+  .uagb-rm__image-position-right.uagb-rm-stacked-tablet.uagb-rm__image-aligned-middle .uagb-rm__image-content {
+    align-self: flex-end; }
+  .uagb-rm__image-position-left.uagb-rm-stacked-tablet.uagb-rm__image-aligned-middle .uagb-rm__image-content {
+    align-self: flex-start; } }
+
+@media (max-width: 767px) {
+  .uagb-rm__image-position-left.uagb-rm-stacked-mobile .uagb-rm__content,
+  .uagb-rm__image-position-right.uagb-rm-stacked-mobile .uagb-rm__content {
+    display: block;
+    -js-display: block;
+    display: block; }
+  .uagb-rm__image-position-right.uagb-rm-stacked-mobile.uagb-rm-reverse-order-mobile .uagb-rm__content {
+    -js-display: flex;
+    display: -moz-flexbox;
+    display: flex;
+    flex-direction: column-reverse; }
+  .uagb-rest_menu__wrap.uagb-rm__mobile-column-3 {
+    width: 33%;
+    float: left;
+    padding-left: 10px;
+    padding-right: 10px; }
+  .uagb-rest_menu__wrap.uagb-rm__mobile-column-2 {
+    width: 50%;
+    float: left;
+    padding-left: 10px;
+    padding-right: 10px; }
+  .uagb-rest_menu__wrap.uagb-rm__mobile-column-1 {
+    width: 100%;
+    float: left;
+    padding-left: 10px;
+    padding-right: 10px; }
+  .uagb-rm__image-position-right.uagb-rm-stacked-mobile.uagb-rm__image-aligned-middle .uagb-rm__image-content {
+    align-self: flex-end; }
+  .uagb-rm__image-position-left.uagb-rm-stacked-mobile.uagb-rm__image-aligned-middle .uagb-rm__image-content {
+    align-self: flex-start; } }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/** * #.# Styles * * CSS for both Frontend+Backend. */
+.uagb-timeline__widget {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  font-size: inherit;
+  color: inherit;
+  margin-bottom: inherit; }
+  .uagb-timeline__widget a {
+    text-decoration: none;
+    color: inherit;
+    font-size: inherit;
+    margin-bottom: inherit; }
+
+.uagb-timeline__image a {
+  display: block;
+  position: relative;
+  max-width: 100%; }
+
+.uagb-timeline__image img {
+  display: inline-block;
+  box-sizing: content-box; }
+
+.uagb-timeline__author {
+  text-transform: uppercase; }
+
+.uagb-timeline__main {
+  position: relative; }
+
+.uagb-content {
+  word-break: break-word; }
+
+a.uagb-timeline__link {
+  padding: 5px 10px;
+  display: inline-block; }
+
+.uagb-timeline__headingh1, .uagb-timeline__headingh2, .uagb-timeline__headingh3, .uagb-timeline__headingh4, .uagb-timeline__headingh5, .uagb-timeline__headingh6 {
+  margin-bottom: 0px; }
+
+.uagb-timeline__inner-date-new p,
+.uagb-timeline__date-inner .uagb-timeline__inner-date-new p {
+  margin-bottom: 0px; }
+
+.uagb-timeline__line {
+  background-color: #eeeeee; }
+
+.uagb-timeline__line__inner {
+  background-color: #5cb85c;
+  width: 100%; }
+
+.uagb-timeline__main .uagb-timeline__icon-new {
+  line-height: 1em;
+  display: inline-block;
+  vertical-align: middle;
+  font-style: normal; }
+
+.uagb-timeline__center-block .uagb-timeline__date-hide {
+  display: none; }
+
+.uagb-timeline__field:not(:last-child) {
+  margin-bottom: 20px; }
+
+.uagb-timeline__center-block .uagb-timeline__widget.uagb-timeline__right,
+.uagb-timeline__right-block .uagb-timeline__widget {
+  flex-direction: row-reverse; }
+
+.uagb-timeline__left-block .uagb-timeline__day-left .uagb-timeline__events-inner-new,
+.uagb-timeline__left-block .uagb-timeline__day-right .uagb-timeline__events-inner-new {
+  text-align: left; }
+
+.uagb-timeline__right-block
+.uagb-timeline__center-block .uagb-timeline__date-new {
+  display: block; }
+
+.uagb-timeline__right-block .uagb-timeline__day-left .uagb-timeline__events-inner-new,
+.uagb-timeline__right-block .uagb-timeline__day-right .uagb-timeline__events-inner-new {
+  text-align: inherit; }
+
+.uagb-timeline__right-block .uagb-timeline__line {
+  right: 16px;
+  left: auto; }
+
+.uagb-timeline__right-block .uagb-timeline__right .uagb-timeline__arrow:after,
+.uagb-timeline__right-block .uagb-timeline__left .uagb-timeline__arrow:after {
+  top: 0; }
+
+.uagb-timeline__right-block .uagb-timeline__right .uagb-timeline__arrow,
+.uagb-timeline__right-block .uagb-timeline__left .uagb-timeline__arrow {
+  top: 0;
+  right: 0;
+  width: 10px;
+  height: 40px;
+  position: absolute; }
+
+.uagb-timeline__right-block .uagb-timeline__right .uagb-timeline__arrow {
+  right: -12px; }
+
+.uagb-timeline__right-block .uagb-timeline__left .uagb-timeline__arrow {
+  right: -10px; }
+
+.uagb-timeline__right-block .uagb-timeline__marker,
+.uagb-timeline__right-block .uagb-timeline__day-new {
+  max-width: 100%;
+  position: relative; }
+
+.uagb-timeline__right-block .uagb-timeline__day-new {
+  margin-right: 14px; }
+
+.uagb-timeline__right-block .uagb-timeline__marker {
+  flex-shrink: 0;
+  flex-grow: 0; }
+
+.uagb-timeline__right-block .uagb-timeline__day-new {
+  flex-grow: 1; }
+
+.uagb-timeline__left-block .uagb-timeline__marker,
+.uagb-timeline__left-block .uagb-timeline__day-new {
+  max-width: 100%;
+  position: relative; }
+
+.uagb-timeline__left-block .uagb-timeline__line {
+  left: 20px;
+  right: auto; }
+
+.uagb-timeline__left-block .uagb-timeline__day-new {
+  margin-left: 14px;
+  flex-grow: 1;
+  order: 1; }
+
+.uagb-timeline__left-block .uagb-timeline__marker {
+  order: 0;
+  flex-shrink: 0;
+  flex-grow: 0; }
+
+.uagb-timeline__left-block .uagb-timeline__right .uagb-timeline__arrow:after,
+.uagb-timeline__left-block .uagb-timeline__left .uagb-timeline__arrow:after {
+  top: 0; }
+
+.uagb-timeline__left-block .uagb-timeline__right .uagb-timeline__arrow,
+.uagb-timeline__left-block .uagb-timeline__left .uagb-timeline__arrow {
+  top: 0;
+  width: 10px;
+  height: 40px;
+  position: absolute; }
+
+.uagb-timeline__left-block .uagb-timeline__right .uagb-timeline__arrow {
+  left: -10px; }
+
+.uagb-timeline__left-block .uagb-timeline__left .uagb-timeline__arrow {
+  left: -12px; }
+
+.uagb-timeline__left-block .uagb-timeline__right .uagb-timeline__arrow:after,
+.uagb-timeline__left-block .uagb-timeline__left .uagb-timeline__arrow:after,
+.uagb-timeline__right-block .uagb-timeline__right .uagb-timeline__arrow:after,
+.uagb-timeline__right-block .uagb-timeline__left .uagb-timeline__arrow:after {
+  top: 50%;
+  transform: translateY(-50%); }
+
+.uagb-timeline__marker {
+  background-color: #eeeeee;
+  border-radius: 999px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
+  transition: all .2s ease-in-out; }
+
+.uagb-timeline__main .uagb-timeline__days .uagb-timeline__field-wrap:hover .uagb-timeline__marker {
+  transition: all .2s ease-in-out; }
+
+.uagb-timeline__center-block .uagb-timeline__marker {
+  order: 1;
+  flex-shrink: 0;
+  flex-grow: 0; }
+
+.uagb-timeline__center-block .uagb-timeline__day-new,
+.uagb-timeline__center-block .uagb-timeline__date-new {
+  flex-grow: 1;
+  flex-basis: 50%;
+  max-width: 100%;
+  position: relative; }
+
+.uagb-timeline__center-block .uagb-timeline__right .uagb-timeline__day-new {
+  order: 2;
+  padding-left: 0;
+  padding-right: 12px; }
+
+.uagb-timeline__center-block .uagb-timeline__left .uagb-timeline__day-new {
+  order: 2;
+  padding-right: 0;
+  padding-left: 12px; }
+
+.uagb-timeline__events-inner-new {
+  padding: 40px; }
+
+.uagb-timeline__center-block .uagb-timeline__left .uagb-timeline__date-new {
+  display: flex;
+  justify-content: flex-end; }
+
+.uagb-timeline__center-block .uagb-timeline__right .uagb-timeline__date-new {
+  display: flex;
+  justify-content: flex-start; }
+
+.uagb-timeline__left-block .uagb-timeline__date-new {
+  margin-right: 10px; }
+
+.uagb-timeline__right-block .uagb-timeline__date-new {
+  margin-left: 10px; }
+
+.uagb-timeline__right-block .uagb-timeline__date-new {
+  display: flex;
+  align-items: center; }
+
+.uagb-timeline__center-block .uagb-timeline__right .uagb-timeline__arrow {
+  right: 0px;
+  top: 0;
+  width: 10px;
+  height: 40px;
+  position: absolute; }
+
+.uagb-timeline__center-block .uagb-timeline__right .uagb-timeline__arrow:after, .uagb-timeline__center-block .uagb-timeline__left .uagb-timeline__arrow:after {
+  top: 50%;
+  transform: translateY(-50%); }
+
+.uagb-timeline__center-block .uagb-timeline__left .uagb-timeline__arrow {
+  left: 0px;
+  top: 0;
+  width: 10px;
+  height: 40px;
+  position: absolute; }
+
+.uagb-timeline__arrow-center .uagb-timeline__widget {
+  align-items: center; }
+
+.uagb-timeline__arrow-bottom .uagb-timeline__widget {
+  align-items: flex-end; }
+
+.uagb-timeline__arrow-center .uagb-timeline__left .uagb-timeline__arrow, .uagb-timeline__arrow-center .uagb-timeline__right .uagb-timeline__arrow {
+  top: 50%;
+  transform: translateY(-50%); }
+
+.uagb-timeline__arrow-bottom .uagb-timeline__left .uagb-timeline__arrow, .uagb-timeline__arrow-bottom .uagb-timeline__right .uagb-timeline__arrow {
+  top: 100%;
+  transform: translateY(-100%); }
+
+.uagb-timeline__day-right .uagb-timeline__events-inner {
+  text-align: right; }
+
+.uagb-timeline__day-left .uagb-timeline__events-inner {
+  text-align: left; }
+
+.uagb-timeline__arrow-top .uagb-timeline__date-new .uagb-timeline__date-new, .uagb-timeline__arrow-bottom .uagb-timeline__date-new .uagb-timeline__date-new {
+  padding-top: 8px;
+  padding-bottom: 8px; }
+
+.uagb-timeline__events-inner-new, .uagb-timeline__arrow {
+  transition: background .2s ease-in-out; }
+
+.uagb-timeline__arrow:after {
+  transition: border-color .2s ease-in-out; }
+
+.uagb-timeline__date-new {
+  transition: color .2s ease-in-out; }
+
+.uagb-timeline__widget.uagb-timeline__left.hide-events .uagb-timeline__events-inner-new, .uagb-timeline__widget.uagb-timeline__left.hide-events .uagb-timeline__date-new {
+  visibility: hidden; }
+
+.uagb-timeline__widget.uagb-timeline__right.hide-events .uagb-timeline__events-inner-new, .uagb-timeline__widget.uagb-timeline__right.hide-events .uagb-timeline__date-new {
+  visibility: hidden; }
+
+.uagb-timeline__main .uagb-timeline__year {
+  display: flex;
+  position: relative; }
+
+.uagb-timeline__main .uagb-timeline__year span {
+  display: inline-block;
+  padding-bottom: 6px; }
+
+.uagb-timeline__day-left .uagb-timeline__arrow:after {
+  content: '';
+  left: 0px;
+  position: absolute;
+  display: inline;
+  width: 0;
+  height: 0;
+  border-top: 12px solid transparent;
+  border-bottom: 12px solid transparent; }
+
+.uagb-timeline__right .uagb-timeline__day-left .uagb-timeline__arrow:after {
+  right: 0; }
+
+.uagb-timeline__day-right .uagb-timeline__arrow:after {
+  content: '';
+  right: 0px;
+  position: absolute;
+  display: inline;
+  width: 0;
+  height: 0;
+  border-top: 12px solid transparent;
+  border-bottom: 12px solid transparent; }
+
+.uagb-timeline__icon {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  text-align: center;
+  line-height: 100px;
+  vertical-align: middle;
+  position: relative;
+  z-index: 1; }
+
+.uagb-timeline__main .uagb-timeline__date .uagb-timeline__inner-date-new {
+  white-space: nowrap;
+  margin: 0px; }
+
+.uagb-timeline__main .uagb-timeline__line {
+  position: absolute;
+  transform: translateX(-50%); }
+
+.uagb-timeline__right-block .uagb-timeline__main .uagb-timeline__line {
+  position: absolute;
+  transform: translateX(50%); }
+
+/* RESPONSIVE ALIGNMENT OF VERTICAL SEPARATOR. */
+.uagb-timeline__center-block .uagb-timeline__line {
+  left: 50%;
+  right: auto; }
+
+/* Icon transition animation */
+.uagb-timeline__main .in-view i.uagb-timeline__in-view-icon {
+  transition: background 0.25s ease-out 0.25s, width 0.25s ease-in-out, height 0.25s ease-in-out, color 0.25s ease-in-out, font-size 0.25s ease-out; }
+
+/* LEFT CSS STARTS */
+.uagb-timeline__left-block .uagb-timeline__days {
+  text-align: left; }
+
+.uagb-timeline__left-block .uagb-timeline__day-right .uagb-timeline__arrow:after {
+  content: '';
+  position: absolute;
+  display: inline;
+  width: 0;
+  height: 0;
+  border-top: 12px solid transparent;
+  border-bottom: 12px solid transparent; }
+
+/* CENTER CSS STARTS */
+.uagb-timeline__center-block .uagb-timeline__days {
+  text-align: center; }
+
+.uagb-timeline__center-block .uagb-timeline__day-right .uagb-timeline__arrow:after {
+  content: '';
+  right: 0px;
+  top: 50%;
+  transform: translateY(-50%);
+  position: absolute;
+  display: inline;
+  width: 0;
+  height: 0;
+  border-top: 12px solid transparent;
+  border-bottom: 12px solid transparent; }
+
+/* RIGHT CSS STARTS */
+.uagb-timeline__right .uagb-timeline__days {
+  text-align: right; }
+
+.uagb-timeline__outer-wrap span.dashicons-admin-users.dashicons {
+  display: inline;
+  vertical-align: baseline;
+  margin-right: 4px; }
+
+@media screen and (max-width: 1023px) {
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__line {
+    position: absolute;
+    transform: translateX(50%); }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__date-hide {
+    display: block; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-left .uagb-timeline__events-inner-new, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-right .uagb-timeline__events-inner-new {
+    text-align: left; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__line {
+    right: 20px;
+    left: auto; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__marker, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-new {
+    max-width: 100%;
+    position: relative; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__line {
+    left: 20px;
+    right: auto; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-new {
+    margin-left: 16px; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__marker {
+    order: 0;
+    flex-shrink: 0;
+    flex-grow: 0; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-new {
+    flex-grow: 1;
+    order: 1; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__right .uagb-timeline__arrow:after, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__left .uagb-timeline__arrow:after {
+    top: 0; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__right .uagb-timeline__arrow, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__left .uagb-timeline__arrow {
+    width: 10px;
+    height: 40px;
+    position: absolute; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__right .uagb-timeline__arrow {
+    left: -10px; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__left .uagb-timeline__arrow {
+    left: -12px; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__right .uagb-timeline__arrow:after, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__left .uagb-timeline__arrow:after {
+    top: 50%;
+    transform: translateY(-50%); }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__days {
+    text-align: left; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-right .uagb-timeline__arrow:after {
+    content: '';
+    position: absolute;
+    display: inline;
+    width: 0;
+    height: 0;
+    border-top: 12px solid transparent;
+    border-bottom: 12px solid transparent; }
+  /* Center align CSS start */
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__widget.uagb-timeline__right {
+    flex-direction: unset; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__date-new {
+    display: none; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-new, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__date-new {
+    flex-grow: unset;
+    flex-basis: unset;
+    max-width: 100%;
+    width: 100%;
+    position: relative; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__right .uagb-timeline__day-new {
+    order: unset;
+    padding-left: 0;
+    padding-right: 0; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__left .uagb-timeline__day-new {
+    order: unset;
+    padding-right: 0;
+    padding-left: 0; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__left .uagb-timeline__date-new {
+    display: none; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__right .uagb-timeline__date-new {
+    display: none; }
+  /* CSS for right alignment */
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__widget {
+    flex-direction: row-reverse; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__day-left .uagb-timeline__events-inner-new, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__day-right .uagb-timeline__events-inner-new {
+    text-align: right; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__line {
+    right: 16px;
+    left: auto; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__arrow:after, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__arrow:after {
+    top: 0; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__arrow, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__arrow {
+    left: auto;
+    right: 0;
+    width: 10px;
+    height: 40px;
+    position: absolute; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__arrow {
+    right: -12px; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__arrow {
+    right: -10px; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__marker, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__day-new {
+    max-width: 100%;
+    position: relative; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__day-new {
+    margin-right: 16px; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__marker {
+    flex-shrink: 0;
+    flex-grow: 0; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__day-new {
+    flex-grow: 1; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__arrow:after, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__arrow:after {
+    top: 50%;
+    transform: translateY(-50%); }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__days {
+    text-align: right; }
+  /* Center align CSS start */
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__day-new, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__date-new {
+    flex-grow: unset;
+    flex-basis: unset;
+    max-width: 100%;
+    position: relative; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__day-new {
+    order: unset;
+    padding-left: 0;
+    padding-right: 0; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__day-new {
+    order: unset;
+    padding-right: 0;
+    padding-left: 0; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__date-new {
+    display: none; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__date-new {
+    display: none; } }
+
+@media screen and (max-width: 767px) {
+  .uagb-timeline-responsive-none .uagb-timeline__events-inner-new {
+    padding: 15px; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__date-hide {
+    display: block; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__day-left .uagb-timeline__events-inner-new, .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__day-right .uagb-timeline__events-inner-new {
+    text-align: left; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__line {
+    right: 20px;
+    left: auto; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__marker, .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__day-new {
+    max-width: 100%;
+    position: relative; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__line {
+    left: 20px;
+    right: auto; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__day-new {
+    margin-left: 16px; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__marker {
+    order: 0;
+    flex-shrink: 0;
+    flex-grow: 0; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__day-new {
+    flex-grow: 1;
+    order: 1; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__right .uagb-timeline__arrow:after, .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__left .uagb-timeline__arrow:after {
+    top: 0; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__right .uagb-timeline__arrow, .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__left .uagb-timeline__arrow {
+    width: 10px;
+    height: 40px;
+    position: absolute; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__right .uagb-timeline__arrow {
+    left: -10px; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__left .uagb-timeline__arrow {
+    left: -12px; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__right .uagb-timeline__arrow:after, .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__left .uagb-timeline__arrow:after {
+    top: 50%;
+    transform: translateY(-50%); }
+  .uagb-timeline__day-left .uagb-timeline__events-inner-new {
+    text-align: left; }
+  .uagb-timeline__left-block .uagb-timeline__date-new {
+    margin-right: 10px; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__days {
+    text-align: left; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__day-right .uagb-timeline__arrow:after {
+    content: '';
+    position: absolute;
+    display: inline;
+    width: 0;
+    height: 0;
+    border-top: 12px solid transparent;
+    border-bottom: 12px solid transparent; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__widget.uagb-timeline__right {
+    flex-direction: unset; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__date-new {
+    display: none; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__day-new, .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__date-new {
+    flex-grow: unset;
+    flex-basis: unset;
+    max-width: 100%;
+    position: relative; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__right .uagb-timeline__day-new {
+    order: unset;
+    padding-left: 0;
+    padding-right: 0; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__left .uagb-timeline__day-new {
+    order: unset;
+    padding-right: 0;
+    padding-left: 0; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__left .uagb-timeline__date-new {
+    display: none; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__right .uagb-timeline__date-new {
+    display: none; }
+  /* CSS for right alignment */
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__widget {
+    flex-direction: row-reverse; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__day-left .uagb-timeline__events-inner-new, .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__day-right .uagb-timeline__events-inner-new {
+    text-align: right; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__line {
+    right: 16px;
+    left: auto; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__arrow:after, .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__arrow:after {
+    top: 0; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__arrow, .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__arrow {
+    left: auto;
+    right: 0;
+    width: 10px;
+    height: 40px;
+    position: absolute; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__arrow {
+    right: -12px; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__arrow {
+    right: -10px; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__marker, .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__day-new {
+    max-width: 100%;
+    position: relative; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__day-new {
+    margin-right: 16px; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__marker {
+    flex-shrink: 0;
+    flex-grow: 0; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__day-new {
+    flex-grow: 1; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__arrow:after, .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__arrow:after {
+    top: 50%;
+    transform: translateY(-50%); }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__line {
+    position: absolute;
+    transform: translateX(50%); }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__days {
+    text-align: right; }
+  /* Center align CSS start */
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__day-new, .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__date-new {
+    flex-grow: unset;
+    flex-basis: unset;
+    max-width: 100%;
+    position: relative; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__day-new {
+    order: unset;
+    padding-left: 0;
+    padding-right: 0; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__day-new {
+    order: unset;
+    padding-right: 0;
+    padding-left: 0; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__date-new {
+    display: none; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__date-new {
+    display: none; } }
+
+.uagb-timeline__line__inner {
+  background-color: #61ce70;
+  width: 100%; }
+
+.uagb-timeline__center-block .uagb-timeline__day-right .uagb-timeline__arrow:after {
+  border-left: 13px solid #eeeeee; }
+
+.uagb-timeline__right-block .uagb-timeline__day-right .uagb-timeline__arrow:after {
+  border-left: 13px solid #eeeeee; }
+
+.uagb-timeline__right-block .uagb-timeline__day-left .uagb-timeline__arrow:after {
+  border-left: 13px solid #eeeeee; }
+
+.rtl .uagb-timeline__center-block .uagb-timeline__day-right .uagb-timeline__arrow:after {
+  border-right: 13px solid #eeeeee;
+  border-left: none; }
+
+.rtl .uagb-timeline__right-block .uagb-timeline__day-right .uagb-timeline__arrow:after {
+  border-right: 13px solid #eeeeee;
+  border-left: none; }
+
+.rtl .uagb-timeline__right-block .uagb-timeline__day-left .uagb-timeline__arrow:after {
+  border-right: 13px solid #eeeeee;
+  border-left: none; }
+
+.uagb-timeline__left-block .uagb-timeline__day-right .uagb-timeline__arrow:after {
+  border-right: 13px solid #eeeeee; }
+
+.uagb-timeline__center-block .uagb-timeline__day-left .uagb-timeline__arrow:after {
+  border-right: 13px solid #eeeeee; }
+
+.uagb-timeline__left-block .uagb-timeline__day-left .uagb-timeline__arrow:after {
+  border-right: 13px solid #eeeeee; }
+
+.rtl .uagb-timeline__left-block .uagb-timeline__day-right .uagb-timeline__arrow:after {
+  border-left: 13px solid #eeeeee;
+  border-right: none; }
+
+.rtl .uagb-timeline__center-block .uagb-timeline__day-left .uagb-timeline__arrow:after {
+  border-left: 13px solid #eeeeee;
+  border-right: none; }
+
+.rtl .uagb-timeline__left-block .uagb-timeline__day-left .uagb-timeline__arrow:after {
+  border-left: 13px solid #eeeeee;
+  border-right: none; }
+
+.uagb-timeline__day-right .uagb-timeline__events-inner-new {
+  border-radius: 4px 4px 4px 4px; }
+
+.uagb-timeline__day-left .uagb-timeline__events-inner-new {
+  border-radius: 4px 4px 4px 4px; }
+
+.uagb-timeline__line {
+  width: 3px; }
+
+.uagb-timeline__main .uagb-timeline__icon-new {
+  font-size: 16px; }
+
+.uagb-timeline__marker {
+  min-height: 3em;
+  min-width: 3em;
+  line-height: 3em; }
+
+.uagb-timeline__arrow {
+  height: 3em; }
+
+.uagb-timeline__left-block .uagb-timeline__line {
+  left: calc(3em / 2); }
+
+.uagb-timeline__right-block .uagb-timeline__line {
+  right: calc(3em / 2); }
+
+.rtl .uagb-timeline__left-block .uagb-timeline__line {
+  right: calc(3em / 2);
+  left: auto; }
+
+.rtl .uagb-timeline__right-block .uagb-timeline__line {
+  left: calc(3em / 2);
+  right: auto; }
+
+.uagb-timeline-desc-content p {
+  font-size: inherit; }
+
+.uagb-timeline__main p:empty {
+  display: none; }
+
+@media (max-width: 976px) {
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__line {
+    position: absolute;
+    transform: translateX(50%); }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__line {
+    position: absolute;
+    transform: translateX(50%); }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__date-hide {
+    display: block; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-left .uagb-timeline__events-inner-new, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-right .uagb-timeline__events-inner-new {
+    text-align: left; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__line {
+    right: 20px;
+    left: auto; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__marker, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-new {
+    max-width: 100%;
+    position: relative; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__line {
+    left: 20px;
+    right: auto; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-new {
+    margin-left: 16px; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__marker {
+    order: 0;
+    flex-shrink: 0;
+    flex-grow: 0; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-new {
+    flex-grow: 1;
+    order: 1; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__right .uagb-timeline__arrow:after, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__left .uagb-timeline__arrow:after {
+    top: 0; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__right .uagb-timeline__arrow, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__left .uagb-timeline__arrow {
+    width: 10px;
+    height: 40px;
+    position: absolute; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__right .uagb-timeline__arrow {
+    left: -10px; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__left .uagb-timeline__arrow {
+    left: -12px; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__right .uagb-timeline__arrow:after, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__left .uagb-timeline__arrow:after {
+    top: 50%;
+    transform: translateY(-50%); }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__days {
+    text-align: left; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-right .uagb-timeline__arrow:after {
+    content: '';
+    position: absolute;
+    display: inline;
+    width: 0;
+    height: 0;
+    border-top: 12px solid transparent;
+    border-bottom: 12px solid transparent; }
+  /* Center align CSS start */
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__widget.uagb-timeline__right {
+    flex-direction: unset; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__date-new {
+    display: none; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-new, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__date-new {
+    flex-grow: unset;
+    flex-basis: unset;
+    max-width: 100%;
+    width: 100%;
+    position: relative; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__right .uagb-timeline__day-new {
+    order: unset;
+    padding-left: 0;
+    padding-right: 0; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__left .uagb-timeline__day-new {
+    order: unset;
+    padding-right: 0;
+    padding-left: 0; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__left .uagb-timeline__date-new {
+    display: none; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__right .uagb-timeline__date-new {
+    display: none; }
+  /* CSS for right alignment */
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__widget {
+    flex-direction: row-reverse; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__day-left .uagb-timeline__events-inner-new, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__day-right .uagb-timeline__events-inner-new {
+    text-align: right; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__line {
+    right: 16px;
+    left: auto; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__arrow:after, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__arrow:after {
+    top: 0; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__arrow, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__arrow {
+    left: auto;
+    right: 0;
+    width: 10px;
+    height: 40px;
+    position: absolute; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__arrow {
+    right: -12px; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__arrow {
+    right: -10px; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__marker, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__day-new {
+    max-width: 100%;
+    position: relative; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__day-new {
+    margin-right: 16px; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__marker {
+    flex-shrink: 0;
+    flex-grow: 0; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__day-new {
+    flex-grow: 1; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__arrow:after, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__arrow:after {
+    top: 50%;
+    transform: translateY(-50%); }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__days {
+    text-align: right; }
+  /* Center align CSS start */
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__day-new, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__date-new {
+    flex-grow: unset;
+    flex-basis: unset;
+    max-width: 100%;
+    position: relative; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__day-new {
+    order: unset;
+    padding-left: 0;
+    padding-right: 0; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__day-new {
+    order: unset;
+    padding-right: 0;
+    padding-left: 0; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__left .uagb-timeline__date-new, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline-res-right .uagb-timeline__right .uagb-timeline__date-new {
+    display: none; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-right .uagb-timeline__arrow:after, .uagb-timeline__center-block.uagb-timeline__responsive-tablet .uagb-timeline__day-left .uagb-timeline__arrow:after {
+    border-right: 13px solid #eeeeee;
+    border-left: none; }
+  .uagb-timeline__responsive-tablet.uagb-timeline__center-block .uagb-timeline__author,
+  .uagb-timeline__responsive-tablet.uagb-timeline__center-block .uagb-timeline__link_parent,
+  .uagb-timeline__responsive-tablet.uagb-timeline__center-block .uagb-timeline__image a,
+  .uagb-timeline__responsive-tablet.uagb-timeline__center-block .uagb-timeline__heading,
+  .uagb-timeline__responsive-tablet.uagb-timeline__center-block .uagb-timeline-desc-content,
+  .uagb-timeline__responsive-tablet.uagb-timeline__center-block .uagb-timeline__date-inner {
+    text-align: left; }
+  .uagb-timeline__responsive-tablet.uagb-timeline__center-block .uagb-timeline__date-hide.uagb-timeline__date-inner {
+    text-align: left; } }
+
+@media (max-width: 767px) {
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__day-right .uagb-timeline__arrow:after, .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__day-left .uagb-timeline__arrow:after, .rtl .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__day-right .uagb-timeline__arrow:after, .rtl .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__day-left .uagb-timeline__arrow:after {
+    border-right: 13px solid #eeeeee;
+    border-left: none; }
+  .rtl .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__day-right .uagb-timeline__arrow:after, .rtl .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__day-left .uagb-timeline__arrow:after, .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__day-right .uagb-timeline__arrow:after, .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__day-left .uagb-timeline__arrow:after {
+    border-left: 13px solid #eeeeee;
+    border-right: none; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__line, .rtl .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__line {
+    left: calc(3em / 2);
+    right: auto; }
+  .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline-res-right .uagb-timeline__line, .rtl .uagb-timeline__center-block.uagb-timeline__responsive-mobile .uagb-timeline__line {
+    right: calc(3em / 2);
+    left: auto; }
+  .uagb-timeline__responsive-mobile.uagb-timeline__center-block .uagb-timeline__author,
+  .uagb-timeline__responsive-mobile.uagb-timeline__center-block .uagb-timeline__link_parent,
+  .uagb-timeline__responsive-mobile.uagb-timeline__center-block .uagb-timeline__image a,
+  .uagb-timeline__responsive-mobile.uagb-timeline__center-block .uagb-timeline__heading,
+  .uagb-timeline__responsive-mobile.uagb-timeline__center-block .uagb-timeline-desc-content,
+  .uagb-timeline__responsive-mobile.uagb-timeline__center-block .uagb-timeline__date-inner {
+    text-align: left; }
+  .uagb-timeline__responsive-mobile.uagb-timeline__center-block .uagb-timeline__date-hide.uagb-timeline__date-inner {
+    text-align: left; } }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.uagb-cta__outer-wrap {
+  position: relative; }
+  .uagb-cta__outer-wrap .wp-block-button__link svg {
+    fill: currentColor; }
+  .uagb-cta__outer-wrap .uagb-cta__content {
+    display: inline-block; }
+  .uagb-cta__outer-wrap a.uagb-cta__block-link span {
+    font-size: inherit;
+    vertical-align: middle;
+    display: inline-block;
+    float: left; }
+  .uagb-cta__outer-wrap .uagb-cta__content-right .uagb-cta__link-wrapper {
+    width: 30%; }
+  .uagb-cta__outer-wrap .uagb-cta__content-right .uagb-cta__content {
+    width: 70%; }
+  .uagb-cta__outer-wrap .uagb-cta__content-right .uagb-cta__button-wrapper {
+    display: inline-block;
+    float: right; }
+  .uagb-cta__outer-wrap .uagb-cta__link-wrapper.uagb-cta__block-link-style:empty {
+    display: none; }
+  .uagb-cta__outer-wrap a.uagb-cta__block-link,
+  .uagb-cta__outer-wrap .entry .entry-content a.uagb-cta__block-link,
+  .uagb-cta__outer-wrap a.uagb-cta__block-link-wrap,
+  .uagb-cta__outer-wrap .entry .entry-content a.uagb-cta__block-link-wrap {
+    text-decoration: none; }
+  .uagb-cta__outer-wrap a.uagb-cta__block-link:hover,
+  .uagb-cta__outer-wrap .entry .entry-content a.uagb-cta__block-link:hover,
+  .uagb-cta__outer-wrap a.uagb-cta__block-link-wrap:hover,
+  .uagb-cta__outer-wrap .entry .entry-content a.uagb-cta__block-link-wrap:hover
+.entry .entry-content a.uagb-cta__block-link:hover {
+    color: inherit; }
+  .uagb-cta__outer-wrap .uagb-cta__content-right {
+    text-align: right;
+    justify-content: flex-end; }
+  .uagb-cta__outer-wrap .uagb-cta__left-right-wrap {
+    width: 100%;
+    word-break: break-word; }
+  .uagb-cta__outer-wrap .uagb-cta__icon-position-below-title .uagb-cta__left-right-wrap {
+    display: block;
+    min-width: 100%;
+    width: 100%; }
+  .uagb-cta__outer-wrap .uagb-cta__icon-position-left .uagb-cta__left-right-wrap,
+  .uagb-cta__outer-wrap .uagb-cta__icon-position-right .uagb-cta__left-right-wrap {
+    display: flex; }
+  .uagb-cta__outer-wrap .uagb-cta__icon-position-right .uagb-cta__left-right-wrap {
+    justify-content: flex-end; }
+  .uagb-cta__outer-wrap .uagb-cta__block-link-icon-after {
+    margin-left: 5px;
+    margin-right: 0; }
+  .uagb-cta__outer-wrap .uagb-cta__block-link-icon-before {
+    margin-left: 0;
+    margin-right: 5px; }
+  .uagb-cta__outer-wrap .uagb-cta__block-link-icon,
+  .uagb-cta__outer-wrap .uagb-cta__block svg {
+    transition: all 200ms linear; }
+  .uagb-cta__outer-wrap .uagb-cta__block {
+    position: relative; }
+  .uagb-cta__outer-wrap .uagb-cta-typeof-button {
+    display: inline-block;
+    line-height: 1;
+    background-color: transparent;
+    color: #333;
+    text-align: center; }
+  .uagb-cta__outer-wrap .uagb-cta__content-right .uagb-cta__button-link-wrapper,
+  .uagb-cta__outer-wrap .uagb-cta__content-right .uagb-cta__block-link,
+  .uagb-cta__outer-wrap .uagb-cta__content-right.uagb-cta__button-valign-middle .uagb-cta__left-right-wrap {
+    display: flex;
+    align-items: center; }
+  .uagb-cta__outer-wrap .uagb-cta__content-right .uagb-cta__button-link-wrapper,
+  .uagb-cta__outer-wrap .uagb-cta__content-right .uagb-cta__block-link {
+    justify-content: center; }
+  .uagb-cta__outer-wrap .uagb-cta__link-wrapper a {
+    box-shadow: none;
+    text-decoration: none; }
+  .uagb-cta__outer-wrap .uagb-cta__title {
+    padding: 0;
+    margin: 0;
+    display: block; }
+  .uagb-cta__outer-wrap .uagb-cta__block,
+  .uagb-cta__outer-wrap .uagb-cta__content {
+    z-index: 1; }
+  .uagb-cta__outer-wrap .uagb-cta__left-right-wrap {
+    z-index: 1; }
+  .uagb-cta__outer-wrap .uagb-cta__block-link {
+    cursor: pointer; }
+  .uagb-cta__outer-wrap .uagb-cta__content-right .uagb-cta__block-link {
+    display: inline-block;
+    float: right;
+    padding: 10px 14px; }
+  .uagb-cta__outer-wrap a.uagb-cta__block-link-wrap {
+    color: inherit; }
+  .uagb-cta__outer-wrap .uagb-cta__content p:empty {
+    display: none; }
+  .uagb-cta__outer-wrap .uagb-cta__button-type-none .uagb-cta__content {
+    width: 100%; }
+  .uagb-cta__outer-wrap .uagb-cta-with-svg {
+    height: 14px;
+    width: 14px;
+    line-height: 14px;
+    display: inline-block;
+    vertical-align: middle; }
+  .uagb-cta__outer-wrap .uagb-cta__block svg {
+    display: block;
+    height: inherit;
+    width: inherit; }
+  .uagb-cta__outer-wrap .uagb-cta__align-button-after {
+    margin-left: 5px; }
+  .uagb-cta__outer-wrap .uagb-cta__align-button-before {
+    margin-right: 5px; }
+  .uagb-cta__outer-wrap .uagb-cta__block-link i {
+    font-style: normal; }
+  .uagb-cta__outer-wrap a.uagb-cta__link-to-all {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 11; }
+
+@media only screen and (max-width: 976px) {
+  .uagb-cta__content-stacked-tablet .uagb-cta__left-right-wrap {
+    flex-direction: column;
+    text-align: center; }
+  .uagb-cta__content-stacked-tablet.uagb-cta__content-right .uagb-cta__button-wrapper {
+    display: inline-block;
+    float: none;
+    margin: 0 auto; }
+  .uagb-cta__content-stacked-tablet .uagb-cta__left-right-wrap .uagb-cta__content {
+    margin-left: 0;
+    margin-right: 0; }
+  .uagb-cta__content-stacked-tablet.uagb-cta__content-right .uagb-cta__left-right-wrap .uagb-cta__content,
+  .uagb-cta__content-stacked-tablet.uagb-cta__content-right .uagb-cta__left-right-wrap .uagb-cta__link-wrapper {
+    width: 100% !important; } }
+
+@media screen and (max-width: 767px) {
+  .uagb-cta__content-stacked-mobile .uagb-cta__left-right-wrap {
+    flex-direction: column;
+    text-align: center; }
+  .uagb-cta__content-stacked-mobile.uagb-cta__content-right .uagb-cta__button-wrapper {
+    display: inline-block;
+    float: none;
+    margin: 0 auto; }
+  .uagb-cta__content-stacked-mobile .uagb-cta__left-right-wrap .uagb-cta__content {
+    margin-left: 0;
+    margin-right: 0; }
+  .uagb-cta__content-stacked-mobile.uagb-cta__content-right .uagb-cta__left-right-wrap .uagb-cta__content,
+  .uagb-cta__content-stacked-mobile.uagb-cta__content-right .uagb-cta__left-right-wrap .uagb-cta__link-wrapper {
+    width: 100% !important; } }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.uagb-column__wrap {
+  position: relative;
+  overflow: hidden; }
+  .uagb-column__wrap .uagb-column__inner-wrap {
+    margin-left: auto;
+    margin-right: auto;
+    position: relative;
+    z-index: 2;
+    width: 100%; }
+  .uagb-column__wrap.uagb-column__align-left .uagb-column__inner-wrap {
+    margin-left: 0;
+    margin-right: auto; }
+  .uagb-column__wrap.uagb-column__align-right .uagb-column__inner-wrap {
+    margin-left: auto;
+    margin-right: 0; }
+  .uagb-column__wrap .uagb-column__overlay {
+    height: 100%;
+    width: 100%;
+    top: 0;
+    left: 0;
+    position: absolute; }
+  .uagb-column__wrap .uagb-column__video-wrap {
+    height: 100%;
+    width: 100%;
+    top: 0;
+    left: 0;
+    position: absolute;
+    overflow: hidden;
+    z-index: 0;
+    transition: opacity 1s; }
+  .uagb-column__wrap .uagb-column__video-wrap video {
+    max-width: 100%;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    line-height: 1;
+    border: none;
+    display: inline-block;
+    vertical-align: baseline;
+    -o-object-fit: cover;
+    object-fit: cover;
+    background-size: cover; }
+
+.wp-block-uagb-columns > .editor-inner-blocks > .editor-block-list__layout > [data-type="uagb/column"] {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding-left: 0;
+  padding-right: 0;
+  margin-left: -14px;
+  margin-right: -14px;
+  min-width: 0;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  flex-basis: 100%; }
+
+@media (max-width: 976px) {
+  .uagb-column__align-tablet-left .uagb-column__inner-wrap {
+    margin-left: 0;
+    margin-right: auto; }
+  .uagb-column__align-tablet-right .uagb-column__inner-wrap {
+    margin-left: auto;
+    margin-right: 0; } }
+
+@media (max-width: 767px) {
+  .uagb-column__align-mobile-left .uagb-column__inner-wrap {
+    margin-left: 0;
+    margin-right: auto; }
+  .uagb-column__align-mobile-right .uagb-column__inner-wrap {
+    margin-left: auto;
+    margin-right: 0; } }
+
+@media (max-width: 449px) {
+  .uagb-columns__wrap.uagb-columns__background-image {
+    background-attachment: scroll !important; } }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.uagb-columns__wrap {
+  position: relative; }
+  .uagb-columns__wrap .uagb-columns__inner-wrap {
+    margin-left: auto;
+    margin-right: auto;
+    position: relative;
+    z-index: 2; }
+  .uagb-columns__wrap .uagb-columns__overlay {
+    height: 100%;
+    width: 100%;
+    top: 0;
+    left: 0;
+    position: absolute; }
+  .uagb-columns__wrap .uagb-columns__video-wrap {
+    height: 100%;
+    width: 100%;
+    top: 0;
+    left: 0;
+    position: absolute;
+    overflow: hidden;
+    z-index: 0;
+    transition: opacity 1s; }
+  .uagb-columns__wrap .uagb-columns__video-wrap video {
+    max-width: 100%;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    line-height: 1;
+    border: none;
+    display: inline-block;
+    vertical-align: baseline;
+    -o-object-fit: cover;
+    object-fit: cover;
+    background-size: cover; }
+  .uagb-columns__wrap .uagb-column__wrap {
+    display: flex; }
+  .uagb-columns__wrap .uagb-columns__shape {
+    overflow: hidden;
+    position: absolute;
+    left: 0;
+    width: 100%;
+    line-height: 0;
+    direction: ltr;
+    z-index: 1; }
+  .uagb-columns__wrap .uagb-columns__shape-top {
+    top: -3px; }
+  .uagb-columns__wrap .uagb-columns__shape-bottom {
+    bottom: -3px; }
+  .uagb-columns__wrap .uagb-columns__shape[data-negative="false"].uagb-columns__shape-bottom {
+    transform: rotate(180deg); }
+  .uagb-columns__wrap .uagb-columns__shape[data-negative="true"].uagb-columns__shape-top {
+    transform: rotate(180deg); }
+  .uagb-columns__wrap .uagb-columns__shape.uagb-columns__shape-flip svg {
+    transform: translateX(-50%) rotateY(180deg); }
+  .uagb-columns__wrap .uagb-columns__shape svg {
+    display: block;
+    width: calc(100% + 1.3px);
+    position: relative;
+    left: 50%;
+    transform: translateX(-50%); }
+  .uagb-columns__wrap .uagb-columns__shape .uagb-columns__shape-fill {
+    fill: #333;
+    transform-origin: center;
+    transform: rotateY(0deg); }
+  .uagb-columns__wrap .uagb-columns__shape.uagb-columns__shape-above-content {
+    z-index: 9;
+    pointer-events: none; }
+
+.uagb-columns__valign-center .uagb-column__wrap,
+.uagb-columns__valign-middle .uagb-column__wrap {
+  align-items: center; }
+
+.uagb-columns__valign-top .uagb-column__wrap {
+  align-items: flex-start; }
+
+.uagb-columns__valign-bottom .uagb-column__wrap {
+  align-items: flex-end; }
+
+.uagb-columns__inner-wrap {
+  display: flex;
+  flex-wrap: nowrap; }
+
+.uagb-columns__columns-1 > .uagb-column__wrap {
+  width: 100%; }
+
+.uagb-columns__columns-2 > .uagb-column__wrap {
+  width: 50%; }
+
+.uagb-columns__columns-3 > .uagb-column__wrap {
+  width: 33.33%; }
+
+.uagb-columns__columns-4 > .uagb-column__wrap {
+  width: 25%; }
+
+.uagb-columns__columns-5 > .uagb-column__wrap {
+  width: 20%; }
+
+.uagb-columns__columns-6 > .uagb-column__wrap {
+  width: 16.66%; }
+
+.uagb-columns__gap-nogap > .wp-block[data-type="uagb/column"] .uagb-column__inner-wrap {
+  padding: 0; }
+
+.uagb-columns__gap-default > .wp-block[data-type="uagb/column"] .uagb-column__inner-wrap {
+  padding: 10px; }
+
+.uagb-columns__gap-narrow > .wp-block[data-type="uagb/column"] .uagb-column__inner-wrap {
+  padding: 5px; }
+
+.uagb-columns__gap-extended > .wp-block[data-type="uagb/column"] .uagb-column__inner-wrap {
+  padding: 15px; }
+
+.uagb-columns__gap-wide > .wp-block[data-type="uagb/column"] .uagb-column__inner-wrap {
+  padding: 20px; }
+
+.uagb-columns__gap-wider > .wp-block[data-type="uagb/column"] .uagb-column__inner-wrap {
+  padding: 30px; }
+
+@media (max-width: 976px) {
+  .uagb-columns__stack-tablet > .uagb-columns__columns-1 > .uagb-column__wrap,
+  .uagb-columns__stack-tablet > .uagb-columns__columns-2 > .uagb-column__wrap,
+  .uagb-columns__stack-tablet > .uagb-columns__columns-3 > .uagb-column__wrap,
+  .uagb-columns__stack-tablet > .uagb-columns__columns-4 > .uagb-column__wrap,
+  .uagb-columns__stack-tablet > .uagb-columns__columns-5 > .uagb-column__wrap,
+  .uagb-columns__stack-tablet > .uagb-columns__columns-6 > .uagb-column__wrap {
+    width: 100% !important; }
+  .uagb-columns__stack-tablet > .uagb-columns__inner-wrap {
+    display: block; }
+  .uagb-columns__reverse-tablet .uagb-columns__inner-wrap {
+    display: flex;
+    flex-direction: column-reverse; } }
+
+@media (max-width: 767px) {
+  .uagb-columns__stack-mobile > .uagb-columns__columns-1 > .uagb-column__wrap,
+  .uagb-columns__stack-mobile > .uagb-columns__columns-2 > .uagb-column__wrap,
+  .uagb-columns__stack-mobile > .uagb-columns__columns-3 > .uagb-column__wrap,
+  .uagb-columns__stack-mobile > .uagb-columns__columns-4 > .uagb-column__wrap,
+  .uagb-columns__stack-mobile > .uagb-columns__columns-5 > .uagb-column__wrap,
+  .uagb-columns__stack-mobile > .uagb-columns__columns-6 > .uagb-column__wrap {
+    width: 100% !important; }
+  .uagb-columns__stack-mobile > .uagb-columns__inner-wrap {
+    display: block; }
+  .uagb-columns__reverse-mobile .uagb-columns__inner-wrap {
+    display: flex;
+    flex-direction: column-reverse; } }
+
+@media (min-width: 768px) and (max-width: 1024px) {
+  .wp-block-uagb-columns.uagb-columns__wrap.uagb-columns__background-image {
+    background-attachment: scroll; } }
+
+@media (max-width: 449px) {
+  .uagb-columns__wrap .uagb-column__wrap.uagb-column__background-image {
+    background-attachment: scroll !important; } }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.wp-block-uagb-cf7-styler {
+  /* Submit button */
+  /* Form validation */ }
+  .wp-block-uagb-cf7-styler .wpcf7 *, .wp-block-uagb-cf7-styler .wpcf7 :after, .wp-block-uagb-cf7-styler .wpcf7 :before {
+    box-sizing: border-box; }
+  .wp-block-uagb-cf7-styler span.wpcf7-list-item-label::before,
+  .wp-block-uagb-cf7-styler span.wpcf7-list-item-label::after {
+    content: " "; }
+  .wp-block-uagb-cf7-styler .wpcf7-acceptance input[type=checkbox] + span:before,
+  .wp-block-uagb-cf7-styler .wpcf7-checkbox input[type=checkbox] + span:before,
+  .wp-block-uagb-cf7-styler .wpcf7-radio input[type=radio] + span:before {
+    content: '';
+    display: inline-block;
+    vertical-align: middle;
+    margin-right: 10px;
+    text-align: center;
+    height: 15px;
+    width: 15px;
+    border-style: solid;
+    border-color: #eaeaea;
+    border-width: 1px 1px 1px 1px; }
+  .wp-block-uagb-cf7-styler span.wpcf7-list-item {
+    display: inline-block;
+    margin: 0 1em 0 0; }
+  .wp-block-uagb-cf7-styler .wpcf7-acceptance input[type=checkbox]:checked + span:before,
+  .wp-block-uagb-cf7-styler .wpcf7-checkbox input[type=checkbox]:checked + span:before {
+    content: "\2714";
+    line-height: 1.2; }
+  .wp-block-uagb-cf7-styler .wpcf7-acceptance input[type=checkbox] + span:before,
+  .wp-block-uagb-cf7-styler .wpcf7-acceptance input[type=checkbox]:checked + span:before,
+  .wp-block-uagb-cf7-styler .wpcf7-checkbox input[type=checkbox] + span:before,
+  .wp-block-uagb-cf7-styler .wpcf7-checkbox input[type=checkbox]:checked + span:before,
+  .wp-block-uagb-cf7-styler .wpcf7-radio input[type=radio] + span:before {
+    box-sizing: content-box; }
+  .wp-block-uagb-cf7-styler input[type=checkbox]:checked + span:before {
+    font-size: calc(12px / 1.2); }
+  .wp-block-uagb-cf7-styler .wpcf7-radio input[type=radio] + span:before {
+    border-radius: 100%; }
+  .wp-block-uagb-cf7-styler .uagb-cf7-styler__field-style-box .wpcf7-radio input[type="radio"]:checked + span:before,
+  .wp-block-uagb-cf7-styler .uagb-cf7-styler__field-style-underline .wpcf7-radio input[type="radio"]:checked + span:before {
+    background-color: #545454;
+    box-shadow: inset 0px 0px 0px 4px #fafafa; }
+  .wp-block-uagb-cf7-styler .uagb-cf7-styler__btn-align-justify input.wpcf7-form-control.wpcf7-submit,
+  .wp-block-uagb-cf7-styler .uagb-cf7-styler__btn-align-left input.wpcf7-form-control.wpcf7-submit,
+  .wp-block-uagb-cf7-styler .uagb-cf7-styler__btn-align-right input.wpcf7-form-control.wpcf7-submit,
+  .wp-block-uagb-cf7-styler .uagb-cf7-styler__btn-align-center input.wpcf7-form-control.wpcf7-submit {
+    -js-display: flex;
+    display: flex;
+    width: auto;
+    line-height: 1em;
+    background: transparent;
+    border-color: #333;
+    border-width: 1px;
+    padding: 10px 25px; }
+  .wp-block-uagb-cf7-styler .uagb-cf7-styler__btn-align-right input.wpcf7-form-control.wpcf7-submit {
+    margin-left: auto;
+    margin-right: 0; }
+  .wp-block-uagb-cf7-styler .uagb-cf7-styler__btn-align-left input.wpcf7-form-control.wpcf7-submit {
+    margin-right: auto;
+    margin-left: 0; }
+  .wp-block-uagb-cf7-styler .uagb-cf7-styler__btn-align-center input.wpcf7-form-control.wpcf7-submit {
+    margin-right: auto;
+    margin-left: auto; }
+  .wp-block-uagb-cf7-styler .uagb-cf7-styler__btn-align-justify input.wpcf7-form-control.wpcf7-submit {
+    justify-content: center;
+    width: 100%; }
+  .wp-block-uagb-cf7-styler .wpcf7 input[type=checkbox],
+  .wp-block-uagb-cf7-styler .wpcf7 input[type=radio] {
+    display: none; }
+  .wp-block-uagb-cf7-styler .wpcf7 select {
+    height: auto;
+    padding: 10px;
+    -webkit-appearance: menulist-button;
+    -moz-appearance: menulist-button;
+    -webkit-appearance: menulist-button; }
+  .wp-block-uagb-cf7-styler select.wpcf7-form-control.wpcf7-select[multiple="multiple"] {
+    padding: 0; }
+  .wp-block-uagb-cf7-styler .wpcf7 select option {
+    padding: 10px; }
+  .wp-block-uagb-cf7-styler .uagb-cf7-styler__highlight-style-bottom_right span.wpcf7-not-valid-tip {
+    display: inline-block;
+    right: 0;
+    top: 100%;
+    padding: .1em .8em;
+    border-radius: 2px;
+    color: #ffffff;
+    background-color: rgba(255, 0, 0, 0.6);
+    padding: 5px 10px;
+    font-size: 15px;
+    float: right;
+    margin-top: 5px; }
+  .wp-block-uagb-cf7-styler .wpcf7 input[type="number"] {
+    height: auto; }
+  .wp-block-uagb-cf7-styler .wpcf7 input.wpcf7-date {
+    -webkit-appearance: none; }
+
+@media (min-width: 769px) {
+  .wp-block-uagb-cf7-styler .uagb-cf7_styler-col {
+    -js-display: flex;
+    display: flex; }
+  .wp-block-uagb-cf7-styler .uagb-cf7_styler-col label, .wp-block-uagb-cf7-styler .uagb-cf7_styler-col > span {
+    flex-grow: 1;
+    flex-basis: 100%; }
+  .wp-block-uagb-cf7-styler .uagb-cf7_styler-col br {
+    display: none; }
+  .wp-block-uagb-cf7-styler .uagb-cf7_styler-col > span.uagb-cf7_styler-col-1 {
+    padding-left: 0;
+    padding-right: 15px; }
+  .wp-block-uagb-cf7-styler .uagb-cf7_styler-col > span.uagb-cf7_styler-col-3 {
+    padding-left: 15px;
+    padding-right: 0; }
+  .wp-block-uagb-cf7-styler .wpcf7 .uagb-cf7_styler-col span.wpcf7-form-control-wrap {
+    height: 100%; }
+  .wp-block-uagb-cf7-styler .wpcf7 .uagb-cf7_styler-col select {
+    height: 100%; } }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+/* Gravity Form - Buttons */
+.uagb-gf-styler__check-style-enabled .gform_wrapper .chosen-container-multi .chosen-choices,
+.uagb-gf-styler__check-style-enabled .gform_wrapper .chosen-container-single .chosen-single {
+  position: relative;
+  display: block;
+  overflow: hidden;
+  padding: 0;
+  height: auto;
+  border: 1px solid #AAA;
+  border-radius: 0;
+  background: #FFF;
+  box-shadow: none;
+  color: #444;
+  text-decoration: none;
+  white-space: nowrap; }
+
+.uagb-gf-styler__gform-heading-none .gform_wrapper .gform_heading, .uagb-gf-styler__gform-heading-no .gform_wrapper .gform_heading,
+.uagb-gf-styler__gform-heading-yes .gform_wrapper .gform_heading.custom_gform_heading {
+  display: none; }
+
+.uagb-gf-styler__gform-heading-no .gform_wrapper .gform_heading.custom_gform_heading, .uagb-gf-styler__gform-heading-yes .gform_wrapper .gform_heading {
+  display: block; }
+
+.uagb-gf-styler__check-style-enabled .gform_wrapper .chosen-container-single .chosen-single span {
+  line-height: 1; }
+
+.uagb-gf-styler__check-style-enabled .gform_wrapper .chosen-container-active.chosen-with-drop .chosen-single {
+  background: #FFF; }
+
+.uagb-gf-styler__check-style-enabled .gform_page .gform_page_footer input[type=button],
+.uagb-gf-styler__check-style-enabled .gform_page .gform_page_footer input[type=submit] {
+  display: inline-block; }
+
+.uagb-gf-styler__check-style-enabled .gform_wrapper .gf_progressbar_wrapper h3.gf_progressbar_title,
+.uagb-gf-styler__check-style-enabled .gform_wrapper .gf_progressbar_wrapper .gf_progressbar_title {
+  opacity: 1; }
+
+.uagb-gf-styler__check-style-enabled .uag-gf-select-custom {
+  position: relative; }
+
+.uagb-gf-styler__check-style-enabled .uag-gf-select-custom:after {
+  content: "\f078";
+  font-family: 'FontAwesome' !important;
+  font-size: 0.7em;
+  line-height: 1;
+  position: absolute;
+  top: 45%;
+  transform: translateY(-45%);
+  right: 0.5em;
+  pointer-events: none;
+  z-index: 5; }
+
+.uagb-gf-styler__check-style-enabled span.name_prefix_select .uag-gf-select-custom {
+  display: inline;
+  vertical-align: middle; }
+
+.uagb-gf-styler__check-style-enabled .gfield_radio input[type="radio"]:checked + label:before {
+  box-shadow: inset 0px 0px 0px 4px #fafafa; }
+
+.uagb-gf-styler__check-style-enabled .gfield_checkbox input[type="checkbox"] + label:before,
+.uagb-gf-styler__check-style-enabled .gfield_radio input[type="radio"] + label:before,
+.uagb-gf-styler__check-style-enabled .ginput_container_consent input[type="checkbox"] + label:before {
+  box-sizing: content-box; }
+
+.uagb-gf-styler__check-style-enabled .ginput_container_consent input[type="checkbox"]:checked + label:before {
+  font-weight: 700; }
+
+.uagb-gf-styler__check-style-enabled select,
+.uagb-gf-styler__check-style-enabled .chosen-single {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none; }
+
+.uagb-gf-styler__check-style-enabled .gform_wrapper div.validation_error {
+  border-top: none;
+  border-bottom: none; }
+
+.uagb-gf-styler__check-style-enabled .gform_wrapper .gfield_radio li label {
+  margin: 0 0 0 0; }
+
+.uagb-gf-styler__check-style-enabled .gform_wrapper .gform_body {
+  width: 100% !important; }
+
+.uagb-gf-styler__check-style-enabled .gform_wrapper input[type="checkbox"]:checked + label:before,
+.uagb-gf-styler__check-style-enabled .gform_wrapper input[type="radio"]:checked + label:before,
+.uagb-gf-styler__check-style-enabled .gform_wrapper input[type="checkbox"] + label:before,
+.uagb-gf-styler__check-style-enabled .gform_wrapper input[type="radio"] + label:before {
+  box-sizing: content-box !important; }
+
+.uagb-gf-styler__check-style-enabled .gform_wrapper .gsection {
+  margin-right: 0; }
+
+/* Input fields size */
+.uag-gf-btn-size-xs .uagb-gf-styler__check-style-enabled input[type=submit],
+.uag-gf-btn-size-xs .uagb-gf-styler__check-style-enabled input[type=button] {
+  font-size: 13px;
+  padding: 10px 20px;
+  border-radius: 2px; }
+
+.uag-gf-input-size-xs .uagb-gf-styler__check-style-enabled .gform_body input:not([type="radio"]):not([type="checkbox"]):not([type="submit"]):not([type="button"]):not([type="image"]):not([type="file"]),
+.uag-gf-input-size-xs .uagb-gf-styler__check-style-enabled .ginput_container textarea,
+.uag-gf-input-size-xs .uagb-gf-styler__check-style-enabled .ginput_container .chosen-single,
+.uag-gf-input-size-xs .uagb-gf-styler__check-style-enabled .ginput_container .chosen-choices {
+  font-size: 13px;
+  padding: 8px 10px; }
+
+.uag-gf-input-size-xs .uagb-gf-styler__check-style-enabled .ginput_container select {
+  font-size: 13px;
+  padding: 6px 10px; }
+
+.ginput_container select {
+  height: 100%;
+  line-height: inherit; }
+
+.uag-gf-input-size-xs .uagb-gf-styler__check-style-enabled .uag-gf-select-custom {
+  font-size: 13px; }
+
+.uag-gf-input-size-xs .uagb-gf-styler__check-style-enabled .gfield_checkbox input[type="checkbox"] + label:before,
+.uag-gf-input-size-xs .uagb-gf-styler__check-style-enabled .gfield_radio input[type="radio"] + label:before,
+.uag-gf-input-size-xs .uagb-gf-styler__check-style-enabled .ginput_container_consent input[type="checkbox"] + label:before {
+  height: 10px;
+  width: 10px; }
+
+.uag-gf-input-size-xs .uagb-gf-styler__check-style-enabled .gfield_checkbox input[type="checkbox"]:checked + label:before,
+.uag-gf-input-size-xs .uagb-gf-styler__check-style-enabled .ginput_container_consent input[type="checkbox"] + label:before {
+  font-size: calc( 10px / 1.2); }
+
+.uag-gf-btn-size-sm .uagb-gf-styler__check-style-enabled input[type=submit],
+.uag-gf-btn-size-sm .uagb-gf-styler__check-style-enabled input[type=button] {
+  font-size: 15px;
+  padding: 12px 24px;
+  border-radius: 3px; }
+
+.uag-gf-input-size-sm .uagb-gf-styler__check-style-enabled .gform_body input:not([type="radio"]):not([type="checkbox"]):not([type="submit"]):not([type="button"]):not([type="image"]):not([type="file"]),
+.uag-gf-input-size-sm .uagb-gf-styler__check-style-enabled .ginput_container textarea,
+.uag-gf-input-size-sm .uagb-gf-styler__check-style-enabled .ginput_container .chosen-single,
+.uag-gf-input-size-sm .uagb-gf-styler__check-style-enabled .ginput_container .chosen-choices {
+  font-size: 15px;
+  padding: 12px 10px; }
+
+.uag-gf-input-size-sm .uagb-gf-styler__check-style-enabled .ginput_container select {
+  font-size: 15px;
+  padding: 10px 10px; }
+
+.uag-gf-input-size-sm .uagb-gf-styler__check-style-enabled .uag-gf-select-custom {
+  font-size: 15px; }
+
+.uag-gf-input-size-sm .uagb-gf-styler__check-style-enabled .gfield_checkbox input[type="checkbox"] + label:before,
+.uag-gf-input-size-sm .uagb-gf-styler__check-style-enabled .gfield_radio input[type="radio"] + label:before,
+.uag-gf-input-size-sm .uagb-gf-styler__check-style-enabled .ginput_container_consent input[type="checkbox"] + label:before {
+  height: 12px;
+  width: 12px; }
+
+.uag-gf-input-size-sm .uagb-gf-styler__check-style-enabled .gfield_checkbox input[type="checkbox"]:checked + label:before,
+.uag-gf-input-size-sm .uagb-gf-styler__check-style-enabled .ginput_container_consent input[type="checkbox"] + label:before {
+  font-size: calc( 12px / 1.2); }
+
+.uag-gf-btn-size-md .uagb-gf-styler__check-style-enabled input[type=submit],
+.uag-gf-btn-size-md .uagb-gf-styler__check-style-enabled input[type=button] {
+  font-size: 16px;
+  padding: 15px 30px;
+  border-radius: 4px; }
+
+.uag-gf-input-size-md .uagb-gf-styler__check-style-enabled .gform_body input:not([type="radio"]):not([type="checkbox"]):not([type="submit"]):not([type="button"]):not([type="image"]):not([type="file"]),
+.uag-gf-input-size-md .uagb-gf-styler__check-style-enabled .ginput_container textarea,
+.uag-gf-input-size-md .uagb-gf-styler__check-style-enabled .ginput_container .chosen-single,
+.uag-gf-input-size-md .uagb-gf-styler__check-style-enabled .ginput_container .chosen-choices {
+  font-size: 16px;
+  padding: 15px 10px; }
+
+.uag-gf-input-size-md .uagb-gf-styler__check-style-enabled .ginput_container select {
+  font-size: 16px;
+  padding: 13px 10px; }
+
+.uag-gf-input-size-md .uagb-gf-styler__check-style-enabled .uag-gf-select-custom {
+  font-size: 16px; }
+
+.uag-gf-input-size-md .uagb-gf-styler__check-style-enabled .gfield_checkbox input[type="checkbox"] + label:before,
+.uag-gf-input-size-md .uagb-gf-styler__check-style-enabled .gfield_radio input[type="radio"] + label:before,
+.uag-gf-input-size-md .uagb-gf-styler__check-style-enabled .ginput_container_consent input[type="checkbox"] + label:before {
+  height: 15px;
+  width: 15px; }
+
+.uag-gf-input-size-md .uagb-gf-styler__check-style-enabled .gfield_checkbox input[type="checkbox"]:checked + label:before,
+.uag-gf-input-size-md .uagb-gf-styler__check-style-enabled .ginput_container_consent input[type="checkbox"] + label:before {
+  font-size: calc( 15px / 1.2); }
+
+.uag-gf-btn-size-lg .uagb-gf-styler__check-style-enabled input[type=submit],
+.uag-gf-btn-size-lg .uagb-gf-styler__check-style-enabled input[type=button] {
+  font-size: 18px;
+  padding: 20px 40px;
+  border-radius: 5px; }
+
+.uag-gf-input-size-lg .uagb-gf-styler__check-style-enabled .gform_body input:not([type="radio"]):not([type="checkbox"]):not([type="submit"]):not([type="button"]):not([type="image"]):not([type="file"]),
+.uag-gf-input-size-lg .uagb-gf-styler__check-style-enabled .ginput_container textarea,
+.uag-gf-input-size-lg .uagb-gf-styler__check-style-enabled .ginput_container .chosen-single,
+.uag-gf-input-size-lg .uagb-gf-styler__check-style-enabled .ginput_container .chosen-choices {
+  font-size: 18px;
+  padding: 20px 10px; }
+
+.uag-gf-input-size-lg .uagb-gf-styler__check-style-enabled .ginput_container select {
+  font-size: 18px;
+  padding: 18px 10px; }
+
+.uag-gf-input-size-lg .uagb-gf-styler__check-style-enabled .uag-gf-select-custom {
+  font-size: 18px; }
+
+.uag-gf-input-size-lg .uagb-gf-styler__check-style-enabled .gfield_checkbox input[type="checkbox"] + label:before,
+.uag-gf-input-size-lg .uagb-gf-styler__check-style-enabled .gfield_radio input[type="radio"] + label:before,
+.uag-gf-input-size-lg .uagb-gf-styler__check-style-enabled .ginput_container_consent input[type="checkbox"] + label:before {
+  height: 20px;
+  width: 20px; }
+
+.uag-gf-input-size-lg .uagb-gf-styler__check-style-enabled .gfield_checkbox input[type="checkbox"]:checked + label:before,
+.uag-gf-input-size-lg .uagb-gf-styler__check-style-enabled .ginput_container_consent input[type="checkbox"] + label:before {
+  font-size: calc( 20px / 1.2); }
+
+.uag-gf-btn-size-xl .uagb-gf-styler__check-style-enabled input[type=submit],
+.uag-gf-btn-size-xl .uagb-gf-styler__check-style-enabled input[type=button] {
+  font-size: 20px;
+  padding: 25px 50px;
+  border-radius: 6px; }
+
+.uag-gf-input-size-xl .uagb-gf-styler__check-style-enabled .gform_body input:not([type="radio"]):not([type="checkbox"]):not([type="submit"]):not([type="button"]):not([type="image"]):not([type="file"]),
+.uag-gf-input-size-xl .uagb-gf-styler__check-style-enabled .ginput_container textarea,
+.uag-gf-input-size-xl .uagb-gf-styler__check-style-enabled .ginput_container .chosen-single,
+.uag-gf-input-size-xl .uagb-gf-styler__check-style-enabled .ginput_container .chosen-choices {
+  font-size: 20px;
+  padding: 25px 10px; }
+
+.uag-gf-input-size-xl .uagb-gf-styler__check-style-enabled .ginput_container select {
+  font-size: 20px;
+  padding: 23px 10px; }
+
+.uag-gf-input-size-xl .uagb-gf-styler__check-style-enabled .uag-gf-select-custom {
+  font-size: 20px; }
+
+.uag-gf-input-size-xl .uagb-gf-styler__check-style-enabled .gfield_checkbox input[type="checkbox"] + label:before,
+.uag-gf-input-size-xl .uagb-gf-styler__check-style-enabled .gfield_radio input[type="radio"] + label:before,
+.uag-gf-input-size-xl .uagb-gf-styler__check-style-enabled .ginput_container_consent input[type="checkbox"] + label:before {
+  height: 25px;
+  width: 25px; }
+
+.uag-gf-input-size-xl .uagb-gf-styler__check-style-enabled .gfield_checkbox input[type="checkbox"]:checked + label:before,
+.uag-gf-input-size-xl .uagb-gf-styler__check-style-enabled .ginput_container_consent input[type="checkbox"]:checked + label:before {
+  font-size: calc( 25px / 1.2); }
+
+/* Gravity Form - Buttons Ends */
+.uagb-gf-styler__btn-align-right .gform_next_button,
+.uagb-gf-styler__btn-align-right .gform_previous_button {
+  margin-right: 5px !important; }
+
+.uagb-gf-styler__check-style-enabled .gform_wrapper .gform_footer:not(.top_label) {
+  padding: 0 0 0 0;
+  margin-right: 0;
+  margin-left: 0;
+  width: 100%; }
+
+.uagb-gf-styler__check-style-enabled .gform_wrapper .gform_page_footer.left_label,
+.uagb-gf-styler__check-style-enabled .gform_wrapper .gform_page_footer.right_label {
+  padding: 0 0 0 0; }
+
+.uagb-gf-styler__check-style-enabled .gfield_radio input[type="radio"] + label:before {
+  border-radius: 100%; }
+
+.uagb-gf-styler__check-style-enabled .gform_wrapper .top_label .gfield_error {
+  width: 100% !important; }
+
+.uagb-gf-styler__check-style-enabled .gform_wrapper.gform_validation_error .gform_body ul li.gfield.gfield_error:not(.gf_left_half):not(.gf_right_half) {
+  max-width: 100% !important; }
+
+.uagb-gf-styler__btn-align-center .gform_wrapper .gform_footer input[type=submit],
+.uagb-gf-styler__btn-align-center .gform_page .gform_page_footer input[type=button],
+.uagb-gf-styler__btn-align-center .gform_page .gform_page_footer input[type=submit],
+.uagb-gf-styler__btn-align-left .gform_wrapper .gform_footer input[type=submit],
+.uagb-gf-styler__btn-align-left .gform_page .gform_page_footer input[type=button],
+.uagb-gf-styler__btn-align-left .gform_page .gform_page_footer input[type=submit],
+.uagb-gf-styler__btn-align-right .gform_wrapper .gform_footer input[type=submit],
+.uagb-gf-styler__btn-align-right .gform_page .gform_page_footer input[type=button],
+.uagb-gf-styler__btn-align-right .gform_page .gform_page_footer input[type=submit],
+.uagb-gf-styler__btn-align-justify .gform_wrapper .gform_footer input[type=submit],
+.uagb-gf-styler__btn-align-justify .gform_page .gform_page_footer input[type=button],
+.uagb-gf-styler__btn-align-justify .gform_page .gform_page_footer input[type=submit] {
+  -js-display: flex;
+  display: flex;
+  width: auto; }
+
+.uagb-gf-styler__btn-align-center .gform_wrapper .gform_footer input[type=submit],
+.uagb-gf-styler__btn-align-center .gform_page .gform_page_footer input[type=button],
+.uagb-gf-styler__btn-align-center .gform_page .gform_page_footer input[type=submit],
+html[dir=rtl] .uagb-gf-styler__btn-align-center .gform_wrapper .gform_footer input[type=submit],
+html[dir=rtl] .uagb-gf-styler__btn-align-center .gform_page .gform_page_footer input[type=button],
+html[dir=rtl] .uagb-gf-styler__btn-align-center .gform_page .gform_page_footer input[type=submit] {
+  margin-left: auto;
+  margin-right: auto; }
+
+.uagb-gf-styler__btn-align-center .gform_page .gform_page_footer {
+  text-align: center; }
+
+.uagb-gf-styler__btn-align-right .gform_page .gform_page_footer {
+  text-align: right; }
+
+.uagb-gf-styler__btn-align-left .gform_wrapper .gform_footer input[type=submit],
+.uagb-gf-styler__btn-align-left .gform_page .gform_page_footer input[type=button],
+.uagb-gf-styler__btn-align-left .gform_page .gform_page_footer input[type=submit],
+html[dir=rtl] .uagb-gf-styler__btn-align-right .gform_wrapper .gform_footer input[type=submit],
+html[dir=rtl] .uagb-gf-styler__btn-align-right .gform_page .gform_page_footer input[type=button],
+html[dir=rtl] .uagb-gf-styler__btn-align-right .gform_page .gform_page_footer input[type=submit] {
+  margin-left: 0;
+  margin-right: auto; }
+
+.uagb-gf-styler__btn-align-right .gform_wrapper .gform_footer input[type=submit],
+.uagb-gf-styler__btn-align-right .gform_page .gform_page_footer input[type=button],
+.uagb-gf-styler__btn-align-right .gform_page .gform_page_footer input[type=submit],
+html[dir=rtl] .uagb-gf-styler__btn-align-left .gform_wrapper .gform_footer input[type=submit],
+html[dir=rtl] .uagb-gf-styler__btn-align-left .gform_page .gform_page_footer input[type=button],
+html[dir=rtl] .uagb-gf-styler__btn-align-left .gform_page .gform_page_footer input[type=submit] {
+  margin-left: auto;
+  margin-right: 0; }
+
+.uagb-gf-styler__btn-align-justify .gform_wrapper .gform_footer input[type=submit],
+.uagb-gf-styler__btn-align-justify .gform_page .gform_page_footer input[type=button],
+.uagb-gf-styler__btn-align-justify .gform_page .gform_page_footer input[type=submit] {
+  justify-content: center;
+  width: 100%; }
+
+.uagb-gf-styler__check-style-enabled .gform_body .ginput_container_checkbox .gfield_checkbox input[type='checkbox'],
+.uagb-gf-styler__check-style-enabled .gform_body .ginput_container_radio .gfield_radio input[type='radio'],
+.uagb-gf-styler__check-style-enabled .gform_body .ginput_container_consent input[type='checkbox'] {
+  display: none; }
+
+.uagb-gf-styler__check-style-enabled .gform_body .ginput_container_checkbox .gfield_checkbox input[type='checkbox'] + label:before,
+.uagb-gf-styler__check-style-enabled .gform_body .ginput_container_radio .gfield_radio input[type='radio'] + label:before,
+.uagb-gf-styler__check-style-enabled .gform_body .ginput_container_consent input[type='checkbox'] + label:before {
+  content: '';
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: 10px;
+  text-align: center; }
+
+.uagb-gf-styler__check-style-enabled .gform_body .ginput_container_checkbox .gfield_checkbox input[type='checkbox']:checked + label:before,
+.uagb-gf-styler__check-style-enabled .gform_body .ginput_container_consent input[type='checkbox']:checked + label:before {
+  content: "\2714";
+  line-height: 1.2; }
+
+/* Gravity Form */
+.uagb-gf-styler__check-style-enabled .gform_wrapper ul.gform_fields li.gfield:not(.gf_left_half):not(.gf_left_third):not(.gf_middle_third) {
+  padding-right: 0; }
+
+.uagb-gf-styler__btn-align-width-full_width .gform_footer input[type=submit] {
+  display: block;
+  text-align: center;
+  width: 100%; }
+
+.uagb-gf-styler__check-style-enabled .gform_body ul {
+  margin-left: 0;
+  list-style: none; }
+
+.uagb-gf-styler__check-style-enabled .gform_wrapper .gfield .ginput_container select,
+.uagb-gf-styler__check-style-enabled .gform_wrapper .gfield .ginput_container .chosen-single,
+.uagb-gf-styler__check-style-enabled .gform_wrapper .gfield .ginput_container .chosen-choices,
+.uagb-gf-styler__check-style-enabled .gform_wrapper .chosen-choices li.search-field input[type="text"],
+.uagb-gf-styler__check-style-enabled .gform_wrapper .chosen-choices li.search-field input.default {
+  height: auto; }
+
+.elementor-widget-uag-gf-styler .uagb-gf-styler__check-style-enabled .gform_wrapper .chosen-choices li.search-field input[type="text"] {
+  padding: 0px 0px 0px 0px; }
+
+.uagb-gf-styler__check-style-enabled .gform_page .gform_page_footer input[type=button] {
+  margin-bottom: 20px; }
+
+.uagb-gf-styler__check-style-enabled .gform_wrapper .chosen-container-single .chosen-single div {
+  display: none; }
+
+.uagb-gf-styler__hide-label .gform_wrapper .gform_fields .gfield_label,
+.uagb-gf-styler__hide-label .gform_wrapper .gform_fields .gfield_required {
+  display: none; }
+
+.wp-block-uagb-gf-styler .gform_wrapper .chosen-container-single .chosen-single span {
+  margin-bottom: 0;
+  width: 100%; }
+
+.wp-block-uagb-gf-styler .gform_wrapper .chosen-container-single .chosen-single {
+  border: none; }
+
+.wp-block-uagb-gf-styler .gform_wrapper .chosen-container-single.chosen-container-active .chosen-single {
+  border: none; }
+
+/* Gravity Form ends */
+@media only screen and (max-width: 976px) {
+  .uagb-gf-styler__btn-align-center .gform_page .gform_page_footer {
+    text-align: center; }
+  .uagb-gf-styler__btn-align-right .gform_page .gform_page_footer {
+    text-align: right; }
+  .uag-tablet-gf-button-center .gform_wrapper .gform_footer input[type=submit],
+  .uag-tablet-gf-button-center .gform_page .gform_page_footer input[type="button"],
+  .uag-tablet-gf-button-center .gform_page .gform_page_footer input[type=submit] {
+    margin-left: auto;
+    margin-right: auto;
+    width: auto; }
+  .uag-tablet-gf-button-left .gform_wrapper .gform_footer input[type=submit],
+  .uag-tablet-gf-button-left .gform_page .gform_page_footer input[type=button],
+  .uag-tablet-gf-button-left .gform_page .gform_page_footer input[type=submit] {
+    margin-left: 0;
+    margin-right: auto;
+    width: auto; }
+  .uag-tablet-gf-button-right .gform_wrapper .gform_footer input[type=submit],
+  .uag-tablet-gf-button-right .gform_page .gform_page_footer input[type=button],
+  .uag-tablet-gf-button-right .gform_page .gform_page_footer input[type=submit] {
+    margin-left: auto;
+    margin-right: 0;
+    width: auto; }
+  .uag-tablet-gf-button-justify .gform_wrapper .gform_footer input[type=submit],
+  .uag-tablet-gf-button-justify .gform_page .gform_page_footer input[type=button],
+  .uag-tablet-gf-button-justify .gform_page .gform_page_footer input[type=submit] {
+    justify-content: center;
+    width: 100%; } }
+
+@media only screen and (max-width: 767px) {
+  .uagb-gf-styler__btn-align-center .gform_page .gform_page_footer {
+    text-align: center; }
+  .uagb-gf-styler__btn-align-right .gform_page .gform_page_footer {
+    text-align: right; }
+  .uag-mobile-gf-button-center .gform_wrapper .gform_footer input[type=submit],
+  .uag-mobile-gf-button-center .gform_page .gform_page_footer input[type=button],
+  .uag-mobile-gf-button-center .gform_page .gform_page_footer input[type=submit] {
+    margin-left: auto;
+    margin-right: auto;
+    width: auto; }
+  .uag-mobile-gf-button-left .gform_wrapper .gform_footer input[type=submit],
+  .uag-mobile-gf-button-left .gform_page .gform_page_footer input[type=button],
+  .uag-mobile-gf-button-left .gform_page .gform_page_footer input[type=submit] {
+    margin-left: 0;
+    margin-right: auto;
+    width: auto; }
+  .uag-mobile-gf-button-right .gform_wrapper .gform_footer input[type=submit],
+  .uag-mobile-gf-button-right .gform_page .gform_page_footer input[type=button],
+  .uag-mobile-gf-button-right .gform_page .gform_page_footer input[type=submit] {
+    margin-left: auto;
+    margin-right: 0;
+    width: auto; }
+  .uag-mobile-gf-button-justify .gform_wrapper .gform_footer input[type=submit],
+  .uag-mobile-gf-button-justify .gform_page .gform_page_footer input[type=button],
+  .uag-mobile-gf-button-justify .gform_page .gform_page_footer input[type=submit] {
+    justify-content: center;
+    width: 100%; } }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.wp-block-uagb-blockquote {
+  padding: 0;
+  margin: 0 auto;
+  /*Twitter icon CSS.*/
+  /* image */
+  /* Left Image */
+  /* Top Image */ }
+  .wp-block-uagb-blockquote .uagb-blockquote__content,
+  .wp-block-uagb-blockquote cite.uagb-blockquote__author {
+    font-style: normal;
+    display: block; }
+  .wp-block-uagb-blockquote cite.uagb-blockquote__author,
+  .wp-block-uagb-blockquote .uagb-blockquote__author {
+    align-self: center; }
+  .wp-block-uagb-blockquote .uagb-blockquote__skin-quotation blockquote.uagb-blockquote {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    outline: 0;
+    font-size: 100%;
+    vertical-align: baseline;
+    background: transparent;
+    quotes: none;
+    border-left: 0 none;
+    border-right: 0 none;
+    border-top: 0 none;
+    border-bottom: 0 none;
+    font-style: normal; }
+  .wp-block-uagb-blockquote .uagb-blockquote__skin-quotation .uagb-blockquote__icon-wrap {
+    position: relative;
+    display: inline-block;
+    padding: 0px;
+    z-index: 1;
+    background: #333;
+    padding: 10px;
+    border-radius: 100%;
+    margin-right: 10px; }
+  .wp-block-uagb-blockquote .uagb-blockquote__skin-quotation .uagb-blockquote__icon {
+    height: 25px;
+    width: 25px;
+    display: inline-block;
+    float: left; }
+  .wp-block-uagb-blockquote .uagb-blockquote__skin-quotation .uagb-blockquote__icon svg {
+    height: inherit;
+    width: inherit;
+    display: inherit; }
+  .wp-block-uagb-blockquote .uagb-blockquote__skin-quotation.uagb-blockquote__style-style_2 .uagb-blockquote__icon-wrap {
+    display: inline-block;
+    float: left; }
+  .wp-block-uagb-blockquote blockquote.uagb-blockquote {
+    margin: 0;
+    padding: 0; }
+  .wp-block-uagb-blockquote .uagb-blockquote__wrap, .wp-block-uagb-blockquote .uagb-blockquote__wrap * {
+    box-sizing: border-box; }
+  .wp-block-uagb-blockquote .uagb-blockquote__style-style_2 .uagb-blockquote__icon-wrap {
+    display: inline-block;
+    float: left;
+    text-align: left; }
+  .wp-block-uagb-blockquote .uagb-blockquote__separator-parent {
+    -js-display: flex;
+    display: flex;
+    justify-content: flex-start; }
+  .wp-block-uagb-blockquote .uagb-blockquote__with-tweet .uagb-blockquote footer {
+    display: flex;
+    justify-content: space-between; }
+  .wp-block-uagb-blockquote .uagb-blockquote a {
+    box-shadow: none;
+    text-decoration: none; }
+  .wp-block-uagb-blockquote .uagb-blockquote a.uagb-blockquote__tweet-button {
+    display: flex;
+    transition: 0.2s;
+    align-self: flex-end;
+    line-height: 1;
+    position: relative;
+    width: -webkit-max-content;
+    width: -moz-max-content;
+    width: max-content;
+    padding: 0;
+    color: #1DA1F2;
+    background-color: transparent;
+    align-self: center; }
+  .wp-block-uagb-blockquote a.uagb-blockquote__tweet-button svg {
+    height: 15px;
+    width: 15px;
+    margin-right: 5px;
+    fill: #fff;
+    vertical-align: middle;
+    align-self: center; }
+  .wp-block-uagb-blockquote a.uagb-blockquote__tweet-button,
+  .wp-block-uagb-blockquote a.uagb-blockquote__tweet-button svg {
+    font-style: normal; }
+  .wp-block-uagb-blockquote .uagb-blockquote__tweet-icon a.uagb-blockquote__tweet-button svg {
+    margin-right: 0; }
+  .wp-block-uagb-blockquote .uagb-blockquote__tweet-icon_text svg {
+    margin-right: 10px; }
+  .wp-block-uagb-blockquote .uagb-blockquote__tweet-icon a.uagb-blockquote__tweet-button {
+    padding: 8px; }
+  .wp-block-uagb-blockquote .uagb-blockquote__tweet-icon_text a.uagb-blockquote__tweet-button,
+  .wp-block-uagb-blockquote .uagb-blockquote__tweet-text a.uagb-blockquote__tweet-button {
+    padding: 10px 14px; }
+  .wp-block-uagb-blockquote .uagb-blockquote__tweet-style-link a.uagb-blockquote__tweet-button {
+    padding: 10px 0; }
+  .wp-block-uagb-blockquote .uagb-blockquote__tweet-style-classic a.uagb-blockquote__tweet-button,
+  .wp-block-uagb-blockquote .uagb-blockquote__tweet-style-bubble a.uagb-blockquote__tweet-button {
+    background-color: #1DA1F2;
+    border-radius: 100em;
+    color: #fff; }
+  .wp-block-uagb-blockquote .uagb-blockquote__tweet-style-bubble a.uagb-blockquote__tweet-button:before {
+    content: '';
+    border: solid 0.5em transparent;
+    border-right-color: #1DA1F2;
+    position: absolute;
+    left: -0.8em;
+    top: 50%;
+    transform: translateY(-50%) scale(1, 0.65);
+    transition: 0.2s; }
+  .wp-block-uagb-blockquote .uagb-blockquote__align-right.uagb-blockquote__tweet-style-bubble a.uagb-blockquote__tweet-button:before {
+    left: auto;
+    right: -0.8em;
+    transform: translateY(-50%) scale(1, 0.65) rotate(180deg); }
+  .wp-block-uagb-blockquote .uagb-blockquote__align-center.uagb-blockquote__tweet-style-bubble a.uagb-blockquote__tweet-button:before {
+    left: 50%;
+    top: -0.8em;
+    right: auto;
+    transform: translate(-50%, 10%) scale(1, 0.85) rotate(90deg); }
+  .wp-block-uagb-blockquote .uagb-blockquote__with-tweet.uagb-blockquote__align-center .uagb-blockquote footer,
+  .wp-block-uagb-blockquote .uagb-blockquote__align-center .uagb-blockquote footer {
+    display: block;
+    text-align: center; }
+  .wp-block-uagb-blockquote .uagb-blockquote__align-center a.uagb-blockquote__tweet-button {
+    display: block;
+    text-align: center;
+    margin: 0 auto;
+    align-self: center; }
+  .wp-block-uagb-blockquote .uagb-blockquote__with-tweet.uagb-blockquote__align-right .uagb-blockquote footer,
+  .wp-block-uagb-blockquote .uagb-blockquote__align-right .uagb-blockquote footer {
+    flex-direction: row-reverse; }
+  .wp-block-uagb-blockquote .uagb-blockquote__author-image {
+    align-self: center; }
+  .wp-block-uagb-blockquote .uagb-blockquote__author-image img {
+    width: 50px;
+    height: 50px;
+    border-radius: 100%;
+    margin-right: 10px; }
+  .wp-block-uagb-blockquote .uagb-blockquote__author-wrap {
+    display: flex;
+    flex-direction: row; }
+  .wp-block-uagb-blockquote .uagb-blockquote__align-right .uagb-blockquote__author-wrap,
+  .wp-block-uagb-blockquote .uagb-blockquote__align-left .uagb-blockquote__author-wrap.uagb-blockquote__author-at-right {
+    justify-content: flex-end;
+    -webkit-box-pack: flex-end;
+    -ms-flex-pack: flex-end;
+    -webkit-justify-content: flex-end;
+    -moz-box-pack: flex-end; }
+  .wp-block-uagb-blockquote .uagb-blockquote__align-left .uagb-blockquote__author-wrap,
+  .wp-block-uagb-blockquote .uagb-blockquote__align-right .uagb-blockquote__author-wrap.uagb-blockquote__author-at-right {
+    justify-content: flex-start;
+    -webkit-box-pack: flex-start;
+    -ms-flex-pack: flex-start;
+    -webkit-justify-content: flex-start;
+    -moz-box-pack: flex-start; }
+  .wp-block-uagb-blockquote .uagb-blockquote__with-tweet .uagb-blockquote__author-wrap {
+    justify-content: unset;
+    -webkit-box-pack: unset;
+    -ms-flex-pack: unset;
+    -webkit-justify-content: unset;
+    -moz-box-pack: unset; }
+  .wp-block-uagb-blockquote .uagb-blockquote__align-center .uagb-blockquote__author-wrap,
+  .wp-block-uagb-blockquote .uagb-blockquote__align-center.uagb-blockquote__with-tweet .uagb-blockquote__author-wrap {
+    justify-content: center;
+    -webkit-box-pack: center;
+    -ms-flex-pack: center;
+    -webkit-justify-content: center;
+    -moz-box-pack: center; }
+  .wp-block-uagb-blockquote .uagb-blockquote__author-wrap.uagb-blockquote__author-at-top {
+    width: 100%; }
+  .wp-block-uagb-blockquote .uagb-blockquote__author-wrap.uagb-blockquote__author-at-top .uagb-blockquote__author-image,
+  .wp-block-uagb-blockquote .uagb-blockquote__author-wrap.uagb-blockquote__author-at-top .uagb-blockquote__author {
+    width: inherit; }
+  .wp-block-uagb-blockquote .uagb-blockquote__with-tweet .uagb-blockquote__author-wrap.uagb-blockquote__author-at-top {
+    width: auto; }
+  .wp-block-uagb-blockquote .uagb-blockquote__author-wrap.uagb-blockquote__author-at-right {
+    flex-direction: row-reverse; }
+  .wp-block-uagb-blockquote .uagb-blockquote__align-right .uagb-blockquote__author-wrap.uagb-blockquote__author-at-top {
+    text-align: right; }
+  .wp-block-uagb-blockquote .uagb-blockquote__author-wrap.uagb-blockquote__author-at-right .uagb-blockquote__author-image img {
+    margin-left: 10px;
+    margin-right: 0; }
+  .wp-block-uagb-blockquote .uagb-blockquote__author-wrap.uagb-blockquote__author-at-top {
+    flex-direction: column; }
+
+@media only screen and (max-width: 976px) {
+  .wp-block-uagb-blockquote {
+    /* Left alignment */
+    /* Right ALignment */ }
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet .uagb-blockquote__author {
+      width: 100%; }
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet .uagb-blockquote__author-wrap.uagb-blockquote__author-at-right,
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet .uagb-blockquote__author-wrap.uagb-blockquote__author-at-left {
+      flex-direction: column; }
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet .uagb-blockquote__author-wrap.uagb-blockquote__author-at-right .uagb-blockquote__author-image img,
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet .uagb-blockquote__author-wrap.uagb-blockquote__author-at-left .uagb-blockquote__author-image img {
+      margin-left: 0;
+      margin-right: 0;
+      margin-bottom: 10px; }
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet.uagb-blockquote__with-tweet .uagb-blockquote footer {
+      flex-direction: column;
+      align-self: flex-start; }
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet .uagb-blockquote__author-wrap.uagb-blockquote__author-at-left,
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet a.uagb-blockquote__tweet-button {
+      align-self: flex-start; }
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet.uagb-blockquote__align-right.uagb-blockquote__with-tweet .uagb-blockquote footer,
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet.uagb-blockquote__align-right .uagb-blockquote__author-wrap.uagb-blockquote__author-at-left,
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet.uagb-blockquote__align-right a.uagb-blockquote__tweet-button {
+      align-self: flex-end; }
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet a.uagb-blockquote__tweet-button {
+      margin-top: 10px; }
+    .wp-block-uagb-blockquote .uagb-blockquote__align-right.uagb-blockquote__stack-img-tablet .uagb-blockquote__author-image {
+      align-self: flex-end; }
+    .wp-block-uagb-blockquote .uagb-blockquote__align-left.uagb-blockquote__stack-img-tablet .uagb-blockquote__author-image,
+    .wp-block-uagb-blockquote .uagb-blockquote__align-left.uagb-blockquote__stack-img-tablet .uagb-blockquote__author {
+      align-self: flex-start; }
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet.uagb-blockquote__align-right.uagb-blockquote__tweet-style-bubble a.uagb-blockquote__tweet-button:before,
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-tablet.uagb-blockquote__align-left.uagb-blockquote__tweet-style-bubble a.uagb-blockquote__tweet-button:before {
+      left: 50%;
+      top: -0.8em;
+      right: auto;
+      transform: translate(-50%, 10%) scale(1, 0.85) rotate(90deg); } }
+
+@media screen and (max-width: 767px) {
+  .wp-block-uagb-blockquote {
+    /* Left alignment */
+    /* Right ALignment */ }
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile .uagb-blockquote__author {
+      width: 100%; }
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile .uagb-blockquote__author-wrap.uagb-blockquote__author-at-right,
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile .uagb-blockquote__author-wrap.uagb-blockquote__author-at-left {
+      flex-direction: column; }
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile .uagb-blockquote__author-wrap.uagb-blockquote__author-at-right .uagb-blockquote__author-image img,
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile .uagb-blockquote__author-wrap.uagb-blockquote__author-at-left .uagb-blockquote__author-image img {
+      margin-left: 0;
+      margin-right: 0;
+      margin-bottom: 10px; }
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile.uagb-blockquote__with-tweet .uagb-blockquote footer {
+      flex-direction: column;
+      align-self: flex-start; }
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile .uagb-blockquote__author-wrap.uagb-blockquote__author-at-left,
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile a.uagb-blockquote__tweet-button {
+      align-self: flex-start; }
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile.uagb-blockquote__align-right.uagb-blockquote__with-tweet .uagb-blockquote footer,
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile.uagb-blockquote__align-right .uagb-blockquote__author-wrap.uagb-blockquote__author-at-left,
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile.uagb-blockquote__align-right a.uagb-blockquote__tweet-button {
+      align-self: flex-end; }
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile a.uagb-blockquote__tweet-button {
+      margin-top: 10px; }
+    .wp-block-uagb-blockquote .uagb-blockquote__align-right.uagb-blockquote__stack-img-mobile .uagb-blockquote__author-image {
+      align-self: flex-end; }
+    .wp-block-uagb-blockquote .uagb-blockquote__align-left.uagb-blockquote__stack-img-mobile .uagb-blockquote__author-image,
+    .wp-block-uagb-blockquote .uagb-blockquote__align-left.uagb-blockquote__stack-img-tablet .uagb-blockquote__author {
+      align-self: flex-start; }
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile.uagb-blockquote__align-right.uagb-blockquote__tweet-style-bubble a.uagb-blockquote__tweet-button:before,
+    .wp-block-uagb-blockquote .uagb-blockquote__stack-img-mobile.uagb-blockquote__align-left.uagb-blockquote__tweet-style-bubble a.uagb-blockquote__tweet-button:before {
+      left: 50%;
+      top: -0.8em;
+      right: auto;
+      transform: translate(-50%, 10%) scale(1, 0.85) rotate(90deg); } }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.wp-block-uagb-marketing-button .uagb-marketing-btn__wrap > p,
+.wp-block-uagb-marketing-button p:empty {
+  display: none; }
+
+.wp-block-uagb-marketing-button .uagb-marketing-btn__title,
+.wp-block-uagb-marketing-button p.uagb-marketing-btn__prefix {
+  margin: 0; }
+
+.wp-block-uagb-marketing-button .uagb-marketing-btn__wrap {
+  display: flex; }
+
+.wp-block-uagb-marketing-button .uagb-marketing-btn__link {
+  z-index: 1; }
+
+.wp-block-uagb-marketing-button .uagb-marketing-btn__link {
+  display: inline-block;
+  position: relative;
+  transition: all 0.2s; }
+
+.wp-block-uagb-marketing-button .uagb-marketing-btn__icon-wrap {
+  width: 20px;
+  height: 20px;
+  display: flex;
+  z-index: 1; }
+
+.wp-block-uagb-marketing-button .uagb-marketing-btn__icon-wrap svg {
+  width: inherit;
+  height: inherit; }
+
+.wp-block-uagb-marketing-button .uagb-marketing-btn__title-wrap {
+  display: flex;
+  align-items: center; }
+
+.wp-block-uagb-marketing-button.uagb-marketing-btn__align-center .uagb-marketing-btn__wrap,
+.wp-block-uagb-marketing-button.uagb-marketing-btn__align-text-center .uagb-marketing-btn__title-wrap {
+  justify-content: center; }
+
+.wp-block-uagb-marketing-button.uagb-marketing-btn__align-left .uagb-marketing-btn__wrap,
+.wp-block-uagb-marketing-button.uagb-marketing-btn__align-text-left .uagb-marketing-btn__title-wrap {
+  justify-content: flex-start; }
+
+.wp-block-uagb-marketing-button.uagb-marketing-btn__align-right .uagb-marketing-btn__wrap,
+.wp-block-uagb-marketing-button.uagb-marketing-btn__align-text-right .uagb-marketing-btn__title-wrap {
+  justify-content: flex-end; }
+
+.wp-block-uagb-marketing-button.uagb-marketing-btn__align-full .uagb-marketing-btn__link {
+  width: 100%; }
+
+.wp-block-uagb-marketing-button.uagb-marketing-btn__align-text-center .uagb-marketing-btn__prefix-wrap {
+  text-align: center; }
+
+.wp-block-uagb-marketing-button.uagb-marketing-btn__align-text-left .uagb-marketing-btn__prefix-wrap {
+  text-align: left; }
+
+.wp-block-uagb-marketing-button.uagb-marketing-btn__align-text-right .uagb-marketing-btn__prefix-wrap {
+  text-align: right; }
+
+.wp-block-uagb-marketing-button.uagb-marketing-btn__icon-after .uagb-marketing-btn__title-wrap {
+  flex-direction: row-reverse; }
+
+.entry-content .wp-block-uagb-marketing-button .uagb-marketing-btn__link {
+  text-decoration: none; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+/**
+ * #.# Styles
+ *
+ * CSS for both Frontend+Backend.
+ */
+.wp-block-uagb-table-of-contents .uagb-toc__wrap {
+  display: inline-block; }
+
+.wp-block-uagb-table-of-contents ul.uagb-toc__list {
+  margin-left: 1.2em;
+  padding-left: 0px;
+  margin-bottom: 0; }
+  .wp-block-uagb-table-of-contents ul.uagb-toc__list li {
+    margin: 0; }
+
+.wp-block-uagb-table-of-contents .uagb-toc__list-wrap ul li a {
+  color: inherit;
+  line-height: inherit;
+  font-size: inherit; }
+
+.wp-block-uagb-table-of-contents.uagb-toc__align-left {
+  text-align: left; }
+
+.wp-block-uagb-table-of-contents.uagb-toc__align-center {
+  text-align: center; }
+
+.wp-block-uagb-table-of-contents.uagb-toc__align-right {
+  text-align: right; }
+
+.wp-block-uagb-table-of-contents ul li:empty {
+  display: none; }
+
+.wp-block-uagb-table-of-contents .uagb-toc__title-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: space-between; }
+
+.wp-block-uagb-table-of-contents .uagb-toc__is-collapsible.uagb-toc__title-wrap {
+  cursor: pointer; }
+
+.wp-block-uagb-table-of-contents .uag-toc__collapsible-wrap svg {
+  width: 20px;
+  height: 20px; }
+
+.wp-block-uagb-table-of-contents .uag-toc__collapsible-wrap {
+  margin-left: 10px;
+  display: flex;
+  cursor: pointer; }
+
+.wp-block-uagb-table-of-contents.uagb-toc__collapse .uagb-toc__list-wrap {
+  display: none; }
+
+.uagb-toc__list .uagb-toc__list {
+  list-style-type: circle; }
+
+.uagb-toc__scroll-top.dashicons {
+  display: none;
+  position: fixed;
+  bottom: 50px;
+  right: 50px;
+  padding: 10px;
+  background: #ccd0d4;
+  cursor: pointer; }
+
+.uagb-toc__scroll-top.uagb-toc__show-scroll {
+  display: inline-table; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+.uagb-howto__cost-wrap {
+  display: block; }
+  .uagb-howto__cost-wrap .uagb-howto-estcost-text,
+  .uagb-howto__cost-wrap .uagb-howto-estcost-value,
+  .uagb-howto__cost-wrap .uagb-howto-estcost-type {
+    display: inline-flex; }
+
+.uagb-howto__time-wrap {
+  display: block; }
+  .uagb-howto__time-wrap .uagb-howto-timeNeeded-text,
+  .uagb-howto__time-wrap .uagb-howto-timeNeeded-value,
+  .uagb-howto__time-wrap .uagb-howto-timeINmin-text {
+    display: inline-flex; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+.wp-block-uagb-faq.uagb-faq-layout-accordion .uagb-faq-child__outer-wrap .uagb-faq-questions-button {
+  cursor: pointer; }
+
+.uagb-faq-layout-grid.uagb-faq-equal-height .uagb-faq__wrap .uagb-faq-child__outer-wrap,
+.uagb-faq-layout-grid.uagb-faq-equal-height .uagb-faq__wrap .uagb-faq-child__wrapper,
+.uagb-faq-layout-grid.uagb-faq-equal-height .uagb-faq__wrap .uagb-faq-item {
+  height: 100%; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+.wp-block-uagb-faq-child.uagb-faq-child__outer-wrap .uagb-faq-item:focus,
+.wp-block-uagb-faq-child.uagb-faq-child__outer-wrap .uagb-faq-item:active {
+  outline: thin dotted; }
+
+.wp-block-uagb-faq-child .uagb-faq-questions-button {
+  display: flex;
+  align-items: center;
+  width: 100%; }
+  .wp-block-uagb-faq-child .uagb-faq-questions-button .uagb-faq-icon-wrap {
+    display: inline-block;
+    vertical-align: middle; }
+  .wp-block-uagb-faq-child .uagb-faq-questions-button .uagb-question {
+    width: 100%;
+    margin-top: 0px;
+    margin-bottom: 0px; }
+
+.wp-block-uagb-faq-child .uagb-icon svg,
+.wp-block-uagb-faq-child .uagb-icon-active svg {
+  width: 15px;
+  height: 15px;
+  font-size: 15px; }
+
+.wp-block-uagb-faq-child .uagb-faq-content span {
+  display: inline-block; }
+
+.wp-block-uagb-faq-child .uagb-faq-content p {
+  margin: 0; }
+
+.wp-block-uagb-faq-child.uagb-faq-child__outer-wrap .uagb-faq-item .uagb-icon-active,
+.wp-block-uagb-faq-child.uagb-faq-child__outer-wrap .uagb-faq-item.uagb-faq-item-active .uagb-icon {
+  display: none;
+  width: 0;
+  padding: 0;
+  height: 0;
+  margin: 0; }
+
+.wp-block-uagb-faq-child.uagb-faq-child__outer-wrap .uagb-faq-item .uagb-icon,
+.wp-block-uagb-faq-child.uagb-faq-child__outer-wrap .uagb-faq-item.uagb-faq-item-active .uagb-icon-active {
+  display: inline-block;
+  width: auto;
+  height: auto; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+.uagb-inline_notice__outer-wrap.uagb-inline_notice__align-right {
+  text-align: right; }
+  .uagb-inline_notice__outer-wrap.uagb-inline_notice__align-right span.uagb-notice-dismiss {
+    left: 13px; }
+
+.uagb-inline_notice__outer-wrap.uagb-inline_notice__align-center {
+  text-align: center; }
+  .uagb-inline_notice__outer-wrap.uagb-inline_notice__align-center span.uagb-notice-dismiss {
+    right: 13px; }
+
+.uagb-inline_notice__outer-wrap.uagb-inline_notice__align-left {
+  text-align: left; }
+  .uagb-inline_notice__outer-wrap.uagb-inline_notice__align-left span.uagb-notice-dismiss {
+    right: 13px; }
+
+.wp-block-uagb-inline-notice {
+  position: relative; }
+  .wp-block-uagb-inline-notice.uagb-notice__active {
+    display: none; }
+  .wp-block-uagb-inline-notice h4 {
+    margin: 0;
+    border-top-right-radius: 3px;
+    border-top-left-radius: 3px;
+    width: 100%;
+    display: inline-block; }
+  .wp-block-uagb-inline-notice .uagb-notice-text {
+    border: solid 2px #000;
+    border-bottom-right-radius: 3px;
+    border-bottom-left-radius: 3px; }
+  .wp-block-uagb-inline-notice span.uagb-notice-dismiss svg {
+    width: 16px;
+    height: 16px; }
+  .wp-block-uagb-inline-notice span.uagb-notice-dismiss {
+    position: absolute;
+    cursor: pointer;
+    top: 13px;
+    opacity: .8;
+    padding: 0;
+    background: none;
+    transition: .3s ease; }
+/**
+ * #.# Common SCSS
+ *
+ * Can include things like variables and mixins
+ * that are used across the project.
+*/
+.wp-block-uagb-wp-search.uagb-wp-search__outer-wrap {
+  min-height: 20px;
+  width: 100%; }
+  .wp-block-uagb-wp-search.uagb-wp-search__outer-wrap.uagb-layout-input-button .uagb-search-submit {
+    color: #fff;
+    border: none;
+    border-radius: 0; }
+  .wp-block-uagb-wp-search.uagb-wp-search__outer-wrap.uagb-layout-input-button svg {
+    fill: currentColor; }
+  .wp-block-uagb-wp-search.uagb-wp-search__outer-wrap.uagb-layout-input .uagb-wp-search-icon-wrap {
+    display: flex;
+    align-items: center; }
+  .wp-block-uagb-wp-search.uagb-wp-search__outer-wrap.uagb-layout-input svg {
+    fill: currentColor;
+    opacity: 0.6; }
+  .wp-block-uagb-wp-search.uagb-wp-search__outer-wrap .uagb-search-wrapper .uagb-search-form__container {
+    display: flex;
+    overflow: hidden; }
+    .wp-block-uagb-wp-search.uagb-wp-search__outer-wrap .uagb-search-wrapper .uagb-search-form__container .uagb-search-form__input {
+      width: 100%; }


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Allow links to be clickable within FAQ sections. The e.preventDefault(); in the FAQ click handler was preventing links from being opened as normal.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bug fix (non-breaking change which fixes an issue).

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Click the link. Expected behavior: link opens, faq section stays open. 
- Click on the open FAQ section but not the link. Expected behavior: faq section closes. Link is not open.

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
