### PR TITLE
fix: PHP Deprecated Notice from Gutenberg Templates library.

### DIFF
--- a/lib/class-uagb-ast-block-templates.php
+++ b/lib/class-uagb-ast-block-templates.php
@@ -88,6 +88,10 @@ if ( ! class_exists( 'UAGB_Ast_Block_Templates' ) ) :
 				$path    = realpath( dirname( __FILE__ ) . '/gutenberg-templates/ast-block-templates.php' );
 				$version = isset( $file_data['ast-block-templates'] ) ? $file_data['ast-block-templates'] : 0;
 
+				if ( null === $ast_block_templates_version ) {
+					$ast_block_templates_version = '1.0.0';
+				}
+
 				// Compare versions.
 				if ( version_compare( $version, $ast_block_templates_version, '>' ) ) {
 					$ast_block_templates_version = $version;


### PR DESCRIPTION
### Description
PHP Deprecated Notice from Gutenberg Templates library.

### Screenshots
https://share.bsf.io/z8uQ14yw

### Types of changes
New feature (non-breaking change which adds functionality)

### How has this been tested?
 - Check on PHP v8.1.9
 - You will get a notice on admin pages.

### Checklist:
- [x] My code is tested
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
