### PR TITLE
refactor: Added WPML compatibility for Info Box & Advanced Heading

### DIFF
--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -2,7 +2,7 @@
 <wpml-config>
 	<gutenberg-blocks>
 		<gutenberg-block type="uagb/advanced-heading" translate="1">
-			<xpath>//*[self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6]</xpath>
+			<xpath>//*[self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6 or self::p]</xpath>
 			<xpath>//div/p[@class="uagb-desc-text"]</xpath>
 			<key name="customUrl" />
 		</gutenberg-block>
@@ -38,7 +38,7 @@
 		<gutenberg-block type="uagb/info-box" translate="1">
 			<xpath>//span[@class="uagb-ifb-title-prefix"]</xpath>
 			<xpath>//a/@href</xpath>
-			<xpath>//*[self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6]</xpath>
+			<xpath>//*[self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6 or self::a]</xpath>
 			<xpath>//p[@class="uagb-ifb-desc"]</xpath>
 			<key name="ctaText" />
 			<key name="ctaType" />


### PR DESCRIPTION
### Description
- Following blocks WPML support has been updated
- - Advanced heading
- - Info box

### Screenshots
<!-- if applicable -->

### Types of changes
- Compatibility (non-breaking change)

### How has this been tested?
- With WPML translations for Advanced heading with inner para
- With WPML translations for Info box with inner anchor link

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
