### PR TITLE
Fix: Margin was not applied to post title on the post Carousel block

### DIFF
--- a/blocks-config/post/class-uagb-post.php
+++ b/blocks-config/post/class-uagb-post.php
@@ -1301,8 +1301,8 @@ if ( ! class_exists( 'UAGB_Post' ) ) {
 				?>
 				<?php do_action( "uagb_post_before_inner_wrap_{$attributes['post_type']}", get_the_ID(), $attributes ); ?>
 				<article <?php ( $post_class_enabled ) ? post_class( 'uagb-post__inner-wrap' ) : esc_html_e( 'class=uagb-post__inner-wrap' ); ?>>
-					<?php $this->render_complete_box_link( $attributes ); ?>
 					<?php $this->render_innerblocks( $attributes ); ?>
+					<?php $this->render_complete_box_link( $attributes ); ?>
 				</article>
 				<?php do_action( "uagb_post_after_inner_wrap_{$attributes['post_type']}", get_the_ID(), $attributes ); ?>
 				<?php
@@ -1348,9 +1348,17 @@ if ( ! class_exists( 'UAGB_Post' ) ) {
 		 */
 		public function render_innerblocks( $attributes ) {
 			$length = count( $attributes['layoutConfig'] );
+			$img_atts = array();
 			for ( $i = 0; $i < $length; $i++ ) {
+				if( 'background' === $attributes['imgPosition'] && 'uagb/post-image' === $attributes['layoutConfig'][ $i ][0] ) {
+					// This is to avoid background image container as first child as we are targetting first child for top margin property. 
+					$img_atts = $attributes['layoutConfig'][ $i ][0]; 
+					continue;
+				}
 				$this->render_layout( $attributes['layoutConfig'][ $i ][0], $attributes );
 			}
+			// Render background image container as a last child. 
+			if( ! empty( $img_atts ) ) $this->render_layout( $img_atts, $attributes );
 		}
 		/**
 		 * Renders the post masonry related script.


### PR DESCRIPTION
### Description
This change will fix the issue with the post title margin for the Post carousel block. 

### Screenshots
![WordPress 2022-05-20 at 6 53 40 PM](https://user-images.githubusercontent.com/10000232/169537304-646dcdf9-df83-4957-9c32-6e26e6db236c.jpg)

### Types of changes
Bug fix (non-breaking change which fixes an issue) 

### How has this been tested?

1. Add a Post Carousel block 
2. Select second Preset from Settings General Tab 
3. Save changes and check preview on the front end
4. Margin for Post title is not matched with Editor Preview 
5. Above change will fix this margin issue

### Checklist:
- [ ] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
