### PR TITLE
Container : Default value for inner content custom width on mobile. 

### DIFF
--- a/includes/blocks/container/attributes.php
+++ b/includes/blocks/container/attributes.php
@@ -120,7 +120,7 @@ return array_merge(
 		'innerContentWidth'                 => 'alignwide',
 		'innerContentCustomWidthDesktop'    => $default_width,
 		'innerContentCustomWidthTablet'     => 768,
-		'innerContentCustomWidthMobile'     => 320,
+		'innerContentCustomWidthMobile'     => 426,
 		'innerContentCustomWidthType'       => 'px',
 		'innerContentCustomWidthTypeTablet' => 'px',
 		'innerContentCustomWidthTypeMobile' => 'px',


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
- Default mobile content width for inner container 426.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->
- Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
- Drag and drop 2 layout containers.
- Add info-box in it.
- Publish and inspect the inner container and check content width is 426 or not.

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
