### PR TITLE
Fix Gutenberg template issue on multisite.

### DIFF
--- a/lib/ast-block-templates/classes/class-ast-block-templates.php
+++ b/lib/ast-block-templates/classes/class-ast-block-templates.php
@@ -383,7 +383,7 @@ if ( ! class_exists( 'Ast_Block_Templates' ) ) :
 						'white_label_name'        => '',
 						'allBlocks'               => $this->get_all_blocks(),
 						'allSites'                => $this->get_all_sites(),
-						'allCategories'           => get_option( 'ast-block-templates-categories', array() ),
+						'allCategories'           => get_site_option( 'ast-block-templates-categories', array() ),
 						'wpforms_status'          => $this->get_plugin_status( 'wpforms-lite/wpforms.php' ),
 						'gutenberg_status'        => $this->get_plugin_status( 'gutenberg/gutenberg.php' ),
 						'_ajax_nonce'             => wp_create_nonce( 'ast-block-templates-ajax-nonce' ),


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
- Trello - https://trello.com/c/Lzpnj7F6/318-fix-uag-template-pattern-categorie-label-not-visible-in-template-popup

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
- Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Check the same branch on a single site and multisite.
- If the label not visible then sync and refresh the page and try again

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
