### PR TITLE
UAG-364 Fix: Responsive icon in tab not clickable issue.

### DIFF
--- a/admin/assets/common-block-editor.css
+++ b/admin/assets/common-block-editor.css
@@ -3376,3 +3376,7 @@ button.components-button.uagb-review-select-btn.is-secondary {
 .uag-typography-font-family-options{
     margin-top: 24px;
 }
+
+.uag-typography-range-options + .components-base-control .components-flex.components-select-control{
+    position:unset;
+}

--- a/dist/blocks.asset.php
+++ b/dist/blocks.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'react-dom', 'wp-block-editor', 'wp-blocks', 'wp-components', 'wp-compose', 'wp-data', 'wp-element', 'wp-hooks', 'wp-i18n', 'wp-polyfill'), 'version' => '7cc759c1000b18dbffa8a2ad69187dd8');
+<?php return array('dependencies' => array('react', 'react-dom', 'wp-block-editor', 'wp-blocks', 'wp-components', 'wp-compose', 'wp-data', 'wp-element', 'wp-hooks', 'wp-i18n', 'wp-polyfill'), 'version' => 'aa38af21611b3864ba47228a65e4581c');


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
- Card - https://ua-gutenberg.atlassian.net/browse/UAG-364

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
- Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Check each and every responsive setting is clickable or not.
- Screencast - https://share.getcloudapp.com/Kou4PK9d

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
