### PR TITLE
UAG-354 - Fix: Table of Contents - Headings not displayed properly when multiple Table of Contents blocks are added on same page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 
 ## Changelog ##
 
+### 1.24.0 ###
+* Fix: Table of Contents - Headings not displayed properly when multiple Table of Contents blocks are added on same page.
+
 ### 1.23.5 ###
 * Improvement: Added compatibility with WordPress v5.8.
 * Fix: Assets generation issue on frontend when Twenty Twenty-one theme was active.

--- a/blocks-config/table-of-content/class-uagb-table-of-content.php
+++ b/blocks-config/table-of-content/class-uagb-table-of-content.php
@@ -99,10 +99,7 @@ if ( ! class_exists( 'UAGB_Table_Of_Content' ) ) {
 		 *
 		 * @return array The list of headings.
 		 */
-		public function table_of_contents_get_headings_from_content(
-			$content,
-			$mapping_headers_array
-		) {
+		public function table_of_contents_get_headings_from_content( $content ) {
 
 			/* phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase */
 			// Disabled because of PHP DOMDocument and DOMXPath APIs using camelCase.
@@ -369,7 +366,7 @@ if ( ! class_exists( 'UAGB_Table_Of_Content' ) ) {
 							$mapping_header = ( $key + 1 );
 						}
 
-						if ( $mapping_header === $heading['level'] ) {
+						if ( isset( $heading ) && $mapping_header === $heading['level'] ) {
 
 							return $heading;
 						}
@@ -404,10 +401,7 @@ if ( ! class_exists( 'UAGB_Table_Of_Content' ) ) {
 
 			if ( empty( $uagb_toc_heading_content ) || UAGB_ASSET_VER !== $uagb_toc_version ) {
 
-				$uagb_toc_heading_content = $this->table_of_contents_get_headings_from_content(
-					get_post( $post->ID )->post_content,
-					$attributes['mappingHeaders']
-				);
+				$uagb_toc_heading_content = $this->table_of_contents_get_headings_from_content( get_post( $post->ID )->post_content );
 
 				$meta_array = array(
 					'_uagb_toc_version'  => UAGB_ASSET_VER,

--- a/blocks-config/table-of-content/class-uagb-table-of-content.php
+++ b/blocks-config/table-of-content/class-uagb-table-of-content.php
@@ -94,8 +94,6 @@ if ( ! class_exists( 'UAGB_Table_Of_Content' ) ) {
 		 * @access public
 		 *
 		 * @param string $content       The post content to extract headings from.
-		 * @param int    $mapping_headers_array The page of the post where the headings are
-		 *                              located.
 		 *
 		 * @return array The list of headings.
 		 */

--- a/blocks-config/table-of-content/class-uagb-table-of-content.php
+++ b/blocks-config/table-of-content/class-uagb-table-of-content.php
@@ -353,25 +353,29 @@ if ( ! class_exists( 'UAGB_Table_Of_Content' ) ) {
 		 */
 		public function filter_headings_by_mapping_headers( $headings, $mapping_headers_array ) {
 
-			return array_map(
-				function ( $heading ) use ( $mapping_headers_array ) {
+			$filtered_headings = array();
 
-					$mapping_header = 0;
-					foreach ( $mapping_headers_array as $key => $value ) {
+			foreach ( $headings as $heading ) {
 
-						if ( $mapping_headers_array[ $key ] ) {
+				$mapping_header = 0;
 
-							$mapping_header = ( $key + 1 );
-						}
+				foreach ( $mapping_headers_array as $key => $value ) {
 
-						if ( isset( $heading ) && $mapping_header === $heading['level'] ) {
+					if ( $mapping_headers_array[ $key ] ) {
 
-							return $heading;
-						}
+						$mapping_header = ( $key + 1 );
 					}
-				},
-				$headings
-			);
+
+					if ( isset( $heading ) && $mapping_header === $heading['level'] ) {
+
+						$filtered_headings[] = $heading;
+						break;
+					}
+				}
+			}
+
+			return $filtered_headings;
+
 		}
 		/**
 		 * Renders the UAGB Table Of Contents block.

--- a/readme.txt
+++ b/readme.txt
@@ -168,6 +168,9 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 
 == Changelog ==
 
+= 1.24.0 =
+* Fix: Table of Contents - Headings not displayed properly when multiple Table of Contents blocks are added on same page.
+
 = 1.23.5 =
 * Improvement: Added compatibility with WordPress v5.8.
 * Fix: Assets generation issue on frontend when Twenty Twenty-one theme was active.


### PR DESCRIPTION
### Description
Task - https://ua-gutenberg.atlassian.net/jira/software/projects/UAG/boards/2?selectedIssue=UAG-354

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
- Add Various Headings on a Page. ( H1 to H6 )
- Add 2 Table of Contents Blocks on a Page.
- Exclude different headings in both the Blocks.( https://d.pr/i/X9WcwD )
- Check on Frontend everything should work as expected.

- Add "uagb-toc-hide-heading" class in Advance Tab to any of the headings & see that the heading should be excluded on the frontend.

### Checklist:
- [x] My code is tested
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
