### PR TITLE
UAG-373 Fix: Blockquote - Multiple blockquote post same content after clicking on tweet button.

### DIFF
--- a/classes/class-uagb-block-js.php
+++ b/classes/class-uagb-block-js.php
@@ -119,8 +119,7 @@ if ( ! class_exists( 'UAGB_Block_JS' ) ) {
 				if ( blockquote__tweet.length > 0 ) {
 
 					blockquote__tweet[0].addEventListener("click",function(){
-						var content = selector[0].getElementsByClassName("uagb-blockquote__content")[0].innerText;
-						var request_url = "https://twitter.com/share?url="+ encodeURIComponent("<?php echo esc_url( $url ); ?>")+"&text="+content+"&via="+("<?php echo esc_html( $via ); ?>"); 
+						var request_url = "https://twitter.com/share?url="+ encodeURIComponent("<?php echo esc_url( $url ); ?>")+"&text="+("<?php echo esc_html( $attr['descriptionText'] ); ?>")+"&via="+("<?php echo esc_html( $via ); ?>");
 						window.open( request_url ); 
 					});
 				}

--- a/classes/class-uagb-config.php
+++ b/classes/class-uagb-config.php
@@ -352,6 +352,7 @@ if ( ! class_exists( 'UAGB_Config' ) ) {
 							'quotePaddingType'         => 'px',
 							'quotePaddingTablet'       => '',
 							'quotePaddingMobile'       => '',
+							'descriptionText'          => 'Click here to change this text. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut elit tellus, luctus nec ullamcorper mattis, pulvinar dapibus leo.Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut elit tellus, luctus nec ullamcorper mattis, pulvinar dapibus leo.',
 						),
 					),
 					'uagb/call-to-action'         => array(

--- a/readme.txt
+++ b/readme.txt
@@ -168,6 +168,8 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 1. /assets/screenshots/1.png
 
 == Changelog ==
+= 1.24.2 =
+* Fix: Blockquote - Multiple blockquote post same content after clicking on tweet button.
 
 = 1.24.1 – TUESDAY, 27TH JULY 2021 =
 * Fix: Table of contents - Uncaught TypeError with the load function.


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
- Card - https://ua-gutenberg.atlassian.net/browse/UAG-373

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
- Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Drag and drop Multiple blockquotes on page with different content.
- Visit the front end and click on the tweet button and check it redirected properly to specific blockquote or not.

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
