### PR TITLE
Fix: Post Timeline - Removed filter for post timeline connector SVG.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ When you use the Ultimate Addons for Gutenberg along with the free Astra theme, 
 
 ## Changelog ##
 
+### 1.18.2 ###
+* Fix: Post Timeline - Removed filter for post timeline connector SVG.
+
 ### 1.18.1 ###
 * Improvement: FAQ Schema - Skipped loading of dependent JS file for Grid layout.
 * Improvement: FAQ Schema - Added keyboard accessibility of spacebar, enter and left-click.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Requires at least:** 4.7  
 **Requires PHP:** 5.6  
 **Tested up to:** 5.5  
-**Stable tag:** 1.18.1  
+**Stable tag:** 1.18.2  
 **License:** GPLv2 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -161,7 +161,7 @@ When you use the Ultimate Addons for Gutenberg along with the free Astra theme, 
 ## Changelog ##
 
 ### 1.18.2 ###
-* Fix: Post Timeline - Removed filter for post timeline connector SVG.
+* Fix: Post Timeline - Fixed the Icon issue and removed the unwanted filter for Post Timeline SVG connector.
 
 ### 1.18.1 ###
 * Improvement: FAQ Schema - Skipped loading of dependent JS file for Grid layout.

--- a/dist/blocks/post-timeline/class-uagb-post-timeline.php
+++ b/dist/blocks/post-timeline/class-uagb-post-timeline.php
@@ -616,11 +616,10 @@ if ( ! class_exists( 'UAGB_Post_Timeline' ) ) {
 		 * @param  array $attributes attribute array.
 		 */
 		public function get_icon( $attributes ) {
-			$icon = apply_filters( 'uagb_timeline_icon_filter', UAGB_Helper::render_svg_html( $attributes['icon'] ) );
 			?>
 			<div class = "uagb-timeline__marker uagb-timeline__out-view-icon" >
-			<?php if ( isset( $icon ) ) { ?>
-				<span class = "uagb-timeline__icon-new uagb-timeline__out-view-icon" ><?php echo $icon; //phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?></span> 
+			<?php if ( has_filter('uagb_timeline_icon_filter') ) { ?>
+				<span class = "uagb-timeline__icon-new uagb-timeline__out-view-icon" ><?php echo apply_filters( 'uagb_timeline_icon_filter', $attributes['icon'] ); ?></span> 
 			<?php	} else { ?>
 				<span class = "uagb-timeline__icon-new uagb-timeline__out-view-icon" ><?php UAGB_Helper::render_svg_html( $attributes['icon'] ); ?></span>
 			<?php	} ?>

--- a/dist/blocks/post-timeline/class-uagb-post-timeline.php
+++ b/dist/blocks/post-timeline/class-uagb-post-timeline.php
@@ -618,11 +618,7 @@ if ( ! class_exists( 'UAGB_Post_Timeline' ) ) {
 		public function get_icon( $attributes ) {
 			?>
 			<div class = "uagb-timeline__marker uagb-timeline__out-view-icon" >
-			<?php if ( has_filter('uagb_timeline_icon_filter') ) { ?>
-				<span class = "uagb-timeline__icon-new uagb-timeline__out-view-icon" ><?php echo apply_filters( 'uagb_timeline_icon_filter', $attributes['icon'] ); ?></span> 
-			<?php	} else { ?>
 				<span class = "uagb-timeline__icon-new uagb-timeline__out-view-icon" ><?php UAGB_Helper::render_svg_html( $attributes['icon'] ); ?></span>
-			<?php	} ?>
 			</div>
 			<?php
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: gutenberg, blocks, gutenberg blocks, editor, block
 Requires at least: 4.7
 Requires PHP: 5.6
 Tested up to: 5.5
-Stable tag: 1.18.1
+Stable tag: 1.18.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -161,7 +161,7 @@ When you use the Ultimate Addons for Gutenberg along with the free Astra theme, 
 == Changelog ==
 
 = 1.18.2 =
-* Fix: Post Timeline - Removed filter for post timeline connector SVG.
+* Fix: Post Timeline - Fixed the Icon issue and removed the unwanted filter for Post Timeline SVG connector.
 
 = 1.18.1 =
 * Improvement: FAQ Schema - Skipped loading of dependent JS file for Grid layout.

--- a/readme.txt
+++ b/readme.txt
@@ -160,6 +160,9 @@ When you use the Ultimate Addons for Gutenberg along with the free Astra theme, 
 
 == Changelog ==
 
+= 1.18.2 =
+* Fix: Post Timeline - Removed filter for post timeline connector SVG.
+
 = 1.18.1 =
 * Improvement: FAQ Schema - Skipped loading of dependent JS file for Grid layout.
 * Improvement: FAQ Schema - Added keyboard accessibility of spacebar, enter and left-click.


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
- Remove filter for the post timeline icon. 

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- No test cases

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
