### PR TITLE
fix: Select control inner text gets cut off from below.

### DIFF
--- a/dist/common-editor.css
+++ b/dist/common-editor.css
@@ -74,6 +74,11 @@
   padding-bottom: 8px !important;
 }
 
+.uagb-inspector-tab .components-select-control .components-select-control__input {
+  font-size: 12px !important;
+  line-height: 2 !important;
+}
+
 /* Tabs Pabel CSS for .uagb-size-type-field-tabs START*/
 .uagb-size-type-field-tabs .components-tab-panel__tabs {
   z-index: unset;
@@ -566,11 +571,6 @@ button.components-button.uagb-review-select-btn.is-secondary {
 > .components-panel__body-title
 .components-button.components-panel__body-toggle:focus {
   box-shadow: none;
-}
-
-.uagb-inspector-tab .components-panel__body .components-select-control__input {
-  font-size: 12px;
-  line-height: normal;
 }
 
 .uag-responsive-common-button {

--- a/src/common-editor.scss
+++ b/src/common-editor.scss
@@ -25,13 +25,13 @@
 			/* Gutenberg DatePicker CSS */
 			.components-datetime {
 				.components-datetime__buttons {
-					margin:10px 0 10px 0;
+					margin: 10px 0 10px 0;
 					/* Unset box-shadow */
-					.components-button:focus:not(:disabled){
-						box-shadow:unset;
+					.components-button:focus:not(:disabled) {
+						box-shadow: unset;
 					}
 				}
-			} 
+			}
 		}
 	}
 }
@@ -72,6 +72,10 @@
 	height: auto;
 	.components-input-control__label {
 		padding-bottom: 8px !important;
+	}
+	.components-select-control__input {
+		font-size: 12px !important;
+		line-height: 2 !important;
 	}
 }
 
@@ -551,10 +555,6 @@ button.components-button.uagb-review-select-btn.is-secondary {
 	> .components-panel__body-title
 	.components-button.components-panel__body-toggle:focus {
 	box-shadow: none;
-}
-.uagb-inspector-tab .components-panel__body .components-select-control__input {
-	font-size: 12px;
-	line-height: normal;
 }
 .uag-responsive-common-button {
 	box-shadow: none;


### PR DESCRIPTION
### Description
 - Select-control inner text gets cut off from below.

### Screenshots
https://share.bsf.io/o0uPqdBR

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
 - text does not get cut off from below

### Checklist:
- [x] My code is tested
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
