### PR TITLE
V1.25.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ When you use the Spectra along with the free Astra theme, you get a huge library
 ### 1.25.7 ###
 * Fix: Styling not applying on frontend when block used in widget area.
 * Fix: Table of contents - Not preview on page when Buddy Boss Platform is activated.
+* Fix: Info Box - Padding not applying on frontend when zero is set.
 
 ### 1.25.6 - TUESDAY, 31ST MAY 2022 ###
 * Improvement: Updated Gutenberg Templates Library.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Requires at least:** 4.7  
 **Requires PHP:** 5.6  
 **Tested up to:** 6.0  
-**Stable tag:** 1.25.6  
+**Stable tag:** 1.25.7  
 **License:** GPLv2 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -168,6 +168,10 @@ When you use the Spectra along with the free Astra theme, you get a huge library
 1. /assets/screenshots/1.png
 
 ## Changelog ##
+
+### 1.25.7 ###
+* Fix: Styling not applying on frontend when block used in widget area.
+* Fix: Table of contents - Not preview on page when Buddy Boss Platform is activated.
 
 ### 1.25.6 - TUESDAY, 31ST MAY 2022 ###
 * Improvement: Updated Gutenberg Templates Library.

--- a/classes/class-uagb-helper.php
+++ b/classes/class-uagb-helper.php
@@ -211,7 +211,7 @@ if ( ! class_exists( 'UAGB_Helper' ) ) {
 
 			$css_val = '';
 
-			if ( ! empty( $value ) ) {
+			if ( isset( $value ) ) {
 				$css_val = esc_attr( $value ) . $unit;
 			}
 

--- a/classes/class-uagb-loader.php
+++ b/classes/class-uagb-loader.php
@@ -66,7 +66,7 @@ if ( ! class_exists( 'UAGB_Loader' ) ) {
 			define( 'UAGB_BASE', plugin_basename( UAGB_FILE ) );
 			define( 'UAGB_DIR', plugin_dir_path( UAGB_FILE ) );
 			define( 'UAGB_URL', plugins_url( '/', UAGB_FILE ) );
-			define( 'UAGB_VER', '1.25.6' );
+			define( 'UAGB_VER', '1.25.7' );
 			define( 'UAGB_MODULES_DIR', UAGB_DIR . 'modules/' );
 			define( 'UAGB_MODULES_URL', UAGB_URL . 'modules/' );
 			define( 'UAGB_SLUG', 'uag' );

--- a/classes/class-uagb-post-assets.php
+++ b/classes/class-uagb-post-assets.php
@@ -172,7 +172,29 @@ class UAGB_Post_Assets {
 			global $post;
 			$this_post = $this->preview ? $post : get_post( $this->post_id );
 			$this->prepare_assets( $this_post );
+			$content = get_option( 'widget_block' );
+			$this->prepare_widget_area_assets( $content );
 		}
+	}
+
+	/**
+	 * Generates stylesheet for widget area.
+	 *
+	 * @param object $content Current Post Object.
+	 * @since x.x.x
+	 */
+	public function prepare_widget_area_assets( $content ) {
+
+		if ( empty( $content ) ) {
+			return;
+		}
+
+		foreach ( $content as $key => $value ) {
+			if ( is_array( $value ) && isset( $value['content'] ) && has_blocks( $value['content'] ) ) {
+				$this->common_function_for_assets_preparation( $value['content'] );
+			}
+		}
+
 	}
 
 	/**
@@ -301,6 +323,33 @@ class UAGB_Post_Assets {
 				add_action( 'wp_footer', array( $this, 'print_script' ), 1000 );
 			}
 		}
+
+		if ( has_blocks( $this_post->ID ) && isset( $this_post->post_content ) ) {
+			$this->common_function_for_assets_preparation( $this_post->post_content );
+		}
+	}
+
+	/**
+	 * Common function to generate stylesheet.
+	 *
+	 * @param array $post_content Current Post Object.
+	 * @since x.x.x
+	 */
+	public function common_function_for_assets_preparation( $post_content ) {
+		$blocks            = $this->parse_blocks( $post_content );
+		$this->page_blocks = $blocks;
+
+		if ( ! is_array( $blocks ) || empty( $blocks ) ) {
+			return;
+		}
+
+		$assets = $this->get_blocks_assets( $blocks );
+
+		$this->stylesheet .= $assets['css'];
+		$this->script     .= $assets['js'];
+
+		// Update fonts.
+		$this->gfonts = array_merge( $this->gfonts, UAGB_Helper::$gfonts );
 	}
 
 

--- a/classes/class-uagb-post-assets.php
+++ b/classes/class-uagb-post-assets.php
@@ -181,7 +181,7 @@ class UAGB_Post_Assets {
 	 * Generates stylesheet for widget area.
 	 *
 	 * @param object $content Current Post Object.
-	 * @since x.x.x
+	 * @since 1.25.7
 	 */
 	public function prepare_widget_area_assets( $content ) {
 
@@ -333,7 +333,7 @@ class UAGB_Post_Assets {
 	 * Common function to generate stylesheet.
 	 *
 	 * @param array $post_content Current Post Object.
-	 * @since x.x.x
+	 * @since 1.25.7
 	 */
 	public function common_function_for_assets_preparation( $post_content ) {
 		$blocks            = $this->parse_blocks( $post_content );

--- a/classes/class-uagb-post-assets.php
+++ b/classes/class-uagb-post-assets.php
@@ -324,9 +324,6 @@ class UAGB_Post_Assets {
 			}
 		}
 
-		if ( has_blocks( $this_post->ID ) && isset( $this_post->post_content ) ) {
-			$this->common_function_for_assets_preparation( $this_post->post_content );
-		}
 	}
 
 	/**
@@ -877,21 +874,7 @@ class UAGB_Post_Assets {
 		}
 
 		if ( has_blocks( $this_post->ID ) && isset( $this_post->post_content ) ) {
-
-			$blocks            = $this->parse_blocks( $this_post->post_content );
-			$this->page_blocks = $blocks;
-
-			if ( ! is_array( $blocks ) || empty( $blocks ) ) {
-				return;
-			}
-
-			$assets = $this->get_blocks_assets( $blocks );
-
-			$this->stylesheet .= $assets['css'];
-			$this->script     .= $assets['js'];
-
-			// Update fonts.
-			$this->gfonts = array_merge( $this->gfonts, UAGB_Helper::$gfonts );
+			$this->common_function_for_assets_preparation( $this_post->post_content );
 		}
 	}
 

--- a/classes/class-uagb-rest-api.php
+++ b/classes/class-uagb-rest-api.php
@@ -45,7 +45,19 @@ if ( ! class_exists( 'UAGB_Rest_API' ) ) {
 
 			// We have added this action here to support both the ways of post updations, Rest API & Normal.
 			add_action( 'save_post', array( $this, 'delete_page_assets' ), 10, 1 );
+			add_action( 'rest_after_save_widget', array( $this, 'after_widget_save_action' ) );
 		}
+
+		/**
+		 * This function updates the __uagb_asset_version when Widgets Editor is Updated.
+		 *
+		 * @since x.x.x
+		 */
+		public function after_widget_save_action() {
+			/* Update the asset version */
+			update_option( '__uagb_asset_version', time() );
+		}
+
 		/**
 		 * This function deletes the Page assets from the Page Meta Key.
 		 *

--- a/classes/class-uagb-rest-api.php
+++ b/classes/class-uagb-rest-api.php
@@ -51,7 +51,7 @@ if ( ! class_exists( 'UAGB_Rest_API' ) ) {
 		/**
 		 * This function updates the __uagb_asset_version when Widgets Editor is Updated.
 		 *
-		 * @since x.x.x
+		 * @since 1.25.7
 		 */
 		public function after_widget_save_action() {
 			/* Update the asset version */

--- a/dist/blocks.asset.php
+++ b/dist/blocks.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'react-dom', 'wp-block-editor', 'wp-blocks', 'wp-components', 'wp-compose', 'wp-data', 'wp-element', 'wp-hooks', 'wp-i18n', 'wp-polyfill'), 'version' => '2c5be76ce77d9e86f06fe4eef867951b');
+<?php return array('dependencies' => array('react', 'react-dom', 'wp-block-editor', 'wp-blocks', 'wp-components', 'wp-compose', 'wp-data', 'wp-element', 'wp-hooks', 'wp-i18n', 'wp-polyfill'), 'version' => 'e2026bb1ad3cb0c357d64adcd0d919b8');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-addons-for-gutenberg",
-	"version": "1.25.6",
+	"version": "1.25.7",
 	"description": "The Ultimate Addons for Gutenberg extends the Gutenberg functionality with several unique and feature-rich blocks that help build websites faster.",
 	"author": "Brainstorm Force",
 	"license": "ISC",

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: gutenberg, blocks, gutenberg blocks, editor, block
 Requires at least: 4.7
 Requires PHP: 5.6
 Tested up to: 6.0
-Stable tag: 1.25.6
+Stable tag: 1.25.7
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -168,6 +168,10 @@ When you use the Spectra along with the free Astra theme, you get a huge library
 1. /assets/screenshots/1.png
 
 == Changelog ==
+
+= 1.25.7 =
+* Fix: Styling not applying on frontend when block used in widget area.
+* Fix: Table of contents - Not preview on page when Buddy Boss Platform is activated.
 
 = 1.25.6 - TUESDAY, 31ST MAY 2022 =
 * Improvement: Updated Gutenberg Templates Library.

--- a/readme.txt
+++ b/readme.txt
@@ -172,6 +172,7 @@ When you use the Spectra along with the free Astra theme, you get a huge library
 = 1.25.7 =
 * Fix: Styling not applying on frontend when block used in widget area.
 * Fix: Table of contents - Not preview on page when Buddy Boss Platform is activated.
+* Fix: Info Box - Padding not applying on frontend when zero is set.
 
 = 1.25.6 - TUESDAY, 31ST MAY 2022 =
 * Improvement: Updated Gutenberg Templates Library.

--- a/src/blocks/table-of-contents/edit.js
+++ b/src/blocks/table-of-contents/edit.js
@@ -51,6 +51,8 @@ const {
 
 let svg_icons = Object.keys( UAGBIcon )
 
+const $ = jQuery;
+
 class UAGBTableOfContentsEdit extends Component {
 
 	constructor() {
@@ -79,12 +81,12 @@ class UAGBTableOfContentsEdit extends Component {
 
 		// Pushing Scroll To Top div
 		var scrollToTopSvg = '<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" version=\"1.1\" id=\"Layer_1\" x=\"0px\" y=\"0px\" width=\"26px\" height=\"16.043px\" viewBox=\"57 35.171 26 16.043\" enable-background=\"new 57 35.171 26 16.043\" xml:space=\"preserve\"><path d=\"M57.5,38.193l12.5,12.5l12.5-12.5l-2.5-2.5l-10,10l-10-10L57.5,38.193z\"/></svg>';
-		
+
 		if ( 0 == scroll_element.length ) {
 			jQuery( "body" ).append( "<div class=\"uagb-toc__scroll-top\"> " + scrollToTopSvg + "</div>" );
 		}
 
-		
+
 	}
 
 	render() {
@@ -242,7 +244,7 @@ class UAGBTableOfContentsEdit extends Component {
 		if ( makeCollapsible && icon ) {
 			icon_html = (
 				<span className="uag-toc__collapsible-wrap">{renderSVG(icon)}</span>
-			)	
+			)
 		}
 
 		return (
@@ -338,7 +340,7 @@ class UAGBTableOfContentsEdit extends Component {
 								{ value: "center", label: __( "Center",'ultimate-addons-for-gutenberg' ) },
 								{ value: "right", label: __( "Right",'ultimate-addons-for-gutenberg' ) },
 							] }
-	  					/>						
+	  					/>
 						<RangeControl
 							label={ __( "Bottom Space",'ultimate-addons-for-gutenberg' ) }
 							value={ headingBottom }
@@ -369,7 +371,7 @@ class UAGBTableOfContentsEdit extends Component {
 							value={ headingColor }
 							onChange={ ( colorValue ) => setAttributes( { headingColor: colorValue } ) }
 							allowReset
-						/>						
+						/>
 						<hr className="uagb-editor__separator" />
 						<h2>{ __( "Collapsible",'ultimate-addons-for-gutenberg' ) }</h2>
 						<ToggleControl
@@ -500,7 +502,7 @@ class UAGBTableOfContentsEdit extends Component {
 							value={ linkHoverColor }
 							onChange={ ( colorValue ) => setAttributes( { linkHoverColor: colorValue } ) }
 							allowReset
-						/>						
+						/>
 					</PanelBody>
 					<PanelBody title={ __( "Style",'ultimate-addons-for-gutenberg' ) } initialOpen={ false }>
 						<h2>{ __( "Background",'ultimate-addons-for-gutenberg' ) }</h2>
@@ -867,8 +869,8 @@ export default compose(
 			if( ! slug ) {
 				return slug;
 			}
-			
-			var parsedSlug = slug.toString().toLowerCase()                        
+
+			var parsedSlug = slug.toString().toLowerCase()
 				.replace(/\…+/g,'')                          // Remove multiple …
 				.replace(/&(amp;)/g, '')					 // Remove &
 				.replace(/&(mdash;)/g, '')					 // Remove long dash
@@ -888,12 +890,12 @@ export default compose(
 		var mainDiv;
 		if( iframeEl ){
 			mainDiv = iframeEl.find('.is-root-container' ).find('h1, h2, h3, h4, h5, h6' );
-		} 
-		
+		}
+
 		if(  0 !== $( '.is-root-container' ).length ) {
 			mainDiv = $( '.is-root-container' ).find('h1, h2, h3, h4, h5, h6' )
 		}
-		
+
 		var headerArray = mainDiv
 		let headers = [];
 		if( headerArray != 'undefined' ) {
@@ -901,7 +903,7 @@ export default compose(
 			headerArray.each( function (index, value){
 				let header = $( this );
 				let excludeHeading ;
-				
+
 				if ( value.className.includes('uagb-toc-hide-heading') ) {
 					excludeHeading = true;
 				} else if ( 0 < header.parents('.uagb-toc-hide-heading').length ) {
@@ -909,13 +911,13 @@ export default compose(
 				} else {
 					excludeHeading = false;
 				}
-				
+
 				let headerText = parseTocSlug(header.text());
 				var openLevel = header[0].nodeName.replace(/^H+/, '');
 				var titleText = header.text();
-					
+
 					level = parseInt(openLevel);
-					
+
 					if ( !excludeHeading ) {
 						headers.push(
 							{
@@ -926,9 +928,9 @@ export default compose(
 							}
 						);
 					}
-				
-									
-			});	
+
+
+			});
 		}
 
 		if ( headers !== undefined ) {

--- a/ultimate-addons-for-gutenberg.php
+++ b/ultimate-addons-for-gutenberg.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://www.brainstormforce.com
  * Author: Brainstorm Force
  * Author URI: https://www.brainstormforce.com
- * Version: 1.25.6
+ * Version: 1.25.7
  * Description: The Ultimate Addons for Gutenberg extends the Gutenberg functionality with several unique and feature-rich blocks that help build websites faster.
  * Text Domain: ultimate-addons-for-gutenberg
  *


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
* Fix: Styling not applying on frontend when block used in the widget area.
* Fix: Table of contents - Not preview on the page when Buddy Boss Platform is activated.
* Fix: Info Box - Padding not applying on frontend when zero is set. [task link](https://brainstormforce.atlassian.net/browse/SPCTR-1053)

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
- Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- For widget area styling 1st case :
  - Clear widget area, removed all blocks from widget area, and save/update.
  - Open customizer, it should not show this kind of error when customizer is open - https://share.getcloudapp.com/X6u8PQ51
- For widget area styling 2nd case :
  - Goto widget area add and Drag drop info-box, advanced heading block change color to check styling issue.
  - Regenerate assets and check is blocks on the front are visible properly and is color styling applies to the block working properly or not.

- For TOC
  - Install BuddyBoss Platform.
  - Drag and drop the UAG TOC block on-page.
  - It will not preview in the editor and throw a console error.
  - Switch to above branch and check is issue is resolved or not.

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
