### PR TITLE
UAG-435 - fix: Font does not load on frontend for Star Rating Block.

### DIFF
--- a/classes/class-uagb-block-js.php
+++ b/classes/class-uagb-block-js.php
@@ -939,5 +939,21 @@ if ( ! class_exists( 'UAGB_Block_JS' ) ) {
 			UAGB_Helper::blocks_google_font( $label_load_google_font, $label_font_family, $label_font_weight, $label_font_subset );
 			UAGB_Helper::blocks_google_font( $input_load_google_font, $input_font_family, $input_font_weight, $input_font_subset );
 		}
+
+		/**
+		 * Adds Google fonts for Star Rating block.
+		 *
+		 * @since x.x.x
+		 * @param array $attr the blocks attr.
+		 */
+		public static function blocks_star_rating_gfont( $attr ) {
+
+			$load_google_font = isset( $attr['loadGoogleFonts'] ) ? $attr['loadGoogleFonts'] : '';
+			$font_family      = isset( $attr['fontFamily'] ) ? $attr['fontFamily'] : '';
+			$font_weight      = isset( $attr['fontWeight'] ) ? $attr['fontWeight'] : '';
+			$font_subset      = isset( $attr['fontSubset'] ) ? $attr['fontSubset'] : '';
+
+			UAGB_Helper::blocks_google_font( $load_google_font, $font_family, $font_weight, $font_subset );
+		}
 	}
 }

--- a/classes/class-uagb-post-assets.php
+++ b/classes/class-uagb-post-assets.php
@@ -739,6 +739,7 @@ class UAGB_Post_Assets {
 
 			case 'uagb/star-rating':
 				$css += UAGB_Block_Helper::get_star_rating_css( $blockattr, $block_id );
+				UAGB_Block_JS::blocks_star_rating_gfont( $blockattr );
 				break;
 
 			default:


### PR DESCRIPTION
### Description
fix: Font does not load on frontend for Star Rating Block.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
- Drop star rating 
- Apply font family on title
- Update & check on the front end
- In DOM it is showing font family 

### Checklist:
- [x] My code is tested
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
