### PR TITLE
Fix: h_tag is not defined issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,9 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 ## Changelog ##
 
 ### 1.20.1 ###
-* Fix: Table of content - Fixed the issue of hyperlink scroll to heading.
+* Fix: Content Timeline - Content not being saved issue.
+* Fix: Post Carousel - Posts layout breaks when equal height option is enabled.
+* Fix: Table of Content - Hyperlink not being scrolled to respective heading issue.
 
 ### 1.20.0 ###
 * New: Lottie Block.

--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 
 ## Changelog ##
 
+### 1.20.1 ###
+* Fix: Table of content - Fixed the issue of hyperlink scroll to heading.
+
 ### 1.20.0 ###
 * New: Lottie Block.
 * Improvement: Post Layout: Added EditMode to shuffle the Post elements i.e Post Title, Post Meta, Post Content, Featured Image, CTA Button etc.

--- a/assets/js/table-of-contents.js
+++ b/assets/js/table-of-contents.js
@@ -124,7 +124,11 @@
 			
 			if ( undefined !== attr.mappingHeaders ) {
 
-				attr.mappingHeaders.forEach((h_tag, index) ( h_tag === true ? allowed_h_tags.push('h' + (index+1)) : null) );
+				attr.mappingHeaders.forEach(
+					function( h_tag, index ) {
+						allowed_h_tags = ( h_tag === true ? allowed_h_tags.push('h' + (index+1)) : null); 
+					}
+				);
 				var allowed_h_tags_str = ( null !== allowed_h_tags ) ? allowed_h_tags.join( ',' ) : '';
 			}
 

--- a/assets/js/table-of-contents.js
+++ b/assets/js/table-of-contents.js
@@ -124,11 +124,7 @@
 			
 			if ( undefined !== attr.mappingHeaders ) {
 
-				attr.mappingHeaders.forEach(
-					function( h_tag, index ) {
-						allowed_h_tags = ( h_tag === true ? allowed_h_tags.push('h' + (index+1)) : null); 
-					}
-				);
+				attr.mappingHeaders.forEach(function(h_tag, index) { (h_tag === true ? allowed_h_tags.push('h' + (index+1)) : null);});
 				var allowed_h_tags_str = ( null !== allowed_h_tags ) ? allowed_h_tags.join( ',' ) : '';
 			}
 

--- a/readme.txt
+++ b/readme.txt
@@ -167,7 +167,9 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 == Changelog ==
 
 = 1.20.1 =
-* Fix: Table of content - Fixed the issue of hyperlink scroll to heading.
+* Fix: Content Timeline - Content not being saved issue.
+* Fix: Post Carousel - Posts layout breaks when equal height option is enabled.
+* Fix: Table of Content - Hyperlink not being scrolled to respective heading issue.
 
 = 1.20.0 =
 * New: Lottie Block.

--- a/readme.txt
+++ b/readme.txt
@@ -166,6 +166,9 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 
 == Changelog ==
 
+= 1.20.1 =
+* Fix: Table of content - Fixed the issue of hyperlink scroll to heading.
+
 = 1.20.0 =
 * New: Lottie Block.
 * Improvement: Post Layout: Added EditMode to shuffle the Post elements i.e Post Title, Post Meta, Post Content, Featured Image, CTA Button etc.


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
- h_tag is not defined issue
- https://trello.com/c/EOWyiaqf/185-issue-of-toc-hyperlink-scroll-to-heading

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
- Breaking change

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
