### PR TITLE
fix: Updated webpack configs to avoid conflicts with 3rd party plugins.

### DIFF
--- a/dist/blocks.asset.php
+++ b/dist/blocks.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'react-dom', 'wp-blocks', 'wp-element', 'wp-i18n', 'wp-polyfill'), 'version' => '8f966fa534c603a0640cc6456e355b8c');
+<?php return array('dependencies' => array('react', 'react-dom', 'wp-blocks', 'wp-element', 'wp-i18n', 'wp-polyfill'), 'version' => 'c666d0e5425ec94d5678ba3c1863fcf3');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,8 +16,8 @@ module.exports = {
 		},
 	},
 	output: {
-		filename: "[name].js",
-		// eslint-disable-next-line no-undef
-		path:  __dirname + "/dist"
-	}
+        ...defaultConfig.output,
+        // eslint-disable-next-line no-undef
+        path: path.resolve( __dirname, 'dist' )
+    }
 }


### PR DESCRIPTION
### Description
PR - https://trello.com/c/VICNcebX/187-blocks-on-registered-when-kadence-blocks-plugin-is-active

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
 - Check with the Kadence plugin active if our blocks get registered or not.

### Checklist:
- [x] My code is tested
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
