### PR TITLE
Fix: Table of Contents: Headings with other tags inside them are not visible on frontend.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 
 ## Changelog ##
 
+### 1.23.2 ###
+* Fix: Table of Contents: Headings with other tags inside them are not visible on frontend.
+
 ### 1.23.1 ###
 * Fix: Broken path while generating assets (CSS/JS).
 * Fix: Table of Contents - Heading convert to question marks on the frontend.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 ## Changelog ##
 
 ### 1.23.2 ###
-* Fix: Table of Contents: Headings with HTML tags are not visible on the frontend..
+* Fix: Table of Contents: Headings with HTML tags are not visible on the frontend.
 * Fix: Table of Contents - Question marks are rendered in place of UTF-8 characters for few languages in Heading.
 * Fix: Section - Full-Width option not being applied on the front-end according to theme content width.
 

--- a/blocks-config/table-of-content/class-uagb-table-of-content.php
+++ b/blocks-config/table-of-content/class-uagb-table-of-content.php
@@ -158,7 +158,7 @@ if ( ! class_exists( 'UAGB_Table_Of_Content' ) ) {
 			// Get all non-empty heading elements in the post content.
 			$headings = iterator_to_array(
 				$xpath->query(
-					'//*[self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6][text()!=""]'
+					'//*[self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6]'
 				)
 			);
 

--- a/readme.txt
+++ b/readme.txt
@@ -168,6 +168,9 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 
 == Changelog ==
 
+= 1.23.2 =
+* Fix: Table of Contents: Headings with other tags inside them are not visible on frontend.
+
 = 1.23.1 =
 * Fix: Broken path while generating assets (CSS/JS).
 * Fix: Table of Contents - Heading convert to question marks on the frontend.

--- a/readme.txt
+++ b/readme.txt
@@ -169,7 +169,7 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 == Changelog ==
 
 = 1.23.2 =
-* Fix: Table of Contents: Headings with HTML tags are not visible on the frontend..
+* Fix: Table of Contents: Headings with HTML tags are not visible on the frontend.
 * Fix: Table of Contents - Question marks are rendered in place of UTF-8 characters for few languages in Heading.
 * Fix: Section - Full-Width option not being applied on the front-end according to theme content width.
 


### PR DESCRIPTION
### Description
 - Trello task - https://trello.com/c/PEX9IzXk/370-fix-table-of-contents-headings-with-other-tags-inside-them-are-not-visible-on-frontend

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
 - Create Headings on a Page & Make the Bold/Italic/Strikethrough.
 - Those headings should be visible on the front end.

### Checklist:
- [x] My code is tested
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
