### PR TITLE
Fix: Asset generation conflicts with WooCommerce pages.

### DIFF
--- a/classes/class-uagb-front-assets.php
+++ b/classes/class-uagb-front-assets.php
@@ -150,6 +150,21 @@ class UAGB_Front_Assets {
 
 			}
 		}
+
+		if ( class_exists( 'WooCommerce' ) ) {
+
+			global $wp_query;
+			$cached_wp_query = $wp_query->posts;
+
+			foreach ( $cached_wp_query as $post ) { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+				$current_post_assets = new UAGB_Post_Assets( $post->ID );
+
+				$current_post_assets->enqueue_scripts();
+
+			}
+		}
+
 	}
 
 	/**

--- a/classes/class-uagb-front-assets.php
+++ b/classes/class-uagb-front-assets.php
@@ -154,7 +154,7 @@ class UAGB_Front_Assets {
 			if ( ! $this->post_id ) {
 				return;
 			}
-	
+
 			$this->post_assets = new UAGB_Post_Assets( $this->post_id );
 
 			$this->post_assets->enqueue_scripts();

--- a/classes/class-uagb-front-assets.php
+++ b/classes/class-uagb-front-assets.php
@@ -74,30 +74,6 @@ class UAGB_Front_Assets {
 			$this->post_id = get_the_ID();
 		}
 
-		if ( class_exists( 'WooCommerce' ) ) {
-
-			if ( is_cart() ) {
-
-				$id = get_option( 'woocommerce_cart_page_id' );
-			} elseif ( is_account_page() ) {
-
-				$id = get_option( 'woocommerce_myaccount_page_id' );
-			} elseif ( is_checkout() ) {
-
-				$id = get_option( 'woocommerce_checkout_page_id' );
-			} elseif ( is_checkout_pay_page() ) {
-
-				$id = get_option( 'woocommerce_pay_page_id' );
-			} elseif ( is_shop() ) {
-
-				$id = get_option( 'woocommerce_shop_page_id' );
-			}
-
-			if ( ! empty( $id ) ) {
-				$this->post_id = intval( $id );
-			}
-		}
-
 		if ( ! $this->post_id ) {
 			return;
 		}
@@ -151,18 +127,37 @@ class UAGB_Front_Assets {
 			}
 		}
 
+		/* WooCommerce compatibility */
 		if ( class_exists( 'WooCommerce' ) ) {
 
-			global $wp_query;
-			$cached_wp_query = $wp_query->posts;
+			if ( is_cart() ) {
 
-			foreach ( $cached_wp_query as $post ) { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$id = get_option( 'woocommerce_cart_page_id' );
+			} elseif ( is_account_page() ) {
 
-				$current_post_assets = new UAGB_Post_Assets( $post->ID );
+				$id = get_option( 'woocommerce_myaccount_page_id' );
+			} elseif ( is_checkout() ) {
 
-				$current_post_assets->enqueue_scripts();
+				$id = get_option( 'woocommerce_checkout_page_id' );
+			} elseif ( is_checkout_pay_page() ) {
 
+				$id = get_option( 'woocommerce_pay_page_id' );
+			} elseif ( is_shop() ) {
+
+				$id = get_option( 'woocommerce_shop_page_id' );
 			}
+
+			if ( ! empty( $id ) ) {
+				$this->post_id = intval( $id );
+			}
+
+			if ( ! $this->post_id ) {
+				return;
+			}
+	
+			$this->post_assets = new UAGB_Post_Assets( $this->post_id );
+
+			$this->post_assets->enqueue_scripts();
 		}
 
 	}

--- a/classes/class-uagb-front-assets.php
+++ b/classes/class-uagb-front-assets.php
@@ -148,16 +148,9 @@ class UAGB_Front_Assets {
 			}
 
 			if ( ! empty( $id ) ) {
-				$this->post_id = intval( $id );
+				$current_post_assets = new UAGB_Post_Assets( intval( $id ) );
+				$current_post_assets->enqueue_scripts();
 			}
-
-			if ( ! $this->post_id ) {
-				return;
-			}
-
-			$this->post_assets = new UAGB_Post_Assets( $this->post_id );
-
-			$this->post_assets->enqueue_scripts();
 		}
 
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -174,7 +174,7 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 * New: Added Masonry option to core Gallery block.
 * Improvement: Table of Contents - Added scroll to specific anchor tag feature.
 * Fix: Table of Contents - Headings were not displaying correctly when multiple blocks were used on the same page.
-* Fix: UAG conflict on one page checkout.
+* Fix: Asset generation conflicts with WooCommerce pages.
 
 = 1.23.5 =
 * Improvement: Added compatibility with WordPress v5.8.

--- a/readme.txt
+++ b/readme.txt
@@ -174,6 +174,7 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 * New: Added Masonry option to core Gallery block.
 * Improvement: Table of Contents - Added scroll to specific anchor tag feature.
 * Fix: Table of Contents - Headings were not displaying correctly when multiple blocks were used on the same page.
+* Fix: UAG conflict on one page checkout.
 
 = 1.23.5 =
 * Improvement: Added compatibility with WordPress v5.8.


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
Issue - https://wordpress.org/support/topic/1-23-5-update-conflict-with-wc-one-page-checkout-plugin/

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
- Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Install cartflows, create a flow, import any template.
- Go To the cartflows settings > set page builder as a Gutenberg
- Visit the checkout page. 
- Screencast of testing - https://share.getcloudapp.com/GGuWgkeD

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
