### PR TITLE
Fix deprecated function return nothing.

### DIFF
--- a/classes/class-uagb-helper.php
+++ b/classes/class-uagb-helper.php
@@ -986,7 +986,7 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 		public function get_generated_stylesheet( $this_post ) {
 			_deprecated_function( __METHOD__, '1.23.0', 'UAGB_Frontend::get_instance()->prepare_assets()' );
 
-			UAGB_Frontend::get_instance()->prepare_assets( $this_post );
+			return UAGB_Frontend::get_instance()->prepare_assets( $this_post );
 		}
 
 		/**
@@ -1000,7 +1000,7 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 		public function get_assets( $blocks ) {
 			_deprecated_function( __METHOD__, '1.23.0', 'UAGB_Frontend::get_instance()->get_blocks_assets()' );
 
-			UAGB_Frontend::get_instance()->get_blocks_assets( $blocks );
+			return UAGB_Frontend::get_instance()->get_blocks_assets( $blocks );
 		}
 
 		/**
@@ -1014,7 +1014,7 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 		public function parse( $content ) {
 			_deprecated_function( __METHOD__, '1.23.0', 'UAGB_Frontend::get_instance()->parse_blocks()' );
 
-			UAGB_Frontend::get_instance()->parse_blocks( $content );
+			return UAGB_Frontend::get_instance()->parse_blocks( $content );
 		}
 		/**
 		 * This is the action where we create dynamic asset files.
@@ -1027,7 +1027,7 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 		public function generate_asset_files() {
 			_deprecated_function( __METHOD__, '1.23.0', 'UAGB_Frontend::get_instance()->generate_asset_files()' );
 
-			UAGB_Frontend::get_instance()->generate_asset_files();
+			return UAGB_Frontend::get_instance()->generate_asset_files();
 		}
 		/**
 		 * Enqueue Gutenberg block assets for both frontend + backend.
@@ -1038,7 +1038,7 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 		public function block_assets() {
 			_deprecated_function( __METHOD__, '1.23.0', 'UAGB_Frontend::get_instance()->enqueue_block_assets()' );
 
-			UAGB_Frontend::get_instance()->enqueue_block_assets();
+			return UAGB_Frontend::get_instance()->enqueue_block_assets();
 
 		}
 		/**
@@ -1050,7 +1050,7 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 		public function print_script() {
 			_deprecated_function( __METHOD__, '1.23.0', 'UAGB_Frontend::get_instance()->print_script()' );
 
-			UAGB_Frontend::get_instance()->print_script();
+			return UAGB_Frontend::get_instance()->print_script();
 
 		}
 		/**
@@ -1062,7 +1062,7 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 		public function print_stylesheet() {
 			_deprecated_function( __METHOD__, '1.23.0', 'UAGB_Frontend::get_instance()->print_stylesheet()' );
 
-			UAGB_Frontend::get_instance()->print_stylesheet();
+			return UAGB_Frontend::get_instance()->print_stylesheet();
 
 		}
 		/**
@@ -1074,7 +1074,7 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 		public function frontend_gfonts() {
 			_deprecated_function( __METHOD__, '1.23.0', 'UAGB_Frontend::get_instance()->print_google_fonts()' );
 
-			UAGB_Frontend::get_instance()->print_google_fonts();
+			return UAGB_Frontend::get_instance()->print_google_fonts();
 
 		}
 		/**
@@ -1087,7 +1087,7 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 		public function get_block_css_and_js( $block ) {
 			_deprecated_function( __METHOD__, '1.23.0', 'UAGB_Frontend::get_instance()->get_block_css_and_js()' );
 
-			UAGB_Frontend::get_instance()->get_block_css_and_js( $block );
+			return UAGB_Frontend::get_instance()->get_block_css_and_js( $block );
 		}
 		/**
 		 * Generates stylesheet and appends in head tag.
@@ -1098,7 +1098,7 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 		public function generate_assets() {
 			_deprecated_function( __METHOD__, '1.23.0', 'UAGB_Frontend::get_instance()->generate_assets()' );
 
-			UAGB_Frontend::get_instance()->generate_assets();
+			return UAGB_Frontend::get_instance()->generate_assets();
 		}
 	}
 

--- a/classes/class-uagb-helper.php
+++ b/classes/class-uagb-helper.php
@@ -986,7 +986,7 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 		public function get_generated_stylesheet( $this_post ) {
 			_deprecated_function( __METHOD__, '1.23.0', 'UAGB_Frontend::get_instance()->prepare_assets()' );
 
-			return UAGB_Frontend::get_instance()->prepare_assets( $this_post );
+			UAGB_Frontend::get_instance()->prepare_assets( $this_post );
 		}
 
 		/**
@@ -1027,7 +1027,7 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 		public function generate_asset_files() {
 			_deprecated_function( __METHOD__, '1.23.0', 'UAGB_Frontend::get_instance()->generate_asset_files()' );
 
-			return UAGB_Frontend::get_instance()->generate_asset_files();
+			UAGB_Frontend::get_instance()->generate_asset_files();
 		}
 		/**
 		 * Enqueue Gutenberg block assets for both frontend + backend.
@@ -1038,7 +1038,7 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 		public function block_assets() {
 			_deprecated_function( __METHOD__, '1.23.0', 'UAGB_Frontend::get_instance()->enqueue_block_assets()' );
 
-			return UAGB_Frontend::get_instance()->enqueue_block_assets();
+			UAGB_Frontend::get_instance()->enqueue_block_assets();
 
 		}
 		/**
@@ -1050,7 +1050,7 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 		public function print_script() {
 			_deprecated_function( __METHOD__, '1.23.0', 'UAGB_Frontend::get_instance()->print_script()' );
 
-			return UAGB_Frontend::get_instance()->print_script();
+			UAGB_Frontend::get_instance()->print_script();
 
 		}
 		/**
@@ -1062,7 +1062,7 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 		public function print_stylesheet() {
 			_deprecated_function( __METHOD__, '1.23.0', 'UAGB_Frontend::get_instance()->print_stylesheet()' );
 
-			return UAGB_Frontend::get_instance()->print_stylesheet();
+			UAGB_Frontend::get_instance()->print_stylesheet();
 
 		}
 		/**
@@ -1074,7 +1074,7 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 		public function frontend_gfonts() {
 			_deprecated_function( __METHOD__, '1.23.0', 'UAGB_Frontend::get_instance()->print_google_fonts()' );
 
-			return UAGB_Frontend::get_instance()->print_google_fonts();
+			UAGB_Frontend::get_instance()->print_google_fonts();
 
 		}
 		/**
@@ -1098,7 +1098,7 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 		public function generate_assets() {
 			_deprecated_function( __METHOD__, '1.23.0', 'UAGB_Frontend::get_instance()->generate_assets()' );
 
-			return UAGB_Frontend::get_instance()->generate_assets();
+			UAGB_Frontend::get_instance()->generate_assets();
 		}
 	}
 


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
- While testing Astra Custom Layout  we get an issue `Invalid value supplied to an for each()`

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
- Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Created custom layout using Astra addon.
- Drag and drop blocks add styling and all is working fine.
- No issue and our deprecated notices for function and classes visible in debug log.

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
