### PR TITLE
Fix invalid HTML markup in Post block

### DIFF
--- a/blocks-config/post/class-uagb-post.php
+++ b/blocks-config/post/class-uagb-post.php
@@ -1359,7 +1359,7 @@ if ( ! class_exists( 'UAGB_Post' ) ) {
 				foreach ( $terms as $key => $value ) {
 					// Get the URL of this category.
 					$category_link = get_category_link( $value->term_id );
-					array_push( $terms_list, '<a href=' . esc_url( $category_link ) . '>' . esc_html( $value->name ) . '</a>' );
+					array_push( $terms_list, '<a href="' . esc_url( $category_link ) . '">' . esc_html( $value->name ) . '</a>' );
 				}
 				echo wp_kses_post( implode( ', ', $terms_list ) );
 				?>


### PR DESCRIPTION
The post meta link anchor tag was missing the `"`s around the URL causing HTML validation to fail.

### Description
Added the missing `"` characters around the URL.

### Types of changes
Bug fix

### How has this been tested?
Manually.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
