### PR TITLE
Fixed broken asset path when file name is empty

### DIFF
--- a/classes/class-uagb-scripts-utils.php
+++ b/classes/class-uagb-scripts-utils.php
@@ -156,11 +156,19 @@ final class UAGB_Scripts_Utils {
 	public static function get_asset_info( $type, $post_id ) {
 
 		$uploads_dir = UAGB_Helper::get_upload_dir();
-		$info        = array();
+		$file_name   = get_post_meta( $post_id, '_uag_' . $type . '_file_name', true );
+		$path        = $type;
+		$url         = $type . '_url';
 
-		$path                   = get_post_meta( $post_id, '_uag_' . $type . '_file_name', true );
-		$info[ $type ]          = $uploads_dir['path'] . $path;
-		$info[ $type . '_url' ] = $uploads_dir['url'] . $path;
+		$info = array(
+			$path => '',
+			$url  => '',
+		);
+
+		if ( ! empty( $file_name ) ) {
+			$info[ $path ] = $uploads_dir['path'] . $file_name;
+			$info[ $url ]  = $uploads_dir['url'] . $file_name;
+		}
 
 		return $info;
 	}


### PR DESCRIPTION
### Description
Fixed broken asset path when filename is empty

### Types of changes
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
