### PR TITLE
Improvement: faq.js is not needed in the grid layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ When you use the Ultimate Addons for Gutenberg along with the free Astra theme, 
 ### 1.19.0 ###
 * Improvement: Inline Notice - New layout added for inline notice.
 * Improvement: Twenty Seventeen Theme : Added compatibility to Twenty Seventeen Sections.
+* Improvement: FAQ Schema - Skipped loading of dependent JS file for Grid layout.
 * Fix: FAQ Schema - Toggle issue when we add multiple FAQ Blocks on same page.
 * Fix: Gravity Form Styler - Submit button text color issue.
 

--- a/classes/class-uagb-block-helper.php
+++ b/classes/class-uagb-block-helper.php
@@ -3843,8 +3843,8 @@ if ( ! class_exists( 'UAGB_Block_Helper' ) ) {
 					'padding-bottom'   => UAGB_Helper::get_css_value( $attr['buttonVrPadding'], 'px' ),
 				),
 
-				' .gform_footer.top_label input[type="submit"]'                    => array(
-					'font-size'        => UAGB_Helper::get_css_value( $attr['buttonFontSize'], $attr['buttonFontSizeType'] ),					
+				' .gform_footer.top_label input[type="submit"]' => array(
+					'font-size' => UAGB_Helper::get_css_value( $attr['buttonFontSize'], $attr['buttonFontSizeType'] ),
 				),
 
 				' input.gform_button:hover'              => array(

--- a/classes/class-uagb-helper.php
+++ b/classes/class-uagb-helper.php
@@ -205,11 +205,11 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 
 				foreach ( $js_assets as $asset_handle => $val ) {
 					// Scripts.
-					if( $val == 'uagb-faq-js'){
-						if( self::$uag_faq_layout ){
+					if ( $val === 'uagb-faq-js' ) {
+						if ( self::$uag_faq_layout ) {
 							wp_enqueue_script( 'uagb-faq-js' );
 						}
-					}else{
+					} else {
 						wp_enqueue_script( $val );
 					}
 				}
@@ -563,7 +563,7 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 
 				case 'uagb/faq':
 					$css += UAGB_Block_Helper::get_faq_css( $blockattr, $block_id );
-					if( !isset( $blockattr['layout'] ) ) {
+					if ( ! isset( $blockattr['layout'] ) ) {
 						self::$uag_faq_layout = true;
 					}
 					UAGB_Block_JS::blocks_faq_gfont( $blockattr );

--- a/classes/class-uagb-helper.php
+++ b/classes/class-uagb-helper.php
@@ -197,7 +197,24 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 
 				foreach ( $js_assets as $asset_handle => $val ) {
 					// Scripts.
-					wp_enqueue_script( $val );
+					if( $val === 'uagb-faq-js' ){
+
+						$post = get_post(); 
+
+						if ( has_blocks( $post->post_content ) ) {
+							$blocks_used_on_page = parse_blocks( $post->post_content );
+							
+							foreach ( $blocks_used_on_page as $key => $value ) {
+								if ( $blocks_used_on_page[$key]['blockName'] === 'uagb/faq' ) {
+									if( !isset($blocks_used_on_page[$key]['attrs']['layout']) ){
+										wp_enqueue_script(  'uagb-faq-js' );
+									}
+								}
+							}
+						}
+					}else{
+						wp_enqueue_script( $val );
+					}
 				}
 
 				foreach ( $css_assets as $asset_handle => $val ) {

--- a/classes/class-uagb-helper.php
+++ b/classes/class-uagb-helper.php
@@ -50,6 +50,14 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 		public static $uag_flag = false;
 
 		/**
+		 * UAG FAQ Layout Flag
+		 *
+		 * @since x.x.x
+		 * @var uag_faq_layout
+		 */
+		public static $uag_faq_layout = false;
+
+		/**
 		 * UAG File Generation Flag
 		 *
 		 * @since 1.14.0
@@ -197,20 +205,9 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 
 				foreach ( $js_assets as $asset_handle => $val ) {
 					// Scripts.
-					if( $val === 'uagb-faq-js' ){
-
-						$post = get_post(); 
-
-						if ( has_blocks( $post->post_content ) ) {
-							$blocks_used_on_page = parse_blocks( $post->post_content );
-							
-							foreach ( $blocks_used_on_page as $key => $value ) {
-								if ( $blocks_used_on_page[$key]['blockName'] === 'uagb/faq' ) {
-									if( !isset($blocks_used_on_page[$key]['attrs']['layout']) ){
-										wp_enqueue_script(  'uagb-faq-js' );
-									}
-								}
-							}
+					if( $val == 'uagb-faq-js'){
+						if( self::$uag_faq_layout ){
+							wp_enqueue_script( 'uagb-faq-js' );
 						}
 					}else{
 						wp_enqueue_script( $val );
@@ -566,6 +563,9 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 
 				case 'uagb/faq':
 					$css += UAGB_Block_Helper::get_faq_css( $blockattr, $block_id );
+					if( !isset( $blockattr['layout'] ) ) {
+						self::$uag_faq_layout = true;
+					}
 					UAGB_Block_JS::blocks_faq_gfont( $blockattr );
 					break;
 

--- a/readme.txt
+++ b/readme.txt
@@ -163,6 +163,7 @@ When you use the Ultimate Addons for Gutenberg along with the free Astra theme, 
 = 1.19.0 =
 * Improvement: Inline Notice - New layout added for inline notice.
 * Improvement: Twenty Seventeen Theme : Added compatibility to Twenty Seventeen Sections.
+* Improvement: FAQ Schema - Skipped loading of dependent JS file for Grid layout.
 * Fix: FAQ Schema - Toggle issue when we add multiple FAQ Blocks on same page.
 * Fix: Gravity Form Styler - Submit button text color issue.
 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Trello - https://trello.com/c/9d6p9eiC/110-faqjs-is-not-needed-in-the-grid-layout

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
- Improvement

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Used faq grid layout and check is it loading `uagb-faq-js` .
- Used some other block-like timeline, testimonials and inline notice. Is this block working when the faq layout is the grid?
- Use both faqs as grid and accordion and check accordion is working or not.

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
