### PR TITLE
Fix: Posts - "B7" displayed in place of " . " icon on frontend when file generation is disabled.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 
 ## Changelog ##
 
+### 1.23.3 ###
+* Fix: Posts - "B7" displayed in place of " . " icon on frontend when file generation is disabled.
+
 ### 1.23.2 ###
 * Fix: Table of Contents: Headings with HTML tags are not visible on the frontend.
 * Fix: Table of Contents - Question marks are rendered in place of UTF-8 characters for few languages in Heading.

--- a/classes/class-uagb-post-assets.php
+++ b/classes/class-uagb-post-assets.php
@@ -298,7 +298,7 @@ class UAGB_Post_Assets {
 	public function update_page_assets() {
 
 		$meta_array = array(
-			'css'                => $this->stylesheet,
+			'css'                => wp_slash( $this->stylesheet ),
 			'js'                 => $this->script,
 			'current_block_list' => $this->current_block_list,
 			'uag_flag'           => $this->uag_flag,

--- a/readme.txt
+++ b/readme.txt
@@ -168,6 +168,9 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 
 == Changelog ==
 
+= 1.23.3 =
+* Fix: Posts - "B7" displayed in place of " . " icon on frontend when file generation is disabled.
+
 = 1.23.2 =
 * Fix: Table of Contents: Headings with HTML tags are not visible on the frontend.
 * Fix: Table of Contents - Question marks are rendered in place of UTF-8 characters for few languages in Heading.


### PR DESCRIPTION
### Description
 - Trello task - https://trello.com/c/sFmnbJlc/373-fix-posts-b7-displayed-in-place-of

### Types of changes
 Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
 - Added test case in the task.

### Checklist:
- [x] My code is tested
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
