### PR TITLE
Fix: Tabs - Active tabs color on frontend.

### DIFF
--- a/includes/blocks/tabs/frontend.css.php
+++ b/includes/blocks/tabs/frontend.css.php
@@ -46,8 +46,7 @@ $selectors = array(
 	' .uagb-tabs__panel .uagb-tab.uagb-tabs__active'       => array(
 		'background' => $attr['activeTabBgColor'],
 	),
-
-	' .uagb-tabs__panel .uagb-tab.uagb-tabs__active a'     => array(
+	'.uagb-tabs__wrap ul.uagb-tabs__panel li.uagb-tab.uagb-tabs__active a'     => array(
 		'color' => $attr['activeTabTextColor'],
 	),
 	' .uagb-tabs__panel .uagb-tab.uagb-tabs__active .uagb-tabs__icon svg' => array(


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
- https://app.startinfinity.com/b/Mi5zu3VRVzk/M7Dpq9yR4Pe/789a120c-f15a-44c3-af94-9d577169bd5a?redirect=true&view=0ce18087-e6b2-4a91-b54c-c386ce1f811c&t=attributes

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
- Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Drag and drop Tabs
- Add an active text color and active bg color.
- Check by changing to a different layout.
- Check other settings like padding, margin and tyography.

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
