### PR TITLE
Fix: Advanced column - Shape Divider issue when using with the Astra Custom Layout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 
 ## Changelog ##
 
+### 1.23.4 ###
+* Fix: Advanced column - Shape Divider issue when using with the Astra Custom Layout.
+
 ### 1.23.3 ###
 * Fix: Table of Contents - UTF-8 encoding on frontend.
 * Fix: Table of Contents - Fatal error when $doc->documentElement is null in some cases on frontend.

--- a/classes/class-uagb-block-helper.php
+++ b/classes/class-uagb-block-helper.php
@@ -571,7 +571,7 @@ if ( ! class_exists( 'UAGB_Block_Helper' ) ) {
 				' .uagb-columns__shape-bottom svg' => array(
 					'height' => UAGB_Helper::get_css_value( $attr['bottomHeight'], 'px' ),
 				),
-				' .uagb-columns__shape-bottom .uagb-columns__shape-fill' => array(
+				' .uagb-columns__shape.uagb-columns__shape-bottom .uagb-columns__shape-fill' => array(
 					'fill' => UAGB_Helper::hex2rgba( $attr['bottomColor'], ( isset( $attr['bottomDividerOpacity'] ) && '' !== $attr['bottomDividerOpacity'] ) ? $attr['bottomDividerOpacity'] : 100 ),
 				),
 				'.wp-block-uagb-columns'           => array(

--- a/classes/class-uagb-block-helper.php
+++ b/classes/class-uagb-block-helper.php
@@ -565,7 +565,7 @@ if ( ! class_exists( 'UAGB_Block_Helper' ) ) {
 				' .uagb-columns__shape-top svg'    => array(
 					'height' => UAGB_Helper::get_css_value( $attr['topHeight'], 'px' ),
 				),
-				' .uagb-columns__shape-top .uagb-columns__shape-fill' => array(
+				' .uagb-columns__shape.uagb-columns__shape-top .uagb-columns__shape-fill' => array(
 					'fill' => UAGB_Helper::hex2rgba( $attr['topColor'], ( isset( $attr['topDividerOpacity'] ) && '' !== $attr['topDividerOpacity'] ) ? $attr['topDividerOpacity'] : 100 ),
 				),
 				' .uagb-columns__shape-bottom svg' => array(

--- a/readme.txt
+++ b/readme.txt
@@ -168,6 +168,9 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 
 == Changelog ==
 
+= 1.23.4 =
+* Fix: Advanced column - Shape Divider issue when using with the Astra Custom Layout.
+
 = 1.23.3 =
 * Fix: Table of Contents - UTF-8 encoding on frontend.
 * Fix: Table of Contents - Fatal error when $doc->documentElement is null in some cases on frontend.


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
- Trello - https://trello.com/c/B5IDxGO5/384-fix-advanced-column-shape-divider-issue-when-using-with-the-astra-custom-layout

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
- Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Added on Trello board.

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
