### PR TITLE
SPCTR-1556 Testimonial: Default Gradient background color not applying at frontend

### DIFF
--- a/includes/blocks/testimonial/attributes.php
+++ b/includes/blocks/testimonial/attributes.php
@@ -114,7 +114,7 @@ return array_merge(
 		'nameSpaceType'              => 'px',
 		'overlayType'                => '',
 		'backgroundAttachment'       => '',
-		'gradientValue'              => '',
+		'gradientValue'              => 'linear-gradient(90deg, rgba(6, 147, 227, 0.5) 0%, rgba(155, 81, 224, 0.5) 100%)',
 		'descTransform'              => '',
 		'descDecoration'             => '',
 		'nameTransform'              => '',


### PR DESCRIPTION
### Description
Fixed Testimonial: Default Gradient background color not applying at frontend

### Screenshots
Issue - https://www.awesomescreenshot.com/video/10337989?key=fde25537d18553f98da2df64dedefa8e
Fixed - https://share.getcloudapp.com/E0uy1N40

### Types of changes
<!-- What types of changes does your code introduce?  -->
 Bug fix (non-breaking change which fixes an issue) 
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
- Drag drop Testimonial block
- Set background color to gradient
- Do not change the gradient field values
- Save and check at frontend

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
