### PR TITLE
Fix Star rating alignment issue in editor when layout is stack.

### DIFF
--- a/dist/blocks.asset.php
+++ b/dist/blocks.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'react-dom', 'wp-block-editor', 'wp-blocks', 'wp-components', 'wp-compose', 'wp-data', 'wp-element', 'wp-hooks', 'wp-i18n', 'wp-polyfill'), 'version' => '821c1cdb08168d7ea3856dc191971a27');
+<?php return array('dependencies' => array('react', 'react-dom', 'wp-block-editor', 'wp-blocks', 'wp-components', 'wp-compose', 'wp-data', 'wp-element', 'wp-hooks', 'wp-i18n', 'wp-polyfill'), 'version' => 'aa38af21611b3864ba47228a65e4581c');

--- a/src/blocks/star-rating/styling.js
+++ b/src/blocks/star-rating/styling.js
@@ -32,14 +32,18 @@ function styling( props ) {
 
 	let alignment = 'flex-start';
 	let stack_alignment = align;
+	
 	if ( align ) {
-		if ( 'right' === align ) 
+		if ( 'right' === align ) {
 			alignment = 'flex-end';
-		if ( 'center' === align ) 
+		}
+		if ( 'center' === align ) {
 			alignment = 'center';
-		if ( 'full' === align ) 
+		}
+		if ( 'full' === align ) {
 			alignment = 'space-between';
 			stack_alignment = 'left';
+		}
 	}
 
 	let remainder = ( rating % 1 ).toFixed(1);


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
- Star Rating > Stack > Alignment - not working in editor - https://vimeo.com/576686720/8034a2db15

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
- Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- https://share.getcloudapp.com/Z4uKR5Dx

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
