### PR TITLE
chore: Astra 4.0 menu position updated next to dashboard on admin screen

### DIFF
--- a/compatibility/class-uagb-astra-compatibility.php
+++ b/compatibility/class-uagb-astra-compatibility.php
@@ -38,6 +38,9 @@ class UAGB_Astra_Compatibility {
 	 */
 	public function __construct() {
 
+		// Update Astra's admin top level menu position.
+		add_filter( 'astra_menu_priority', array( $this, 'update_admin_menu_position' ) );
+
 		$uag_load_fonts_locally = UAGB_Admin_Helper::get_admin_settings_option( 'uag_load_gfonts_locally', 'disabled' );
 
 		if ( 'disabled' === $uag_load_fonts_locally ) {
@@ -89,6 +92,16 @@ class UAGB_Astra_Compatibility {
 		}
 
 		return $astra_fonts;
+	}
+
+	/**
+	 * Update Astra's menu priority to show after Dashboard menu.
+	 *
+	 * @param int $menu_priority top level menu priority.
+	 * @since x.x.x
+	 */
+	public function update_admin_menu_position( $menu_priority ) {
+		return 2.1;
 	}
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -171,6 +171,7 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 == Changelog ==
 
 = 2.2.1 =
+* Improvement: Added support for Astra's 4.0 theme menu position next to the Dashboard in admin.
 * Fix: Image Gallery - When adding any of the HTML code or adding the link, the visibility of that caption gets changed to always visible
 * Fix: Image Gallery - Broken link were shown in gallery on frontend when added to caption.
 * Fix: Testimonial - Carousel dots overlapping on below blocks in the mobile device.


### PR DESCRIPTION
### Description
- When Spectra gets activate, update the Astra menu position on top.
- Ref PR for Starter Templates - https://github.com/brainstormforce/astra-sites/pull/490

### Screenshots
- With default position - https://share.getcloudapp.com/geuOdeAA
- With Spectra - https://share.getcloudapp.com/4gu4ZElA

### Types of changes
- New feature (non-breaking change)

### How has this been tested?
- Use this Astra 4.0 zip - https://share.getcloudapp.com/kpuO6kpG
- Once this zip installed you will get Astra menu on top of "Appearance"
- Once switched to this Spectra's branch Astra menu position gets updated at 2nd location.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
