### PR TITLE
Add an action to "broadcast" the common CSS for a single block.

### DIFF
--- a/classes/class-uagb-post-assets.php
+++ b/classes/class-uagb-post-assets.php
@@ -872,6 +872,13 @@ class UAGB_Post_Assets {
 					$css = $block_assets['css'];
 
 					if ( ! empty( $css['common'] ) ) {
+						/**
+						 * Action that is triggered when the common single block CSS has been composed.
+						 *
+						 * @param string $common_css The composed common CSS.
+						 * @param array  $block      The block related information.
+						 */
+						do_action( 'uagb_single_block_common_css_composed', $css['common'], $block );
 						$desktop .= $css['common'];
 					}
 


### PR DESCRIPTION
**Please don't merge this, while it's in draft state**

### Description
Adds an action that broadcasts the common CSS for a single block. This is needed in our loops so that we can track the common CSS and append it to the styles only once.
