### PR TITLE
SPCTR-1743 Footer Widgets - CSS was not loading for empty archive/category and 404 pages. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ When you use the Spectra along with the free Astra theme, you get a huge library
 ### 2.0.8 - MONDAY, 29th AUGUST 2022 ###
 * Fix: Image - Box shadow not applying to a valid element.
 * Fix: Post Carousel/Grid/Masonry - Inaccurate font size for 'Read More' link was displayed in the editor for tablet preview (when mobile and tablet font sizes were set).
+* Fix: Footer Widgets - CSS was not loading for empty archive/category and 404 pages. 
 
 ### 2.0.7 - FRIDAY, 26th AUGUST 2022 ###
 * Improvement: Added Legacy Labels in the Editor Block Inserter.

--- a/classes/class-uagb-front-assets.php
+++ b/classes/class-uagb-front-assets.php
@@ -112,8 +112,8 @@ class UAGB_Front_Assets {
 			$this->post_assets->enqueue_scripts();
 		}
 
-		/* Archive compatibility */
-		if ( is_archive() || is_home() || is_search() ) {
+		/* Archive & 404 page compatibility */
+		if ( is_archive() || is_home() || is_search() || is_404() ) {
 
 			global $wp_query;
 			$cached_wp_query = $wp_query->posts;
@@ -124,6 +124,15 @@ class UAGB_Front_Assets {
 
 				$current_post_assets->enqueue_scripts();
 
+			}
+
+			/*
+			If no posts are present in the category/archive
+			or 404 page (which is an obvious case for 404), then get the current page ID and enqueue script.
+			*/
+			if ( ! $cached_wp_query ) {
+				$current_post_assets = new UAGB_Post_Assets( get_queried_object_id() );
+				$current_post_assets->enqueue_scripts();
 			}
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -169,6 +169,7 @@ When you use the Spectra along with the free Astra theme, you get a huge library
 = 2.0.8 - MONDAY, 29th AUGUST 2022 =
 * Fix: Image - Box shadow not applying to a valid element.
 * Fix: Post Carousel/Grid/Masonry - Inaccurate font size for 'Read More' link was displayed in the editor for tablet preview (when mobile and tablet font sizes were set).
+* Fix: Footer Widgets - CSS was not loading for empty archive/category and 404 pages. 
 
 = 2.0.7 - FRIDAY, 26th AUGUST 2022 =
 * Improvement: Added Legacy Labels in the Editor Block Inserter.


### PR DESCRIPTION
### Description
- Footer Widgets - CSS was not loading for empty archive/category and 404 pages. 
- For this bug to be recreated, we need to have some Spectra blocks in footer
- And also an empty category
- [JIRA](https://brainstormforce.atlassian.net/browse/SPCTR-1743)

### Types of changes
<!-- What types of changes does your code introduce?  -->
- Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
