### PR TITLE
UAG-365 Fix: Table of contents - Uncaught TypeError with the load function.

### DIFF
--- a/assets/js/table-of-contents.js
+++ b/assets/js/table-of-contents.js
@@ -196,7 +196,7 @@
 		UAGBTableOfContents.init();
 	})
 
-	$( window ).load(function() {
+	$(window).on('load', function(){
 		UAGBTableOfContents.hyperLinks();
 	})
 

--- a/readme.txt
+++ b/readme.txt
@@ -169,6 +169,9 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 
 == Changelog ==
 
+= 1.24.1 =
+* Fix: Table of contents - Uncaught TypeError with the load function.
+
 = 1.24.0 =
 * New: Introduced Star Rating block.
 * New: Added Masonry option to core Gallery block.


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
- Card -https://ua-gutenberg.atlassian.net/browse/UAG-365
- Refrence - https://brainstormforce.slack.com/archives/CAQ2TSA6A/p1626940888042800

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
- Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Drag and drop Table of Contents on-page.
- Add styling to the block.
- Copy the hyperlink and open it in incognito mode and check scroll to heading in the new tab working fine or not.
- No deprecated notice no console error.

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
