### PR TITLE
fix: Excluded Icon JSON files from Release ZIP.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,6 +38,8 @@ module.exports = function ( grunt ) {
 					'!admin-core/webpack.config.js',
 					'!admin-core/package.json',
 					'!admin-core/package-lock.json',
+					'!blocks-config/uagb-controls/SpectraIconsV6.json',
+					'!blocks-config/uagb-controls/UAGBIcon.json',
 				],
 				dest: 'ultimate-addons-for-gutenberg/',
 			},


### PR DESCRIPTION
### Description
The JSONS are not needed in the ZIP & also they increase the size of ZIP, so we excluded it.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
 - Check if all Icons in Blocks work fine.

### Checklist:
- [x] My code is tested
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
