### PR TITLE
SPCTR-2174 - Advanced Heading - Alignment set to center by default on front-end after 2.1 release

### DIFF
--- a/includes/blocks/advanced-heading/attributes.php
+++ b/includes/blocks/advanced-heading/attributes.php
@@ -11,8 +11,6 @@ $highLight_border_attribute = UAGB_Block_Helper::uag_generate_border_attribute( 
 
 $enable_legacy_blocks = UAGB_Admin_Helper::get_admin_settings_option( 'uag_enable_legacy_blocks', ( 'yes' === get_option( 'uagb-old-user-less-than-2' ) ) ? 'yes' : 'no' );
 
-$heading_alignment_default = ( 'yes' === get_option( 'uagb-old-user-less-than-2' ) ) ? 'center' : '';
-
 return array_merge(
 	$highLight_border_attribute,
 	array(
@@ -20,7 +18,7 @@ return array_merge(
 		'blockBackground'              => '',
 		'blockBackgroundType'          => 'classic',
 		'blockGradientBackground'      => 'linear-gradient(90deg, rgb(6, 147, 227) 0%, rgb(155, 81, 224) 100%)',
-		'headingAlign'                 => $heading_alignment_default,
+		'headingAlign'                 => '',
 		'headingAlignTablet'           => '',
 		'headingDescPosition'          => 'below-heading',
 		'seperatorPosition'            => 'below-heading',

--- a/includes/blocks/advanced-heading/frontend.css.php
+++ b/includes/blocks/advanced-heading/frontend.css.php
@@ -19,6 +19,7 @@ $highLight_border_css        = UAGB_Block_Helper::uag_generate_border_css( $attr
 $highLight_border_css_tablet = UAGB_Block_Helper::uag_generate_border_css( $attr, 'highLight', 'tablet' );
 $highLight_border_css_mobile = UAGB_Block_Helper::uag_generate_border_css( $attr, 'highLight', 'mobile' );
 
+$heading_alignment_default = $attr['headingAlign'] ? $attr['headingAlign'] : ( ( 'yes' === get_option( 'uagb-old-user-less-than-2' ) ) ? 'center' : 'left' ) ;
 
 $selectors = array(
 	'.wp-block-uagb-advanced-heading .uagb-heading-text' => array(
@@ -30,7 +31,7 @@ $selectors = array(
 	),
 	'.wp-block-uagb-advanced-heading '                   => array(
 		'background'     => 'classic' === $attr['blockBackgroundType'] ? $attr['blockBackground'] : $attr['blockGradientBackground'],
-		'text-align'     => $attr['headingAlign'],
+		'text-align'     => $heading_alignment_default,
 		'margin-top'     => UAGB_Helper::get_css_value(
 			$attr['blockTopMargin'],
 			$attr['blockMarginUnit']


### PR DESCRIPTION
### Description
Advanced Heading - Alignment set to center by default on front-end after 2.1 release

### Types of changes
Bug fix (non-breaking change which fixes an issue) 

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
