### PR TITLE
SPCTR-1232 Bug: Forms - Field border width is not working in mobile mode

### DIFF
--- a/includes/blocks/forms/frontend.css.php
+++ b/includes/blocks/forms/frontend.css.php
@@ -353,7 +353,7 @@ if ( 'boxed' === $attr['formStyle'] ) {
 	$m_selectors[' .uagb-forms-main-form  .uagb-forms-radio-wrap input[type=radio] + label:before']       = $toggle_border_Tablet;
 	$m_selectors[' .uagb-forms-main-form .uagb-slider'] = $toggle_border_Tablet;
 	$m_selectors[' .uagb-forms-main-form  .uagb-forms-accept-wrap input[type=checkbox] + label:before'] = $toggle_border_Tablet;
-	$m_selectors[' .uagb-forms-main-form .uagb-forms-input'] = $input_overall_border_Tablet;
+	$m_selectors[' .uagb-forms-main-form .uagb-forms-input'] = $input_overall_border_Mobile;
 }
 
 $selectors[' .uagb-forms-main-form  .uagb-forms-input']   = array(


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
- https://brainstormforce.atlassian.net/browse/SPCTR-1232

### Screenshots
<!-- if applicable -->
- https://share.getcloudapp.com/5zurnXpn

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
- Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Added in the card.

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
