### PR TITLE
Fix: Assets Generation on Archive Pages not working for all Posts on frontend.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 
 ## Changelog ##
 
+### 1.23.4 ###
+* Fix: Assets Generation on Archive Pages not working for all Posts on frontend.
+
 ### 1.23.3 ###
 * Fix: Table of Contents - UTF-8 encoding on frontend.
 * Fix: Table of Contents - Fatal error when $doc->documentElement is null in some cases on frontend.

--- a/classes/class-uagb-front-assets.php
+++ b/classes/class-uagb-front-assets.php
@@ -129,7 +129,7 @@ class UAGB_Front_Assets {
 		} elseif ( is_archive() || is_home() || is_search() ) {
 
 			global $wp_query;
-			$cached_wp_query = $wp_query;
+			$cached_wp_query = $wp_query->posts;
 
 			foreach ( $cached_wp_query as $post ) { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 				$this->post_assets->prepare_assets( $post );

--- a/readme.txt
+++ b/readme.txt
@@ -168,6 +168,9 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 
 == Changelog ==
 
+= 1.23.4 =
+* Fix: Assets Generation on Archive Pages not working for all Posts on frontend.
+
 = 1.23.3 =
 * Fix: Table of Contents - UTF-8 encoding on frontend.
 * Fix: Table of Contents - Fatal error when $doc->documentElement is null in some cases on frontend.


### PR DESCRIPTION
### Description
 - Trello task - https://trello.com/c/wvnWpTBW/379-fix-assets-generation-on-archive-pages-not-working-for-all-posts-on-frontend

### Types of changes
 Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
 - Create a post with some content and an immediate after content Icon list with the label.
 - Visite customizer > Blog/archive > Post content > Full content.
 - Go To reading > Your homepage displays > Your latest posts
 - Check the Posts page. ( First Post Looks Okay, In other Icons are not visible )

### Checklist:
- [x] My code is tested
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
