### PR TITLE
Fix: Multiple blockquote post same content after tweet

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 
 ## Changelog ##
 
+### 1.23.5 ###
+* Fix: Multiple blockquote post same content after clicking on tweet button.
+
 ### 1.23.4 ###
 * Fix: Advanced column - Shape Divider issue when using with the Astra Custom Layout.
 * Fix: Assets Generation on Archive Pages not working for all Posts on frontend.

--- a/classes/class-uagb-block-js.php
+++ b/classes/class-uagb-block-js.php
@@ -108,7 +108,6 @@ if ( ! class_exists( 'UAGB_Block_JS' ) ) {
 
 			$base_selector = ( isset( $attr['classMigrate'] ) && $attr['classMigrate'] ) ? '.uagb-block-' : '#uagb-blockquote-';
 			$selector      = $base_selector . $id;
-
 			ob_start();
 			?>
 			var selector = document.querySelectorAll( '<?php echo esc_attr( $selector ); ?>' );

--- a/classes/class-uagb-block-js.php
+++ b/classes/class-uagb-block-js.php
@@ -119,8 +119,7 @@ if ( ! class_exists( 'UAGB_Block_JS' ) ) {
 				if ( blockquote__tweet.length > 0 ) {
 
 					blockquote__tweet[0].addEventListener("click",function(){
-						var content = selector[0].getElementsByClassName("uagb-blockquote__content")[0].innerText;
-						var request_url = "https://twitter.com/share?url="+ encodeURIComponent("<?php echo esc_url( $url ); ?>")+"&text="+("<?php echo $attr['descriptionText'] ?>")+"&via="+("<?php echo esc_html( $via ); ?>"); 
+						var request_url = "https://twitter.com/share?url="+ encodeURIComponent("<?php echo esc_url( $url ); ?>")+"&text="+("<?php echo esc_html($attr['descriptionText']) ?>")+"&via="+("<?php echo esc_html( $via ); ?>"); 
 						window.open( request_url ); 
 					});
 				}

--- a/classes/class-uagb-block-js.php
+++ b/classes/class-uagb-block-js.php
@@ -108,7 +108,7 @@ if ( ! class_exists( 'UAGB_Block_JS' ) ) {
 
 			$base_selector = ( isset( $attr['classMigrate'] ) && $attr['classMigrate'] ) ? '.uagb-block-' : '#uagb-blockquote-';
 			$selector      = $base_selector . $id;
-
+		
 			ob_start();
 			?>
 			var selector = document.querySelectorAll( '<?php echo esc_attr( $selector ); ?>' );
@@ -120,7 +120,7 @@ if ( ! class_exists( 'UAGB_Block_JS' ) ) {
 
 					blockquote__tweet[0].addEventListener("click",function(){
 						var content = selector[0].getElementsByClassName("uagb-blockquote__content")[0].innerText;
-						var request_url = "https://twitter.com/share?url="+ encodeURIComponent("<?php echo esc_url( $url ); ?>")+"&text="+content+"&via="+("<?php echo esc_html( $via ); ?>"); 
+						var request_url = "https://twitter.com/share?url="+ encodeURIComponent("<?php echo esc_url( $url ); ?>")+"&text="+("<?php echo $attr['descriptionText'] ?>")+"&via="+("<?php echo esc_html( $via ); ?>"); 
 						window.open( request_url ); 
 					});
 				}

--- a/classes/class-uagb-block-js.php
+++ b/classes/class-uagb-block-js.php
@@ -108,7 +108,7 @@ if ( ! class_exists( 'UAGB_Block_JS' ) ) {
 
 			$base_selector = ( isset( $attr['classMigrate'] ) && $attr['classMigrate'] ) ? '.uagb-block-' : '#uagb-blockquote-';
 			$selector      = $base_selector . $id;
-		
+
 			ob_start();
 			?>
 			var selector = document.querySelectorAll( '<?php echo esc_attr( $selector ); ?>' );
@@ -119,7 +119,7 @@ if ( ! class_exists( 'UAGB_Block_JS' ) ) {
 				if ( blockquote__tweet.length > 0 ) {
 
 					blockquote__tweet[0].addEventListener("click",function(){
-						var request_url = "https://twitter.com/share?url="+ encodeURIComponent("<?php echo esc_url( $url ); ?>")+"&text="+("<?php echo esc_html($attr['descriptionText']) ?>")+"&via="+("<?php echo esc_html( $via ); ?>"); 
+						var request_url = "https://twitter.com/share?url="+ encodeURIComponent("<?php echo esc_url( $url ); ?>")+"&text="+("<?php echo esc_html( $attr['descriptionText'] ); ?>")+"&via="+("<?php echo esc_html( $via ); ?>"); 
 						window.open( request_url ); 
 					});
 				}

--- a/classes/class-uagb-config.php
+++ b/classes/class-uagb-config.php
@@ -291,8 +291,7 @@ if ( ! class_exists( 'UAGB_Config' ) ) {
 							'authorFontFamily'         => '',
 							'authorFontWeight'         => '',
 							'authorFontSubset'         => '',
-							'authorLineHeightType'     => 'em
-							',
+							'authorLineHeightType'     => 'em',
 							'authorLineHeight'         => '',
 							'authorLineHeightTablet'   => '',
 							'authorLineHeightMobile'   => '',
@@ -352,6 +351,7 @@ if ( ! class_exists( 'UAGB_Config' ) ) {
 							'quotePaddingType'         => 'px',
 							'quotePaddingTablet'       => '',
 							'quotePaddingMobile'       => '',
+							'descriptionText'          => 'Click here to change this text. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut elit tellus, luctus nec ullamcorper mattis, pulvinar dapibus leo.Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut elit tellus, luctus nec ullamcorper mattis, pulvinar dapibus leo.',
 						),
 					),
 					'uagb/call-to-action'         => array(

--- a/readme.txt
+++ b/readme.txt
@@ -168,6 +168,9 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 
 == Changelog ==
 
+= 1.23.5 =
+* Fix: Multiple blockquote post same content after clicking on tweet button.
+
 = 1.23.4 =
 * Fix: Advanced column - Shape Divider issue when using with the Astra Custom Layout.
 * Fix: Assets Generation on Archive Pages not working for all Posts on frontend.


### PR DESCRIPTION
[Jira](https://ua-gutenberg.atlassian.net/browse/UAG-309)

### Description
Multiple blockquote blocks on the same page return the latest block content after clicking on tweet button.

### Types of changes
- non-breaking change which fixes an issue

### How has this been tested?
tested on Front-end.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
