### PR TITLE
fix: Webpack dynamic public path

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,10 +1,11 @@
 module.exports = {
 	extends: [ 'plugin:@wordpress/eslint-plugin/recommended' ],
-	"ignorePatterns": ["deprecated.js"],
+	ignorePatterns: [ 'deprecated.js' ],
 	rules: {
-		'camelcase': 'off',
+		camelcase: 'off',
 	},
-	"globals": {
-		"uagb_blocks_info": true,
-	}
+	globals: {
+		uagb_blocks_info: true,
+		__webpack_public_path__: true,
+	},
 };

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -8,60 +8,62 @@
  * All blocks should be included here since this is the file that
  * Webpack is compiling as the input file.
  */
-import "./blocks/extensions/attributes.js"
-import "./blocks/advanced-heading/block.js"
-import "./blocks/post/block.js"
-import "./blocks/section/block.js"
-import "./blocks/buttons/block.js"
-import "./blocks/buttons-child/block.js"
-import "./blocks/info-box/block.js"
-import "./blocks/testimonial/block.js"
-import "./blocks/team/block.js"
-import "./blocks/social-share/block.js"
-import "./blocks/social-share-child/block.js"
-import "./blocks/google-map/block.js"
-import "./blocks/icon-list/block.js"
-import "./blocks/icon-list-child/block.js"
-import "./blocks/price-list/block.js"
-import "./blocks/price-list-child/block.js"
-import "./blocks/timeline/block.js"
-import "./blocks/call-to-action/block.js"
-import "./blocks/column/block.js"
-import "./blocks/columns/block.js"
-import "./blocks/cf7-styler/block.js"
-import "./blocks/gf-styler/block.js"
-import "./blocks/blockquote/block.js"
-import "./blocks/marketing-button/block.js"
-import "./blocks/table-of-contents/block.js"
-import "./blocks/how-to/block.js"
-import "./blocks/faq/block.js"
-import "./blocks/faq-child/block.js"
-import "./blocks/inline-notice/block.js"
-import "./blocks/wp-search/block.js"
-import "./blocks/review/block.js"
-import "./blocks/taxonomy-list/block.js"
-import "./blocks/forms/block.js"
-import "./blocks/forms/child-blocks/name/block.js"
-import "./blocks/forms/child-blocks/email/block.js"
-import "./blocks/forms/child-blocks/hidden/block.js"
-import "./blocks/forms/child-blocks/phone/block.js"
-import "./blocks/forms/child-blocks/textarea/block.js"
-import "./blocks/forms/child-blocks/checkbox/block.js"
-import "./blocks/forms/child-blocks/radio/block.js"
-import "./blocks/forms/child-blocks/url/block.js"
-import "./blocks/forms/child-blocks/select/block.js"
-import "./blocks/forms/child-blocks/toggle/block.js"
-import "./blocks/forms/child-blocks/date/block.js"
-import "./blocks/forms/child-blocks/accept/block.js"
-import "./blocks/extensions/block.js"
-import "./blocks/tabs/block.js"
-import "./blocks/tabs-child/block.js"
-import "./blocks/lottie/block.js"
+__webpack_public_path__ = uagb_blocks_info.uagb_url + 'dist/build/';
 
-import UAGB_Block_Icons from "@Controls/block-icons"
+import './blocks/extensions/attributes.js';
+import './blocks/advanced-heading/block.js';
+import './blocks/post/block.js';
+import './blocks/section/block.js';
+import './blocks/buttons/block.js';
+import './blocks/buttons-child/block.js';
+import './blocks/info-box/block.js';
+import './blocks/testimonial/block.js';
+import './blocks/team/block.js';
+import './blocks/social-share/block.js';
+import './blocks/social-share-child/block.js';
+import './blocks/google-map/block.js';
+import './blocks/icon-list/block.js';
+import './blocks/icon-list-child/block.js';
+import './blocks/price-list/block.js';
+import './blocks/price-list-child/block.js';
+import './blocks/timeline/block.js';
+import './blocks/call-to-action/block.js';
+import './blocks/column/block.js';
+import './blocks/columns/block.js';
+import './blocks/cf7-styler/block.js';
+import './blocks/gf-styler/block.js';
+import './blocks/blockquote/block.js';
+import './blocks/marketing-button/block.js';
+import './blocks/table-of-contents/block.js';
+import './blocks/how-to/block.js';
+import './blocks/faq/block.js';
+import './blocks/faq-child/block.js';
+import './blocks/inline-notice/block.js';
+import './blocks/wp-search/block.js';
+import './blocks/review/block.js';
+import './blocks/taxonomy-list/block.js';
+import './blocks/forms/block.js';
+import './blocks/forms/child-blocks/name/block.js';
+import './blocks/forms/child-blocks/email/block.js';
+import './blocks/forms/child-blocks/hidden/block.js';
+import './blocks/forms/child-blocks/phone/block.js';
+import './blocks/forms/child-blocks/textarea/block.js';
+import './blocks/forms/child-blocks/checkbox/block.js';
+import './blocks/forms/child-blocks/radio/block.js';
+import './blocks/forms/child-blocks/url/block.js';
+import './blocks/forms/child-blocks/select/block.js';
+import './blocks/forms/child-blocks/toggle/block.js';
+import './blocks/forms/child-blocks/date/block.js';
+import './blocks/forms/child-blocks/accept/block.js';
+import './blocks/extensions/block.js';
+import './blocks/tabs/block.js';
+import './blocks/tabs-child/block.js';
+import './blocks/lottie/block.js';
 
-const { updateCategory } = wp.blocks
+import UAGB_Block_Icons from '@Controls/block-icons';
 
-updateCategory( "uagb", {
+import { updateCategory } from '@wordpress/blocks';
+
+updateCategory( 'uagb', {
 	icon: UAGB_Block_Icons.logo,
-}, )
+} );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,34 +1,30 @@
-const defaultConfig = require("@wordpress/scripts/config/webpack.config");
-const path = require( "path" );
-const CHUNK_DIR  = '/wp-content' + path.resolve( __dirname, 'dist/build' ).split('wp-content').pop() + '/';
-const LodashModuleReplacementPlugin = require('lodash-webpack-plugin');
+const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
+const path = require( 'path' );
+const LodashModuleReplacementPlugin = require( 'lodash-webpack-plugin' );
 // const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
-
 
 module.exports = {
 	...defaultConfig,
-	plugins:[
+	plugins: [
 		...defaultConfig.plugins,
-		new LodashModuleReplacementPlugin,
+		new LodashModuleReplacementPlugin(),
 		// new BundleAnalyzerPlugin,
 	],
 	entry: {
-		"blocks": path.resolve(
-			__dirname,
-			'src/blocks.js'
-		),
+		blocks: path.resolve( __dirname, 'src/blocks.js' ),
 	},
 	resolve: {
 		alias: {
 			...defaultConfig.resolve.alias,
-			'@Controls': path.resolve( __dirname, 'blocks-config/uagb-controls/' ),
+			'@Controls': path.resolve(
+				__dirname,
+				'blocks-config/uagb-controls/'
+			),
 			'@Components': path.resolve( __dirname, 'src/components/' ),
 		},
 	},
 	output: {
-		filename: "[name].js",
-		// eslint-disable-next-line no-undef
-		path:  __dirname + "/dist/build",
-		publicPath: CHUNK_DIR
-	}
-}
+		filename: '[name].js',
+		path: __dirname + '/dist/build',
+	},
+};


### PR DESCRIPTION
### Description
- Webpack chunk breaking on Multisite and Sub folder domain and non-virtual cases due to static public path of the chunk.

### Screenshots
- NA

### Types of changes
- Added a public path dynamically.

### How has this been tested?
- NA

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
