### PR TITLE
Version Update: 2.0.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Requires at least:** 4.7  
 **Requires PHP:** 5.6  
 **Tested up to:** 6.1  
-**Stable tag:** 2.0.14  
+**Stable tag:** 2.0.15  
 **License:** GPLv2 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -170,9 +170,8 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 
 ## Changelog ##
 
-
-### 2.0.15 - TUESDAY, 08th NOVEMBER 2022 ###
-* Improvement: Highlight selected text on editor in Spectra blocks..
+### 2.0.15 - TUESDAY, 15th NOVEMBER 2022 ###
+* Improvement: Highlight selected text on editor in Spectra blocks.
 * Improvement: Responsive Conditions - Slanted lines are not visible in the editor.
 * Improvement: Post Carousel/Masonry/Grid - Button text is now editable inside the editor.
 * Improvement: Call To Action - CTA button text is now editable inside the editor.

--- a/classes/class-uagb-loader.php
+++ b/classes/class-uagb-loader.php
@@ -83,7 +83,7 @@ if ( ! class_exists( 'UAGB_Loader' ) ) {
 			define( 'UAGB_BASE', plugin_basename( UAGB_FILE ) );
 			define( 'UAGB_DIR', plugin_dir_path( UAGB_FILE ) );
 			define( 'UAGB_URL', plugins_url( '/', UAGB_FILE ) );
-			define( 'UAGB_VER', '2.0.14' );
+			define( 'UAGB_VER', '2.0.15' );
 			define( 'UAGB_MODULES_DIR', UAGB_DIR . 'modules/' );
 			define( 'UAGB_MODULES_URL', UAGB_URL . 'modules/' );
 			define( 'UAGB_SLUG', 'spectra' );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ultimate-addons-for-gutenberg",
-  "version": "2.0.14",
+  "version": "2.0.15",
   "description": "The Ultimate Addons for Gutenberg extends the Gutenberg functionality with several unique and feature-rich blocks that help build websites faster.",
   "author": "Brainstorm Force",
   "license": "ISC",

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: gutenberg, blocks, gutenberg blocks, editor, block
 Requires at least: 4.7
 Requires PHP: 5.6
 Tested up to: 6.1
-Stable tag: 2.0.14
+Stable tag: 2.0.15
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -170,7 +170,7 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 
 == Changelog ==
 
-= 2.0.15 - TUESDAY, 08th NOVEMBER 2022 =
+= 2.0.15 - TUESDAY, 15th NOVEMBER 2022 =
 * Improvement: Highlight selected text on editor in Spectra blocks.
 * Improvement: Responsive Conditions - Slanted lines are not visible in the editor.
 * Improvement: Post Carousel/Masonry/Grid - Button text is now editable inside the editor.

--- a/ultimate-addons-for-gutenberg.php
+++ b/ultimate-addons-for-gutenberg.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://www.brainstormforce.com
  * Author: Brainstorm Force
  * Author URI: https://www.brainstormforce.com
- * Version: 2.0.14
+ * Version: 2.0.15
  * Description: The Spectra extends the Gutenberg functionality with several unique and feature-rich blocks that help build websites faster.
  * Text Domain: ultimate-addons-for-gutenberg
  *


### PR DESCRIPTION
* Improvement: Highlight selected text on editor in Spectra blocks.
* Improvement: Responsive Conditions - Slanted lines are not visible in the editor.
* Improvement: Post Carousel/Masonry/Grid - Button text is now editable inside the editor.
* Improvement: Call To Action - CTA button text is now editable inside the editor.
* Improvement: Post Timeline - Button text is now editable inside the editor.
* Improvement: Info-Box - Add responsive feature in Info Box Icon width.
* Improvement: Call to Action: Added show icon toggle.
* Improvement: FAQ: Added background type selector for the question-answer container.
* Improvement: Forms: Added background type selector for submit button.
* Improvement: Info Box: Added background type selector for CTA.
* Improvement: Info Box: Added show icon toggle for CTA.
* Improvement: Post Carousel: Added background type selector.
* Improvement: Post (Grid/Masonry/Carousel): Added background type selector for CTA.
* Improvement: Implemented CLS for all the blocks which have image tag.
* Improvement: Spectra Text Control: New text component in settings for a more consistent styling.
* Fix: Admin Dashboard - Font dropdown control was going under the section.
* Fix: Table Of Contents - Alignment issue of marker's view.
* Fix: Marketing Button - Block does not remain in the stack order when the Blocksy theme is active.
* Fix: Call To Action - Second button CSS style issue on the frontend.
* Fix: Scroll to specific block not working when switch from desktop/tablet/mobile.
* Fix: Post Block - Article tag class conflicting with TranslatePress plugin.
* Fix: Presets - Most presets used to override background color, box-shadow color, text content and even selected icons; This has been fixed where ever possible.
* Fix: Info Box - The title is disabled on the editor if we set P tag.
* Fix: Tabs block - Aria mismatch issue on the lighthouse.
* Fix: Image block - Negative margin is not working inside container.
* Fix: Responsive condition does not save when we use the Legacy Widget.