### PR TITLE
SPCTR-1749 Table of Content - Collapsible icon is right beside the text on frontend, whereas it is on extreme-right in editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ When you use the Spectra along with the free Astra theme, you get a huge library
 ### 2.0.8 - MONDAY, 29th AUGUST 2022 ###
 * Fix: Image - Box shadow not applying to a valid element.
 * Fix: Post Carousel/Grid/Masonry - Inaccurate font size for 'Read More' link was displayed in the editor for tablet preview (when mobile and tablet font sizes were set).
+* Fix: Table of Content - Fixed collapsible icon alignment for frontend.
 
 ### 2.0.7 - FRIDAY, 26th AUGUST 2022 ###
 * Improvement: Added Legacy Labels in the Editor Block Inserter.

--- a/includes/blocks/table-of-contents/frontend.css.php
+++ b/includes/blocks/table-of-contents/frontend.css.php
@@ -76,7 +76,7 @@ $selectors = array(
 	' .uagb-toc__list-wrap li a'                          => array(
 		'color' => $attr['linkColor'],
 	),
-	' .uagb-toc__title-wrap'                              => array(
+	' .uagb-toc__wrap .uagb-toc__title-wrap'                              => array(
 		'justify-content' => $attr['align'],
 		'margin-bottom'   => UAGB_Helper::get_css_value( $attr['headingBottom'], 'px' ),
 	),
@@ -145,7 +145,7 @@ if ( $attr['customWidth'] ) {
 }
 
 if ( $attr['customWidth'] && $attr['makeCollapsible'] ) {
-	$selectors[' .uagb-toc__title']['justify-content'] = 'space-between';
+	$selectors[' .uagb-toc__wrap .uagb-toc__title']['justify-content'] = 'space-between';
 }
 
 if ( $attr['disableBullets'] ) {

--- a/readme.txt
+++ b/readme.txt
@@ -169,6 +169,7 @@ When you use the Spectra along with the free Astra theme, you get a huge library
 = 2.0.8 - MONDAY, 29th AUGUST 2022 =
 * Fix: Image - Box shadow not applying to a valid element.
 * Fix: Post Carousel/Grid/Masonry - Inaccurate font size for 'Read More' link was displayed in the editor for tablet preview (when mobile and tablet font sizes were set).
+* Fix: Table of Content - Fixed collapsible icon alignment for frontend.
 
 = 2.0.7 - FRIDAY, 26th AUGUST 2022 =
 * Improvement: Added Legacy Labels in the Editor Block Inserter.


### PR DESCRIPTION
### Description
<!-- Please describe what you have changed or added -->
- Table of Content - Collapsible icon is right beside the text on frontend, whereas it is on extreme-right in editor
- Hence, fixed collapsible icon position for frontend

### Screenshots
<!-- if applicable -->
![image](https://user-images.githubusercontent.com/20199688/187398930-a1879fbf-81bb-4068-a71b-d484da31f2b1.png)

![image](https://user-images.githubusercontent.com/20199688/187398957-ee591874-7814-460d-b1b8-9a4571fb9028.png)


### Types of changes
<!-- What types of changes does your code introduce?  -->
- Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
