### PR TITLE
Fix: Table of Contents - Fatal error when $doc->documentElement is null in some cases on frontend.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 
 ## Changelog ##
 
+### 1.23.3 ###
+* Fix: Table of Contents - Fatal error when $doc->documentElement is null in some cases on frontend.
+
 ### 1.23.2 ###
 * Fix: Table of Contents: Headings with HTML tags are not visible on the frontend.
 * Fix: Table of Contents - Question marks are rendered in place of UTF-8 characters for few languages in Heading.

--- a/blocks-config/table-of-content/class-uagb-table-of-content.php
+++ b/blocks-config/table-of-content/class-uagb-table-of-content.php
@@ -137,6 +137,12 @@ if ( ! class_exists( 'UAGB_Table_Of_Content' ) ) {
 			// We can't use foreach directly on the $templates DOMNodeList because it's a
 			// dynamic list, and removing nodes confuses the foreach iterator. So
 			// instead, we convert the iterator to an array and then iterate over that.
+
+			if ( ! isset( $doc->documentElement ) || ! is_object( $doc->documentElement ) ) {
+
+				return array();
+			}
+
 			$templates = iterator_to_array(
 				$doc->documentElement->getElementsByTagName( 'template' )
 			);

--- a/readme.txt
+++ b/readme.txt
@@ -168,6 +168,9 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 
 == Changelog ==
 
+= 1.23.3 =
+* Fix: Table of Contents - Fatal error when $doc->documentElement is null in some cases on frontend.
+
 = 1.23.2 =
 * Fix: Table of Contents: Headings with HTML tags are not visible on the frontend.
 * Fix: Table of Contents - Question marks are rendered in place of UTF-8 characters for few languages in Heading.


### PR DESCRIPTION
### Description
 - Trello task - https://trello.com/c/LFFxwYKV/374-fix-table-of-contents

### Types of changes
Bugfix (non-breaking change which fixes an issue

### How has this been tested?
 - Added in the task.

### Checklist:
- [x] My code is tested
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
