### PR TITLE
Fix undefined `this_post` issue when Woocommece is install and the current page is not from WooCommerce.

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 * Fix: Lottie - Alignment issue in the editor.
 * Fix: Post Grid - Link to complete box redirect to the last post when image background set to Top.
 * Fix: Post Layout - Conflicting with the Envira Gallery plugin.
-* Fix: Post Layout - Invalid HTML markup in Post block.
+* Fix: Post Layout - Invalid HTML markup of a post meta link.
 * Fix: Section - Margin Left/Right not working issue.
 * Fix: Social Share - Query string variables were omitted after the first ampersand. Encoded the Page/Post URL.
 * Fix: Table of content - HTML validation issue.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Requires at least:** 4.7  
 **Requires PHP:** 5.6  
 **Tested up to:** 5.7  
-**Stable tag:** 1.23.0  
+**Stable tag:** 1.23.0-beta.1  
 **License:** GPLv2 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html  
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Requires at least:** 4.7  
 **Requires PHP:** 5.6  
 **Tested up to:** 5.7  
-**Stable tag:** 1.23.0-beta.1  
+**Stable tag:** 1.23.0  
 **License:** GPLv2 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -187,6 +187,7 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 * Fix: Lottie - Alignment issue in the editor.
 * Fix: Post Grid - Link to complete box redirect to the last post when image background set to Top.
 * Fix: Post Layout - Conflicting with the Envira Gallery plugin.
+* Fix: Post Layout - Invalid HTML markup in Post block.
 * Fix: Section - Margin Left/Right not working issue.
 * Fix: Social Share - Query string variables were omitted after the first ampersand. Encoded the Page/Post URL.
 * Fix: Table of content - HTML validation issue.

--- a/classes/class-uagb-front-assets.php
+++ b/classes/class-uagb-front-assets.php
@@ -107,7 +107,7 @@ class UAGB_Front_Assets {
 				$this_post = get_post( $id );
 			}
 
-			if ( is_object( $this_post ) ) {
+			if (  ! empty( $this_post ) && is_object( $this_post ) ) {
 				$this->post_assets->prepare_assets( $this_post );
 			}
 		}

--- a/classes/class-uagb-front-assets.php
+++ b/classes/class-uagb-front-assets.php
@@ -107,7 +107,7 @@ class UAGB_Front_Assets {
 				$this_post = get_post( $id );
 			}
 
-			if (  ! empty( $this_post ) && is_object( $this_post ) ) {
+			if ( ! empty( $this_post ) && is_object( $this_post ) ) {
 				$this->post_assets->prepare_assets( $this_post );
 			}
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -187,7 +187,7 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 * Fix: Lottie - Alignment issue in the editor.
 * Fix: Post Grid - Link to complete box redirect to the last post when image background set to Top.
 * Fix: Post Layout - Conflicting with the Envira Gallery plugin.
-* Fix: Post Layout - Invalid HTML markup in Post block.
+* Fix: Post Layout - Invalid HTML markup of a post meta link.
 * Fix: Section - Margin Left/Right not working issue.
 * Fix: Social Share - Query string variables were omitted after the first ampersand. Encoded the Page/Post URL.
 * Fix: Table of content - HTML validation issue.

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: gutenberg, blocks, gutenberg blocks, editor, block
 Requires at least: 4.7
 Requires PHP: 5.6
 Tested up to: 5.7
-Stable tag: 1.23.0
+Stable tag: 1.23.0-beta.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -187,6 +187,7 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 * Fix: Lottie - Alignment issue in the editor.
 * Fix: Post Grid - Link to complete box redirect to the last post when image background set to Top.
 * Fix: Post Layout - Conflicting with the Envira Gallery plugin.
+* Fix: Post Layout - Invalid HTML markup in Post block.
 * Fix: Section - Margin Left/Right not working issue.
 * Fix: Social Share - Query string variables were omitted after the first ampersand. Encoded the Page/Post URL.
 * Fix: Table of content - HTML validation issue.


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
- Woocommece is installed and the current page is not from WooCOmmerce that's why it's throwing an issue. And It displays only on the first load.
- Added [changelog](https://github.com/brainstormforce/ultimate-addons-for-gutenberg/pull/713) for Invalid HTML markup of a post meta link.

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
- Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- install the WooCommerce plugin.
- Visit any page which is not from WooCommerce.

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
