### PR TITLE
Fix: Undefined index notice for disable blocks on fresh setup.

### DIFF
--- a/classes/class-uagb-init-blocks.php
+++ b/classes/class-uagb-init-blocks.php
@@ -312,7 +312,7 @@ class UAGB_Init_Blocks {
 
 		// We can remove this code after 2-3 releases.
 
-		if ( 'disabled' === $disabled_blocks['info-box'] ) {
+		if ( isset( $disabled_blocks['info-box'] ) && 'disabled' === $disabled_blocks['info-box'] ) {
 
 			$disabled_blocks['info-box'] = 'info-box';
 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
- Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Tested on fresh setup with Toolset content template and WP Archive pages.
- Display deprecated PHP notices for uagb function and class name change.
- All is working fine.

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
