### PR TITLE
fix: CF7 & GF styler CSS does not get added in the editor combined css file.

### DIFF
--- a/classes/class-uagb-admin-helper.php
+++ b/classes/class-uagb-admin-helper.php
@@ -284,6 +284,14 @@ if ( ! class_exists( 'UAGB_Admin_Helper' ) ) {
 			$wp_filesystem = uagb_filesystem();
 
 			foreach ( $combined as $key => $c_block ) {
+
+				if ( 'cf7-styler' === $c_block ) {
+					$c_block = 'cf7-designer';
+				}
+				if ( 'gf-styler' === $c_block ) {
+					$c_block = 'gf-designer';
+				}
+
 				$style .= $wp_filesystem->get_contents( UAGB_DIR . 'assets/css/blocks/' . $c_block . '.css' );
 
 			}


### PR DESCRIPTION
### Description
CF7 & GF styler CSS does not get added in the editor combined css file.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
 -  Test CF7 & GF Styler blocks.

### Checklist:
- [x] My code is tested
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
