### PR TITLE
User mail@example.com as default email

### DIFF
--- a/src/blocks/forms/child-blocks/email/attributes.js
+++ b/src/blocks/forms/child-blocks/email/attributes.js
@@ -18,7 +18,7 @@ const attributes = {
 	},
 	placeholder: {
         type: "string",
-        default: __( "example@mail.com" , 'ultimate-addons-for-gutenberg')
+        default: __( "mail@example.com" , 'ultimate-addons-for-gutenberg')
     },
 }
 export default attributes


### PR DESCRIPTION
This is just a minor change, but it always triggers me. "example.com" is [reserved by the iana for exactly such usecases](https://www.iana.org/domains/reserved). It will never be taken by someone else. On the other side "mail.com" IS reserved. That'swhy it should be changed.

Note:
There is another place in the code, where this mail is used. I am not sure, if it is also save to change this place as well. I have not tested this change, please double test.
https://github.com/brainstormforce/ultimate-addons-for-gutenberg/blob/b738aa4b75db145e2f601b55c7c28f186fe3fdbe/languages/ultimate-addons-for-gutenberg.pot#L5314

### Description
<!-- Please describe what you have changed or added -->

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
