### PR TITLE
Fix: post masonry post_type undefined issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 ## Changelog ##
 
 ### 1.22.0 ###
-* Fix: Post Masonary - post_type undefined issue.
+* Fix: Post Layouts - Fixed the JS undefined error with `post_type` in block editor while using Post Masonry.
 
 ### 1.21.0 ###
 * New: Tabs Block. [Read More](https://ultimategutenberg.com/tabs/)

--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 
 ## Changelog ##
 
+### 1.22.0 ###
+* Fix: Post Masonary - post_type undefined issue.
+
 ### 1.21.0 ###
 * New: Tabs Block. [Read More](https://ultimategutenberg.com/tabs/)
 * New: Added ability to import pre-made pages, patterns for block editor.

--- a/classes/class-uagb-config.php
+++ b/classes/class-uagb-config.php
@@ -1377,6 +1377,7 @@ if ( ! class_exists( 'UAGB_Config' ) ) {
 						'js_assets'   => array( 'uagb-slick-js', 'uagb-post-js', 'uagb-imagesloaded' ),
 						'css_assets'  => array( 'uagb-slick-css' ),
 						'attributes'  => array(
+							'post_type'			      => 'carousel',
 							'inheritFromTheme'        => false,
 							'align'                   => 'left',
 							'rowGap'                  => '20',
@@ -1477,6 +1478,7 @@ if ( ! class_exists( 'UAGB_Config' ) ) {
 						'default'     => true,
 						'extension'   => false,
 						'attributes'  => array(
+							'post_type'					  => 'grid',
 							'inheritFromTheme'            => false,
 							'align'                       => 'left',
 							'rowGap'                      => '20',
@@ -1589,6 +1591,7 @@ if ( ! class_exists( 'UAGB_Config' ) ) {
 						'extension'   => false,
 						'js_assets'   => array( 'uagb-masonry', 'uagb-imagesloaded', 'uagb-post-js' ),
 						'attributes'  => array(
+							'post_type'			           => 'masonry',
 							'postType'                     => 'post',
 							'inheritFromTheme'             => false,
 							'align'                        => 'left',

--- a/dist/blocks/post/class-uagb-post.php
+++ b/dist/blocks/post/class-uagb-post.php
@@ -153,6 +153,10 @@ if ( ! class_exists( 'UAGB_Post' ) ) {
 									array( 'uagb/post-button' ),
 								),
 							),
+							'post_type'                => array(
+								'type'    => 'string',
+								'default' => 'grid',
+							),
 						)
 					),
 					'render_callback' => array( $this, 'post_grid_callback' ),
@@ -218,6 +222,10 @@ if ( ! class_exists( 'UAGB_Post' ) ) {
 									array( 'uagb/post-excerpt' ),
 									array( 'uagb/post-button' ),
 								),
+							),
+							'post_type'                => array(
+								'type'    => 'string',
+								'default' => 'carousel',
 							),
 						)
 					),
@@ -326,6 +334,10 @@ if ( ! class_exists( 'UAGB_Post' ) ) {
 									array( 'uagb/post-excerpt' ),
 									array( 'uagb/post-button' ),
 								),
+							),
+							'post_type'                => array(
+								'type'    => 'string',
+								'default' => 'masonry',
 							),
 						)
 					),

--- a/readme.txt
+++ b/readme.txt
@@ -168,7 +168,7 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 == Changelog ==
 
 = 1.22.0 =
-* Fix: Post Masonary - post_type undefined issue.
+* Fix: Post Layouts - Fixed the JS undefined error with `post_type` in block editor while using Post Masonry.
 
 = 1.21.0 =
 * New: Tabs Block. [Read More](https://ultimategutenberg.com/tabs/)

--- a/readme.txt
+++ b/readme.txt
@@ -167,6 +167,9 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 
 == Changelog ==
 
+= 1.22.0 =
+* Fix: Post Masonary - post_type undefined issue.
+
 = 1.21.0 =
 * New: Tabs Block. [Read More](https://ultimategutenberg.com/tabs/)
 * New: Added ability to import pre-made pages, patterns for block editor.


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Trello - https://trello.com/c/ieHPjlAD/207-post-masonry-posttype-undefined-issue 

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
- Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Drag and drop masonry set pagination to Scroll or Load more.
- Visit frontend. scroll or click on load more and check the debug log.
- You will see the post_type undefined.
- Clear the debug log and Switch to this `post-type-undefined-in-masonry branch and refresh the page and check the debug log.

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
