### PR TITLE
Fix: Post layout - Excerpt logic broken issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 
 ## Changelog ##
 
+### 1.23.2 ###
+* Fix: Post layout - Excerpt logic broken issue.
+
 ### 1.23.1 ###
 * Fix: Broken path while generating assets (CSS/JS).
 * Fix: Table of Contents - Heading convert to question marks on the frontend.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,6 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 ## Changelog ##
 
 ### 1.23.2 ###
-* Fix: Post layout - Excerpt logic broken issue.
 * Fix: Table of Contents: Headings with HTML tags are not visible on the frontend.
 * Fix: Table of Contents - Question marks are rendered in place of UTF-8 characters for few languages in Heading.
 * Fix: Section - Full-Width option not being applied on the front-end according to theme content width.

--- a/blocks-config/post/class-uagb-post.php
+++ b/blocks-config/post/class-uagb-post.php
@@ -1455,7 +1455,7 @@ if ( ! class_exists( 'UAGB_Post' ) ) {
 			$length = ( isset( $attributes['excerptLength'] ) ) ? $attributes['excerptLength'] : 25;
 
 			if ( 'full_post' === $attributes['displayPostContentRadio'] ) {
-				$excerpt = get_the_content();
+				$excerpt = strip_shortcodes( get_the_content() );
 			} else {
 				$excerpt = $this->get_excerpt_by_id( $post->ID, $length );
 			}

--- a/blocks-config/post/class-uagb-post.php
+++ b/blocks-config/post/class-uagb-post.php
@@ -1425,7 +1425,7 @@ if ( ! class_exists( 'UAGB_Post' ) ) {
 		 */
 		public function get_excerpt_by_id( $post_id, $length ) {
 			$the_post    = get_post( $post_id ); // Gets post ID.
-			$the_excerpt = ( $the_post ? $the_post->post_content : null ); // Gets post_content to be used as a basis for the excerpt.
+			$the_excerpt = ( ( $the_post->post_excerpt ) ? $the_post->post_excerpt : $the_post->post_content ); // Gets post_content to be used as a basis for the excerpt.
 			$the_excerpt = wp_strip_all_tags( strip_shortcodes( $the_excerpt ) ); // Strips tags and images.
 			$words       = explode( ' ', $the_excerpt, $length + 1 );
 

--- a/readme.txt
+++ b/readme.txt
@@ -169,7 +169,6 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 == Changelog ==
 
 = 1.23.2 =
-* Fix: Post layout - Excerpt logic broken issue.
 * Fix: Table of Contents: Headings with HTML tags are not visible on the frontend.
 * Fix: Table of Contents - Question marks are rendered in place of UTF-8 characters for few languages in Heading.
 * Fix: Section - Full-Width option not being applied on the front-end according to theme content width.

--- a/readme.txt
+++ b/readme.txt
@@ -168,6 +168,9 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 
 == Changelog ==
 
+= 1.23.2 =
+* Fix: Post layout - Excerpt logic broken issue.
+
 = 1.23.1 =
 * Fix: Broken path while generating assets (CSS/JS).
 * Fix: Table of Contents - Heading convert to question marks on the frontend.


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
- Trello - https://trello.com/c/kVgHs8yS/369-fix-post-layout-excerpt-logic-broken-issue

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
- Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Add a post with post content and excerpt in the excerpt box in master.
- Drag and drop the post layout any and check front-end.  it will show post content in excerpt instead of excerpt box.
- Switch to  `post-layout-excerpt-issue` and check post layout it display correctly excerpt box content if added.

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
