### PR TITLE
Fix: Icon List Font Size rendered as PX when configured as EM

### DIFF
--- a/classes/class-uagb-block-helper.php
+++ b/classes/class-uagb-block-helper.php
@@ -2045,7 +2045,7 @@ if ( ! class_exists( 'UAGB_Block_Helper' ) ) {
 				$selectors[' .uagb-icon-list-repeater'] = array(
 					'font-family' => $attr['fontFamily'],
 					'font-weight' => $attr['fontWeight'],
-					'font-size'   => UAGB_Helper::get_css_value( $attr['fontSize'], $attr['sizeType'] ),
+					'font-size'   => UAGB_Helper::get_css_value( $attr['fontSize'], $attr['fontSizeType'] ),
 					'line-height' => $attr['lineHeight'] . $attr['lineHeightType'],
 				);
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -159,6 +159,9 @@ When you use the Ultimate Addons for Gutenberg along with the free Astra theme, 
 
 == Changelog ==
 
+= 1.17.0 =
+* Fix: Icon List - Icon List Font Size rendered as PX when configured as EM
+
 = 1.16.1 = 
 * Improvement: Post Masonry - Added Pagination option.
 * Improvement: Advanced Columns - New Gradient Palette is introduced to set background.


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Trello task - https://trello.com/c/gbEJBAjm

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Check font size type for the label is applied to correctly or not

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
