### PR TITLE
SPCTR-2521: Improvement: Prettier formatting

### DIFF
--- a/src/blocks/forms/child-blocks/accept/attributes.js
+++ b/src/blocks/forms/child-blocks/accept/attributes.js
@@ -17,10 +17,7 @@ const attributes = {
 	},
 	acceptText: {
 		type: 'string',
-		default: __(
-			'I have read and agree to the Privacy Policy.',
-			'ultimate-addons-for-gutenberg'
-		),
+		default: __( 'I have read and agree to the Privacy Policy.', 'ultimate-addons-for-gutenberg' ),
 	},
 	showLink: {
 		type: 'boolean',

--- a/src/blocks/forms/child-blocks/accept/block.js
+++ b/src/blocks/forms/child-blocks/accept/block.js
@@ -19,18 +19,14 @@ registerBlockType( 'uagb/forms-accept', {
 	parent: [ 'uagb/forms' ],
 	attributes,
 	edit: ( props ) =>
-		props.attributes.isPreview ? (
-			<PreviewImage image="form-accept" isChildren={ true } />
-		) : (
-			<Edit { ...props } />
-		),
+		props.attributes.isPreview ? <PreviewImage image="form-accept" isChildren={ true } /> : <Edit { ...props } />,
 	supports: {
 		anchor: true,
 	},
 	example: {
 		attributes: {
 			isPreview: true,
-		}
+		},
 	},
 	save,
 } );

--- a/src/blocks/forms/child-blocks/accept/edit.js
+++ b/src/blocks/forms/child-blocks/accept/edit.js
@@ -4,7 +4,6 @@
 
 import { useEffect } from '@wordpress/element';
 
-
 import Settings from './settings';
 import Render from './render';
 
@@ -17,10 +16,7 @@ const UAGBFormsAcceptEdit = ( props ) => {
 
 		// Pushing Style tag for this block css.
 		const $style = document.createElement( 'style' );
-		$style.setAttribute(
-			'id',
-			'uagb-style-forms-accept-' + clientId.substr( 0, 8 )
-		);
+		$style.setAttribute( 'id', 'uagb-style-forms-accept-' + clientId.substr( 0, 8 ) );
 		document.head.appendChild( $style );
 	}, [] );
 

--- a/src/blocks/forms/child-blocks/accept/render.js
+++ b/src/blocks/forms/child-blocks/accept/render.js
@@ -15,19 +15,9 @@ const Render = ( props ) => {
 
 	const { attributes } = props;
 
-	const {
-		block_id,
-		acceptRequired,
-		acceptText,
-		showLink,
-		linkLabel,
-		link,
-		linkInNewTab,
-	} = attributes;
+	const { block_id, acceptRequired, acceptText, showLink, linkLabel, link, linkInNewTab } = attributes;
 
-	const isRequired = acceptRequired
-		? __( 'required', 'ultimate-addons-for-gutenberg' )
-		: '';
+	const isRequired = acceptRequired ? __( 'required', 'ultimate-addons-for-gutenberg' ) : '';
 	const target = linkInNewTab
 		? __( '_blank', 'ultimate-addons-for-gutenberg' )
 		: __( '_self', 'ultimate-addons-for-gutenberg' );
@@ -35,19 +25,11 @@ const Render = ( props ) => {
 	return (
 		<>
 			<div
-				className={ classnames(
-					'uagb-forms-accept-wrap',
-					'uagb-forms-field-set',
-					`uagb-block-${ block_id }`
-				) }
+				className={ classnames( 'uagb-forms-accept-wrap', 'uagb-forms-field-set', `uagb-block-${ block_id }` ) }
 			>
 				{ showLink && (
 					<div className="uagb-forms-accept-privacy-link">
-						<a
-							href={ link }
-							target={ target }
-							rel="noopener noreferrer"
-						>
+						<a href={ link } target={ target } rel="noopener noreferrer">
 							{ ' ' }
 							{ linkLabel }{ ' ' }
 						</a>

--- a/src/blocks/forms/child-blocks/accept/save.js
+++ b/src/blocks/forms/child-blocks/accept/save.js
@@ -9,38 +9,18 @@ import { __ } from '@wordpress/i18n';
 export default function save( props ) {
 	const { attributes } = props;
 
-	const {
-		block_id,
-		acceptRequired,
-		acceptText,
-		showLink,
-		linkLabel,
-		link,
-		linkInNewTab,
-	} = attributes;
+	const { block_id, acceptRequired, acceptText, showLink, linkLabel, link, linkInNewTab } = attributes;
 
-	const isRequired = acceptRequired
-		? __( 'required', 'ultimate-addons-for-gutenberg' )
-		: '';
+	const isRequired = acceptRequired ? __( 'required', 'ultimate-addons-for-gutenberg' ) : '';
 	const target = linkInNewTab
 		? __( '_blank', 'ultimate-addons-for-gutenberg' )
 		: __( '_self', 'ultimate-addons-for-gutenberg' );
 
 	return (
-		<div
-			className={ classnames(
-				'uagb-forms-accept-wrap',
-				'uagb-forms-field-set',
-				`uagb-block-${ block_id }`
-			) }
-		>
+		<div className={ classnames( 'uagb-forms-accept-wrap', 'uagb-forms-field-set', `uagb-block-${ block_id }` ) }>
 			{ showLink && (
 				<div className="uagb-forms-accept-privacy-link">
-					<a
-						href={ link }
-						target={ target }
-						rel="noopener noreferrer"
-					>
+					<a href={ link } target={ target } rel="noopener noreferrer">
 						{ ' ' }
 						{ linkLabel }{ ' ' }
 					</a>

--- a/src/blocks/forms/child-blocks/accept/settings.js
+++ b/src/blocks/forms/child-blocks/accept/settings.js
@@ -1,17 +1,12 @@
 import { __ } from '@wordpress/i18n';
 import { memo } from '@wordpress/element';
 import InspectorTabs from '@Components/inspector-tabs/InspectorTabs.js';
-import InspectorTab, {
-	UAGTabs,
-} from '@Components/inspector-tabs/InspectorTab.js';
+import InspectorTab, { UAGTabs } from '@Components/inspector-tabs/InspectorTab.js';
 
-import {
-	ToggleControl,
-} from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
 
 import { InspectorControls } from '@wordpress/block-editor';
 import UAGTextControl from '@Components/text-control';
-
 
 import UAGAdvancedPanelBody from '@Components/advanced-panel-body';
 
@@ -20,47 +15,30 @@ const Settings = ( props ) => {
 
 	const { attributes, setAttributes } = props;
 
-	const {
-		acceptRequired,
-		acceptText,
-		showLink,
-		linkLabel,
-		link,
-		linkInNewTab,
-	} = attributes;
+	const { acceptRequired, acceptText, showLink, linkLabel, link, linkInNewTab } = attributes;
 
 	const acceptInspectorControls = () => {
 		return (
 			<UAGAdvancedPanelBody initialOpen={ true }>
 				<UAGTextControl
-					variant='textarea'
-					label={ __(
-						'Acceptance Text',
-						'ultimate-addons-for-gutenberg'
-					) }
+					variant="textarea"
+					label={ __( 'Acceptance Text', 'ultimate-addons-for-gutenberg' ) }
 					help={ __( 'Label to display as acceptance message.', 'ultimate-addons-for-gutenberg' ) }
 					value={ acceptText }
-					data={{
+					data={ {
 						value: acceptText,
 						label: 'acceptText',
-					}}
+					} }
 					setAttributes={ setAttributes }
-					onChange={ ( value ) =>
-						setAttributes( { acceptText: value } )
-					}
+					onChange={ ( value ) => setAttributes( { acceptText: value } ) }
 				/>
 				<ToggleControl
 					label={ __( 'Required', 'ultimate-addons-for-gutenberg' ) }
 					checked={ acceptRequired }
-					onChange={ () =>
-						setAttributes( { acceptRequired: ! acceptRequired } )
-					}
+					onChange={ () => setAttributes( { acceptRequired: ! acceptRequired } ) }
 				/>
 				<ToggleControl
-					label={ __(
-						'Enable Privacy Link',
-						'ultimate-addons-for-gutenberg'
-					) }
+					label={ __( 'Enable Privacy Link', 'ultimate-addons-for-gutenberg' ) }
 					checked={ showLink }
 					onChange={ () => setAttributes( { showLink: ! showLink } ) }
 				/>
@@ -68,49 +46,29 @@ const Settings = ( props ) => {
 				{ showLink && (
 					<>
 						<UAGTextControl
-							label={ __(
-								'Link Label',
-								'ultimate-addons-for-gutenberg'
-							) }
+							label={ __( 'Link Label', 'ultimate-addons-for-gutenberg' ) }
 							value={ linkLabel }
-							data={{
+							data={ {
 								value: linkLabel,
 								label: 'linkLabel',
-							}}
+							} }
 							setAttributes={ setAttributes }
-							onChange={ ( value ) =>
-								setAttributes( { linkLabel: value } )
-							}
+							onChange={ ( value ) => setAttributes( { linkLabel: value } ) }
 						/>
 						<UAGTextControl
 							className="uagb-forms-editor-privacy-link"
-							label={ __(
-								'Link',
-								'ultimate-addons-for-gutenberg'
-							) }
+							label={ __( 'Link', 'ultimate-addons-for-gutenberg' ) }
 							value={ link }
-							data={{
+							data={ {
 								value: link,
 								label: 'link',
-							}}
+							} }
 							setAttributes={ setAttributes }
-							onChange={ ( value ) =>
-								setAttributes( { link: value } )
-							}
-							help={
-								'' === link
-									? __(
-											'Enter a valid link.',
-											'ultimate-addons-for-gutenberg'
-									  )
-									: ''
-							}
+							onChange={ ( value ) => setAttributes( { link: value } ) }
+							help={ '' === link ? __( 'Enter a valid link.', 'ultimate-addons-for-gutenberg' ) : '' }
 						/>
 						<ToggleControl
-							label={ __(
-								'Open in new tab',
-								'ultimate-addons-for-gutenberg'
-							) }
+							label={ __( 'Open in new tab', 'ultimate-addons-for-gutenberg' ) }
 							checked={ linkInNewTab }
 							onChange={ () =>
 								setAttributes( {
@@ -128,9 +86,7 @@ const Settings = ( props ) => {
 		<>
 			<InspectorControls>
 				<InspectorTabs tabs={ [ 'general', 'advance' ] }>
-					<InspectorTab { ...UAGTabs.general }>
-						{ acceptInspectorControls() }
-					</InspectorTab>
+					<InspectorTab { ...UAGTabs.general }>{ acceptInspectorControls() }</InspectorTab>
 					<InspectorTab { ...UAGTabs.advance }></InspectorTab>
 				</InspectorTabs>
 			</InspectorControls>

--- a/src/blocks/forms/child-blocks/checkbox/attributes.js
+++ b/src/blocks/forms/child-blocks/checkbox/attributes.js
@@ -23,14 +23,8 @@ const attributes = {
 		type: 'array',
 		default: [
 			{
-				optiontitle: __(
-					'Option Name 1',
-					'ultimate-addons-for-gutenberg'
-				),
-				optionvalue: __(
-					'Option Value 1',
-					'ultimate-addons-for-gutenberg'
-				),
+				optiontitle: __( 'Option Name 1', 'ultimate-addons-for-gutenberg' ),
+				optionvalue: __( 'Option Value 1', 'ultimate-addons-for-gutenberg' ),
 			},
 		],
 	},

--- a/src/blocks/forms/child-blocks/checkbox/block.js
+++ b/src/blocks/forms/child-blocks/checkbox/block.js
@@ -20,18 +20,14 @@ registerBlockType( 'uagb/forms-checkbox', {
 	parent: [ 'uagb/forms' ],
 	attributes,
 	edit: ( props ) =>
-		props.attributes.isPreview ? (
-			<PreviewImage image="form-checkbox" isChildren={ true } />
-		) : (
-			<Edit { ...props } />
-		),
+		props.attributes.isPreview ? <PreviewImage image="form-checkbox" isChildren={ true } /> : <Edit { ...props } />,
 	supports: {
 		anchor: true,
 	},
 	example: {
 		attributes: {
 			isPreview: true,
-		}
+		},
 	},
 	save,
 	deprecated,

--- a/src/blocks/forms/child-blocks/checkbox/deprecated.js
+++ b/src/blocks/forms/child-blocks/checkbox/deprecated.js
@@ -1,12 +1,12 @@
 /**
  * BLOCK: Forms - Checkbox - Deprecared
  */
- import classnames from 'classnames';
- import { __ } from '@wordpress/i18n';
- import { RichText } from '@wordpress/block-editor';
+import classnames from 'classnames';
+import { __ } from '@wordpress/i18n';
+import { RichText } from '@wordpress/block-editor';
 import { Fragment } from '@wordpress/element';
- 
- const attributes = {
+
+const attributes = {
 	isPreview: {
 		type: 'boolean',
 		default: false,
@@ -26,71 +26,61 @@ import { Fragment } from '@wordpress/element';
 		type: 'array',
 		default: [
 			{
-				optiontitle: __(
-					'Option Name 1',
-					'ultimate-addons-for-gutenberg'
-				),
-				optionvalue: __(
-					'Option Value 1',
-					'ultimate-addons-for-gutenberg'
-				),
+				optiontitle: __( 'Option Name 1', 'ultimate-addons-for-gutenberg' ),
+				optionvalue: __( 'Option Value 1', 'ultimate-addons-for-gutenberg' ),
 			},
 		],
 	},
 };
- 
- const deprecated = [
-     {
-         attributes,
-         save( props ) {
-            const { attributes } = props;
-        
-            const { block_id, checkboxRequired, options, checkboxName } = attributes;
-        
-            const isRequired = checkboxRequired
-                ? __( 'required', 'ultimate-addons-for-gutenberg' )
-                : '';
-        
-            return (
-                <div
-                    className={ classnames(
-                        'uagb-forms-checkbox-wrap',
-                        'uagb-forms-field-set',
-                        `uagb-block-${ block_id }`
-                    ) }
-                >
-                    <RichText.Content
-                        tagName="div"
-                        value={ checkboxName }
-                        className={ `uagb-forms-checkbox-label ${ isRequired } uagb-forms-input-label` }
-                        id={ block_id }
-                    />
-        
-                    { options.map( ( o, index ) => {
-                        const optionvalue = o.optionvalue;
-                        const value = optionvalue.replace( /\s+/g, '-' ).toLowerCase();
-                        return (
-                            <Fragment key={ index }>
-                                <input
-                                    type="checkbox"
-                                    className="uagb-forms-checkbox"
-                                    id={ `checkbox-${ value }-${ block_id }` }
-                                    name={ `${ checkboxName }[]` }
-                                    value={ optionvalue }
-                                    required={ checkboxRequired }
-                                    onInvalid="this.setCustomValidity('Please check this box if you want to proceed.')"
-                                />
-                                <label htmlFor={ `checkbox-${ value }-${ block_id }` }>
-                                    { o.optiontitle }
-                                </label>
-                                <br />
-                            </Fragment>
-                        );
-                    } ) }
-                </div>
-            );
-        }        
-     }
- ];
- 
- export default deprecated;
+
+const deprecated = [
+	{
+		attributes,
+		save( props ) {
+			const { attributes } = props;
+
+			const { block_id, checkboxRequired, options, checkboxName } = attributes;
+
+			const isRequired = checkboxRequired ? __( 'required', 'ultimate-addons-for-gutenberg' ) : '';
+
+			return (
+				<div
+					className={ classnames(
+						'uagb-forms-checkbox-wrap',
+						'uagb-forms-field-set',
+						`uagb-block-${ block_id }`
+					) }
+				>
+					<RichText.Content
+						tagName="div"
+						value={ checkboxName }
+						className={ `uagb-forms-checkbox-label ${ isRequired } uagb-forms-input-label` }
+						id={ block_id }
+					/>
+
+					{ options.map( ( o, index ) => {
+						const optionvalue = o.optionvalue;
+						const value = optionvalue.replace( /\s+/g, '-' ).toLowerCase();
+						return (
+							<Fragment key={ index }>
+								<input
+									type="checkbox"
+									className="uagb-forms-checkbox"
+									id={ `checkbox-${ value }-${ block_id }` }
+									name={ `${ checkboxName }[]` }
+									value={ optionvalue }
+									required={ checkboxRequired }
+									onInvalid="this.setCustomValidity('Please check this box if you want to proceed.')"
+								/>
+								<label htmlFor={ `checkbox-${ value }-${ block_id }` }>{ o.optiontitle }</label>
+								<br />
+							</Fragment>
+						);
+					} ) }
+				</div>
+			);
+		},
+	},
+];
+
+export default deprecated;

--- a/src/blocks/forms/child-blocks/checkbox/edit.js
+++ b/src/blocks/forms/child-blocks/checkbox/edit.js
@@ -5,21 +5,19 @@
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
 
-
 import Settings from './settings';
 import Render from './render';
 
 const UAGBFormsCheckboxEdit = ( props ) => {
-
 	const { isSelected, setAttributes, clientId } = props;
-    const [ state, setState ] = useState( { optionsstate: [ // eslint-disable-line no-unused-vars
-		{
-			optiontitle: __(
-				'Option Name 1',
-				'ultimate-addons-for-gutenberg'
-			),
-		},
-	], } );
+	// eslint-disable-next-line no-unused-vars
+	const [ state, setState ] = useState( {
+		optionsstate: [
+			{
+				optiontitle: __( 'Option Name 1', 'ultimate-addons-for-gutenberg' ),
+			},
+		],
+	} );
 
 	useEffect( () => {
 		// Assigning block_id in the attribute.
@@ -27,18 +25,15 @@ const UAGBFormsCheckboxEdit = ( props ) => {
 
 		// Pushing Style tag for this block css.
 		const $style = document.createElement( 'style' );
-		$style.setAttribute(
-			'id',
-			'uagb-style-forms-checkbox-' + clientId.substr( 0, 8 )
-		);
+		$style.setAttribute( 'id', 'uagb-style-forms-checkbox-' + clientId.substr( 0, 8 ) );
 		document.head.appendChild( $style );
 	}, [] );
 
 	return (
-			<>
-				{ isSelected && <Settings parentProps={ props } /> }
-				<Render parentProps={ props } setState={ setState } />
-			</>
+		<>
+			{ isSelected && <Settings parentProps={ props } /> }
+			<Render parentProps={ props } setState={ setState } />
+		</>
 	);
 };
 

--- a/src/blocks/forms/child-blocks/checkbox/render.js
+++ b/src/blocks/forms/child-blocks/checkbox/render.js
@@ -24,18 +24,12 @@ const Render = ( props ) => {
 
 	const { block_id, checkboxRequired, options, checkboxName } = attributes;
 
-	const isRequired = checkboxRequired
-	? __( 'required', 'ultimate-addons-for-gutenberg' )
-	: '';
+	const isRequired = checkboxRequired ? __( 'required', 'ultimate-addons-for-gutenberg' ) : '';
 
 	const addOption = () => {
 		const newOption = {
-			optiontitle:
-				__( 'Option Name ', 'ultimate-addons-for-gutenberg' ) +
-				`${ options.length + 1 }`,
-			optionvalue:
-				__( 'Option Value ', 'ultimate-addons-for-gutenberg' ) +
-				`${ options.length + 1 }`,
+			optiontitle: __( 'Option Name ', 'ultimate-addons-for-gutenberg' ) + `${ options.length + 1 }`,
+			optionvalue: __( 'Option Value ', 'ultimate-addons-for-gutenberg' ) + `${ options.length + 1 }`,
 		};
 		options[ options.length ] = newOption;
 		const addnewOptions = options.map( ( item ) => item );
@@ -74,9 +68,7 @@ const Render = ( props ) => {
 				<input
 					className="uagb-inner-input-view"
 					aria-label={ option.optionvalue }
-					onChange={ ( e ) =>
-						changeOption( { optionvalue: e.target.value }, index )
-					}
+					onChange={ ( e ) => changeOption( { optionvalue: e.target.value }, index ) }
 					type="text"
 					value={ option.optionvalue }
 					required={ checkboxRequired }
@@ -105,9 +97,7 @@ const Render = ( props ) => {
 						value={ value }
 						required={ checkboxRequired }
 					/>
-					<label htmlFor={ `checkbox-${ value }-${ block_id }` }>
-						{ option.optiontitle }
-					</label>
+					<label htmlFor={ `checkbox-${ value }-${ block_id }` }>{ option.optiontitle }</label>
 					<br />
 				</>
 			);
@@ -150,14 +140,9 @@ const Render = ( props ) => {
 			>
 				<RichText
 					tagName="div"
-					placeholder={ __(
-						'Checkbox Title',
-						'ultimate-addons-for-gutenberg'
-					) }
+					placeholder={ __( 'Checkbox Title', 'ultimate-addons-for-gutenberg' ) }
 					value={ checkboxName }
-					onChange={ ( value ) =>
-						setAttributes( { checkboxName: value } )
-					}
+					onChange={ ( value ) => setAttributes( { checkboxName: value } ) }
 					className={ `uagb-forms-checkbox-label ${ isRequired } uagb-forms-input-label` }
 					multiline={ false }
 					id={ block_id }
@@ -168,10 +153,7 @@ const Render = ( props ) => {
 						<div className="uagb-forms-checkbox-controls">
 							<div>
 								<Button isSecondary onClick={ addOption }>
-									{ __(
-										' + Add Option ',
-										'ultimate-addons-for-gutenberg'
-									) }
+									{ __( ' + Add Option ', 'ultimate-addons-for-gutenberg' ) }
 								</Button>
 							</div>
 						</div>

--- a/src/blocks/forms/child-blocks/checkbox/save.js
+++ b/src/blocks/forms/child-blocks/checkbox/save.js
@@ -12,18 +12,10 @@ export default function save( props ) {
 
 	const { block_id, checkboxRequired, options, checkboxName } = attributes;
 
-	const isRequired = checkboxRequired
-		? __( 'required', 'ultimate-addons-for-gutenberg' )
-		: '';
+	const isRequired = checkboxRequired ? __( 'required', 'ultimate-addons-for-gutenberg' ) : '';
 
 	return (
-		<div
-			className={ classnames(
-				'uagb-forms-checkbox-wrap',
-				'uagb-forms-field-set',
-				`uagb-block-${ block_id }`
-			) }
-		>
+		<div className={ classnames( 'uagb-forms-checkbox-wrap', 'uagb-forms-field-set', `uagb-block-${ block_id }` ) }>
 			<RichText.Content
 				tagName="div"
 				value={ checkboxName }
@@ -44,9 +36,7 @@ export default function save( props ) {
 							value={ optionvalue }
 							required={ checkboxRequired }
 						/>
-						<label htmlFor={ `checkbox-${ value }-${ block_id }` }>
-							{ o.optiontitle }
-						</label>
+						<label htmlFor={ `checkbox-${ value }-${ block_id }` }>{ o.optiontitle }</label>
 						<br />
 					</Fragment>
 				);

--- a/src/blocks/forms/child-blocks/checkbox/settings.js
+++ b/src/blocks/forms/child-blocks/checkbox/settings.js
@@ -2,13 +2,9 @@ import { __ } from '@wordpress/i18n';
 import { memo } from '@wordpress/element';
 import { ToggleControl } from '@wordpress/components';
 import InspectorTabs from '@Components/inspector-tabs/InspectorTabs.js';
-import InspectorTab, {
-	UAGTabs,
-} from '@Components/inspector-tabs/InspectorTab.js';
+import InspectorTab, { UAGTabs } from '@Components/inspector-tabs/InspectorTab.js';
 
 import { InspectorControls } from '@wordpress/block-editor';
-
-
 
 import UAGAdvancedPanelBody from '@Components/advanced-panel-body';
 
@@ -38,9 +34,7 @@ const Settings = ( props ) => {
 	return (
 		<InspectorControls>
 			<InspectorTabs tabs={ [ 'general', 'advance' ] }>
-				<InspectorTab { ...UAGTabs.general }>
-					{ checkboxInspectorControls() }
-				</InspectorTab>
+				<InspectorTab { ...UAGTabs.general }>{ checkboxInspectorControls() }</InspectorTab>
 				<InspectorTab { ...UAGTabs.advance }></InspectorTab>
 			</InspectorTabs>
 		</InspectorControls>

--- a/src/blocks/forms/child-blocks/date/attributes.js
+++ b/src/blocks/forms/child-blocks/date/attributes.js
@@ -50,6 +50,6 @@ const attributes = {
 	autocomplete: {
 		type: 'string',
 		default: 'bday',
-	}
+	},
 };
 export default attributes;

--- a/src/blocks/forms/child-blocks/date/block.js
+++ b/src/blocks/forms/child-blocks/date/block.js
@@ -20,18 +20,14 @@ registerBlockType( 'uagb/forms-date', {
 	parent: [ 'uagb/forms' ],
 	attributes,
 	edit: ( props ) =>
-		props.attributes.isPreview ? (
-			<PreviewImage image="form-field" isChildren={ true } />
-		) : (
-			<Edit { ...props } />
-		),
+		props.attributes.isPreview ? <PreviewImage image="form-field" isChildren={ true } /> : <Edit { ...props } />,
 	supports: {
 		anchor: true,
 	},
 	example: {
 		attributes: {
 			isPreview: true,
-		}
+		},
 	},
 	save,
 	deprecated,

--- a/src/blocks/forms/child-blocks/date/deprecated.js
+++ b/src/blocks/forms/child-blocks/date/deprecated.js
@@ -52,8 +52,18 @@ const deprecated = [
 	{
 		attributes,
 		save( props ) {
-			const { block_id, dateRequired, name, additonalVal, minYear, minMonth, minDay, maxYear, maxMonth, maxDay } =
-				props.attributes;
+			const {
+				block_id,
+				dateRequired,
+				name,
+				additonalVal,
+				minYear,
+				minMonth,
+				minDay,
+				maxYear,
+				maxMonth,
+				maxDay,
+			} = props.attributes;
 
 			var validation_min_value = '';
 			var validation_max_value = '';

--- a/src/blocks/forms/child-blocks/date/deprecated.js
+++ b/src/blocks/forms/child-blocks/date/deprecated.js
@@ -8,101 +8,107 @@ import { RichText } from '@wordpress/block-editor';
 
 const attributes = {
 	block_id: {
-	  type: "string"
+		type: 'string',
 	},
-	dateRequired : {
-	  type: "boolean",
-	  default: false
+	dateRequired: {
+		type: 'boolean',
+		default: false,
 	},
 	name: {
-	  type: "string",
-	  default: __("Date" , 'ultimate-addons-for-gutenberg' )
+		type: 'string',
+		default: __( 'Date', 'ultimate-addons-for-gutenberg' ),
 	},
-	additonalVal : {
-	  type: "boolean",
-	  default: false
+	additonalVal: {
+		type: 'boolean',
+		default: false,
 	},
 	minYear: {
-	  type: "string",    
-	  default: "",   
+		type: 'string',
+		default: '',
 	},
 	minMonth: {
-	  type: "string",  
-	  default: "",   
+		type: 'string',
+		default: '',
 	},
 	minDay: {
-	  type: "string",   
-	  default: "",   
+		type: 'string',
+		default: '',
 	},
 	maxYear: {
-	  type: "string",
-	  default: "",   
+		type: 'string',
+		default: '',
 	},
 	maxMonth: {
-	  type: "string",
-	  default: "",   
+		type: 'string',
+		default: '',
 	},
 	maxDay: {
-	  type: "string",
-	  default: "",  
+		type: 'string',
+		default: '',
 	},
-}
+};
 
 const deprecated = [
 	{
 		attributes,
 		save( props ) {
-			const {
-				block_id,
-				dateRequired,
-				name,
-				additonalVal,
-				minYear,
-				minMonth,
-				minDay,
-				maxYear,
-				maxMonth,
-				maxDay
-			} = props.attributes
-			
-			var validation_min_value = "";
-			var validation_max_value = "";
-			
-			if( minYear && minMonth && minDay ){
-				validation_min_value = minYear+"-"+minMonth+"-"+minDay			
+			const { block_id, dateRequired, name, additonalVal, minYear, minMonth, minDay, maxYear, maxMonth, maxDay } =
+				props.attributes;
+
+			var validation_min_value = '';
+			var validation_max_value = '';
+
+			if ( minYear && minMonth && minDay ) {
+				validation_min_value = minYear + '-' + minMonth + '-' + minDay;
 			}
-		
-			if( maxYear && maxMonth && maxDay ){	
-				validation_max_value = maxYear+"-"+maxMonth+"-"+maxDay		
+
+			if ( maxYear && maxMonth && maxDay ) {
+				validation_max_value = maxYear + '-' + maxMonth + '-' + maxDay;
 			}
-		
-			var date_html = "";
-			if( additonalVal ){
-				date_html = <input type="date" className="uagb-forms-date-input uagb-forms-input"  required={ dateRequired } min={validation_min_value} max={validation_max_value} name={ block_id }/>
-				
-			}else{
-				date_html = <input type="date" className="uagb-forms-date-input uagb-forms-input"  required={ dateRequired } name={ block_id }/>
-		
-			}
-			const isRequired = (dateRequired) ? __("required", 'ultimate-addons-for-gutenberg') : "";
-		
-			return (
-				<div className={ classnames(
-					"uagb-forms-date-wrap",
-					"uagb-forms-field-set",
-					`uagb-block-${ block_id }`,
-				) }>
-					<RichText.Content
-					tagName="div"
-					value={ name }
-					className={`uagb-forms-date-label ${isRequired} uagb-forms-input-label`}	
-					id={ block_id }
+
+			var date_html = '';
+			if ( additonalVal ) {
+				date_html = (
+					<input
+						type="date"
+						className="uagb-forms-date-input uagb-forms-input"
+						required={ dateRequired }
+						min={ validation_min_value }
+						max={ validation_max_value }
+						name={ block_id }
 					/>
-					{date_html}
+				);
+			} else {
+				date_html = (
+					<input
+						type="date"
+						className="uagb-forms-date-input uagb-forms-input"
+						required={ dateRequired }
+						name={ block_id }
+					/>
+				);
+			}
+			const isRequired = dateRequired ? __( 'required', 'ultimate-addons-for-gutenberg' ) : '';
+
+			return (
+				<div
+					className={ classnames(
+						'uagb-forms-date-wrap',
+						'uagb-forms-field-set',
+						`uagb-block-${ block_id }`
+					) }
+				>
+					<RichText.Content
+						tagName="div"
+						value={ name }
+						className={ `uagb-forms-date-label ${ isRequired } uagb-forms-input-label` }
+						id={ block_id }
+					/>
+					{ date_html }
 				</div>
-			)
-        }
-    }
+			);
+		},
+	},
 ];
 
 export default deprecated;

--- a/src/blocks/forms/child-blocks/date/edit.js
+++ b/src/blocks/forms/child-blocks/date/edit.js
@@ -4,31 +4,27 @@
 
 import { useEffect } from '@wordpress/element';
 
-
 import Settings from './settings';
 import Render from './render';
 
 const UAGBFormsDateEdit = ( props ) => {
 	const { isSelected, setAttributes, clientId } = props;
-	
+
 	useEffect( () => {
 		// Assigning block_id in the attribute.
 		setAttributes( { block_id: clientId.substr( 0, 8 ) } );
 
 		// Pushing Style tag for this block css.
 		const $style = document.createElement( 'style' );
-		$style.setAttribute(
-			'id',
-			'uagb-style-forms-date-' + clientId.substr( 0, 8 )
-		);
+		$style.setAttribute( 'id', 'uagb-style-forms-date-' + clientId.substr( 0, 8 ) );
 		document.head.appendChild( $style );
 	}, [] );
 
 	return (
-			<>
+		<>
 			{ isSelected && <Settings parentProps={ props } /> }
-				<Render parentProps={ props } />
-			</>
+			<Render parentProps={ props } />
+		</>
 	);
 };
 

--- a/src/blocks/forms/child-blocks/date/render.js
+++ b/src/blocks/forms/child-blocks/date/render.js
@@ -3,7 +3,6 @@ import { useLayoutEffect, memo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import styles from './editor.lazy.scss';
 
-
 import { RichText } from '@wordpress/block-editor';
 
 const Render = ( props ) => {
@@ -19,15 +18,7 @@ const Render = ( props ) => {
 
 	const { attributes, setAttributes } = props;
 
-	const {
-		block_id,
-		dateRequired,
-		name,
-		additonalVal,
-		minYear,
-		minMonth,
-		minDay,
-	} = attributes;
+	const { block_id, dateRequired, name, additonalVal, minYear, minMonth, minDay } = attributes;
 
 	let validation_min_value = '';
 	const validation_max_value = '';
@@ -59,25 +50,14 @@ const Render = ( props ) => {
 		);
 	}
 
-	const isRequired = dateRequired
-		? __( 'required', 'ultimate-addons-for-gutenberg' )
-		: '';
+	const isRequired = dateRequired ? __( 'required', 'ultimate-addons-for-gutenberg' ) : '';
 
 	return (
 		<>
-			<div
-				className={ classnames(
-					'uagb-forms-date-wrap',
-					'uagb-forms-field-set',
-					`uagb-block-${ block_id }`
-				) }
-			>
+			<div className={ classnames( 'uagb-forms-date-wrap', 'uagb-forms-field-set', `uagb-block-${ block_id }` ) }>
 				<RichText
 					tagName="div"
-					placeholder={ __(
-						'Date',
-						'ultimate-addons-for-gutenberg'
-					) }
+					placeholder={ __( 'Date', 'ultimate-addons-for-gutenberg' ) }
 					value={ name }
 					onChange={ ( value ) => setAttributes( { name: value } ) }
 					className={ `uagb-forms-date-label ${ isRequired } uagb-forms-input-label` }

--- a/src/blocks/forms/child-blocks/date/save.js
+++ b/src/blocks/forms/child-blocks/date/save.js
@@ -60,18 +60,10 @@ export default function save( props ) {
 			/>
 		);
 	}
-	const isRequired = dateRequired
-		? __( 'required', 'ultimate-addons-for-gutenberg' )
-		: '';
+	const isRequired = dateRequired ? __( 'required', 'ultimate-addons-for-gutenberg' ) : '';
 
 	return (
-		<div
-			className={ classnames(
-				'uagb-forms-date-wrap',
-				'uagb-forms-field-set',
-				`uagb-block-${ block_id }`
-			) }
-		>
+		<div className={ classnames( 'uagb-forms-date-wrap', 'uagb-forms-field-set', `uagb-block-${ block_id }` ) }>
 			<RichText.Content
 				tagName="div"
 				value={ name }

--- a/src/blocks/forms/child-blocks/date/settings.js
+++ b/src/blocks/forms/child-blocks/date/settings.js
@@ -4,9 +4,7 @@ import { ToggleControl } from '@wordpress/components';
 import UAGSelectControl from '@Components/select-control';
 import Separator from '@Components/separator';
 import InspectorTabs from '@Components/inspector-tabs/InspectorTabs.js';
-import InspectorTab, {
-	UAGTabs,
-} from '@Components/inspector-tabs/InspectorTab.js';
+import InspectorTab, { UAGTabs } from '@Components/inspector-tabs/InspectorTab.js';
 
 import { InspectorControls } from '@wordpress/block-editor';
 
@@ -30,8 +28,6 @@ for ( index = 1; index <= 31; index++ ) {
 	dateDefaults.push( { label: twoDigitDate, value: twoDigitDate } );
 }
 
-
-
 import UAGAdvancedPanelBody from '@Components/advanced-panel-body';
 
 const Settings = ( props ) => {
@@ -39,16 +35,7 @@ const Settings = ( props ) => {
 
 	const { attributes, setAttributes } = props;
 
-	const {
-		dateRequired,
-		additonalVal,
-		minYear,
-		minMonth,
-		minDay,
-		maxYear,
-		maxMonth,
-		maxDay,
-	} = attributes;
+	const { dateRequired, additonalVal, minYear, minMonth, minDay, maxYear, maxMonth, maxDay } = attributes;
 
 	let validation_min_value = '';
 	let validation_max_value = '';
@@ -68,10 +55,7 @@ const Settings = ( props ) => {
 	if ( start > end ) {
 		invalidDateErrorMsg = (
 			<p className="uagb-forms-date-invalidate">
-				{ __(
-					'Invalid date range selected',
-					'ultimate-addons-for-gutenberg'
-				) }
+				{ __( 'Invalid date range selected', 'ultimate-addons-for-gutenberg' ) }
 			</p>
 		);
 	}
@@ -82,35 +66,20 @@ const Settings = ( props ) => {
 				<ToggleControl
 					label={ __( 'Required', 'ultimate-addons-for-gutenberg' ) }
 					checked={ dateRequired }
-					onChange={ () =>
-						setAttributes( { dateRequired: ! dateRequired } )
-					}
+					onChange={ () => setAttributes( { dateRequired: ! dateRequired } ) }
 				/>
 				<ToggleControl
-					label={ __(
-						'Additional Validation',
-						'ultimate-addons-for-gutenberg'
-					) }
+					label={ __( 'Additional Validation', 'ultimate-addons-for-gutenberg' ) }
 					checked={ additonalVal }
-					onChange={ () =>
-						setAttributes( { additonalVal: ! additonalVal } )
-					}
-					help={ __(
-						'Helps to set range of calender',
-						'ultimate-addons-for-gutenberg'
-					) }
+					onChange={ () => setAttributes( { additonalVal: ! additonalVal } ) }
+					help={ __( 'Helps to set range of calender', 'ultimate-addons-for-gutenberg' ) }
 				/>
 				{ additonalVal && (
 					<>
-						<Separator/>
-						<p>
-							{ __( 'From', 'ultimate-addons-for-gutenberg' ) } :
-						</p>
+						<Separator />
+						<p>{ __( 'From', 'ultimate-addons-for-gutenberg' ) } :</p>
 						<UAGSelectControl
-							label={ __(
-								'Year',
-								'ultimate-addons-for-gutenberg'
-							) }
+							label={ __( 'Year', 'ultimate-addons-for-gutenberg' ) }
 							data={ {
 								value: minYear,
 								label: 'minYear',
@@ -119,10 +88,7 @@ const Settings = ( props ) => {
 							options={ YearDefaults }
 						/>
 						<UAGSelectControl
-							label={ __(
-								'Month',
-								'ultimate-addons-for-gutenberg'
-							) }
+							label={ __( 'Month', 'ultimate-addons-for-gutenberg' ) }
 							data={ {
 								value: minMonth,
 								label: 'minMonth',
@@ -131,10 +97,7 @@ const Settings = ( props ) => {
 							options={ MonthsDefaults }
 						/>
 						<UAGSelectControl
-							label={ __(
-								'Date',
-								'ultimate-addons-for-gutenberg'
-							) }
+							label={ __( 'Date', 'ultimate-addons-for-gutenberg' ) }
 							data={ {
 								value: minDay,
 								label: 'minDay',
@@ -142,15 +105,10 @@ const Settings = ( props ) => {
 							setAttributes={ setAttributes }
 							options={ dateDefaults }
 						/>
-						<Separator/>
-						<p>
-							{ __( 'To', 'ultimate-addons-for-gutenberg' ) } :
-						</p>
+						<Separator />
+						<p>{ __( 'To', 'ultimate-addons-for-gutenberg' ) } :</p>
 						<UAGSelectControl
-							label={ __(
-								'Year',
-								'ultimate-addons-for-gutenberg'
-							) }
+							label={ __( 'Year', 'ultimate-addons-for-gutenberg' ) }
 							data={ {
 								value: maxYear,
 								label: 'maxYear',
@@ -159,10 +117,7 @@ const Settings = ( props ) => {
 							options={ YearDefaults }
 						/>
 						<UAGSelectControl
-							label={ __(
-								'Month',
-								'ultimate-addons-for-gutenberg'
-							) }
+							label={ __( 'Month', 'ultimate-addons-for-gutenberg' ) }
 							data={ {
 								value: maxMonth,
 								label: 'maxMonth',
@@ -171,10 +126,7 @@ const Settings = ( props ) => {
 							options={ MonthsDefaults }
 						/>
 						<UAGSelectControl
-							label={ __(
-								'Date',
-								'ultimate-addons-for-gutenberg'
-							) }
+							label={ __( 'Date', 'ultimate-addons-for-gutenberg' ) }
 							data={ {
 								value: maxDay,
 								label: 'maxDay',
@@ -193,9 +145,7 @@ const Settings = ( props ) => {
 		<>
 			<InspectorControls>
 				<InspectorTabs tabs={ [ 'general', 'advance' ] }>
-					<InspectorTab { ...UAGTabs.general }>
-						{ dateInspectorControls() }
-					</InspectorTab>
+					<InspectorTab { ...UAGTabs.general }>{ dateInspectorControls() }</InspectorTab>
 					<InspectorTab { ...UAGTabs.advance }></InspectorTab>
 				</InspectorTabs>
 			</InspectorControls>

--- a/src/blocks/forms/child-blocks/email/attributes.js
+++ b/src/blocks/forms/child-blocks/email/attributes.js
@@ -26,6 +26,6 @@ const attributes = {
 	autocomplete: {
 		type: 'string',
 		default: 'email',
-	}
+	},
 };
 export default attributes;

--- a/src/blocks/forms/child-blocks/email/block.js
+++ b/src/blocks/forms/child-blocks/email/block.js
@@ -19,18 +19,14 @@ registerBlockType( 'uagb/forms-email', {
 	parent: [ 'uagb/forms' ],
 	attributes,
 	edit: ( props ) =>
-		props.attributes.isPreview ? (
-			<PreviewImage image="form-field" isChildren={ true } />
-		) : (
-			<Edit { ...props } />
-		),
+		props.attributes.isPreview ? <PreviewImage image="form-field" isChildren={ true } /> : <Edit { ...props } />,
 	supports: {
 		anchor: true,
 	},
 	example: {
 		attributes: {
 			isPreview: true,
-		}
+		},
 	},
 	save,
 	deprecated,

--- a/src/blocks/forms/child-blocks/email/deprecated.js
+++ b/src/blocks/forms/child-blocks/email/deprecated.js
@@ -7,52 +7,55 @@ import { RichText } from '@wordpress/block-editor';
 
 const attributes = {
 	block_id: {
-		type: "string"
+		type: 'string',
 	},
 	name: {
-        type: "string",
-        default: __("Email" , 'ultimate-addons-for-gutenberg' )
+		type: 'string',
+		default: __( 'Email', 'ultimate-addons-for-gutenberg' ),
 	},
-	required : {
-        type: "boolean",
-        default: false
+	required: {
+		type: 'boolean',
+		default: false,
 	},
 	placeholder: {
-        type: "string",
-        default: __( "example@mail.com" , 'ultimate-addons-for-gutenberg')
-    },
-}
+		type: 'string',
+		default: __( 'example@mail.com', 'ultimate-addons-for-gutenberg' ),
+	},
+};
 
 const deprecated = [
 	{
 		attributes,
 		save( props ) {
-			const {
-				block_id,
-				name,
-				required,
-				placeholder
-			} = props.attributes
-			
-			const isRequired = (required) ? __("required", 'ultimate-addons-for-gutenberg' ): "";
-		
+			const { block_id, name, required, placeholder } = props.attributes;
+
+			const isRequired = required ? __( 'required', 'ultimate-addons-for-gutenberg' ) : '';
+
 			return (
-				<div className={ classnames(
-					"uagb-forms-email-wrap",
-					"uagb-forms-field-set",
-					`uagb-block-${ block_id }`,
-				) }>
+				<div
+					className={ classnames(
+						'uagb-forms-email-wrap',
+						'uagb-forms-field-set',
+						`uagb-block-${ block_id }`
+					) }
+				>
 					<RichText.Content
 						tagName="div"
 						value={ name }
-						className={`uagb-forms-email-label ${isRequired} uagb-forms-input-label`}	
-						id={ block_id }		
-					/>			
-					<input type="email" className="uagb-forms-email-input uagb-forms-input" placeholder={placeholder} required={ required } name={ block_id }/>
+						className={ `uagb-forms-email-label ${ isRequired } uagb-forms-input-label` }
+						id={ block_id }
+					/>
+					<input
+						type="email"
+						className="uagb-forms-email-input uagb-forms-input"
+						placeholder={ placeholder }
+						required={ required }
+						name={ block_id }
+					/>
 				</div>
-			)
-        }
-    }
+			);
+		},
+	},
 ];
 
 export default deprecated;

--- a/src/blocks/forms/child-blocks/email/edit.js
+++ b/src/blocks/forms/child-blocks/email/edit.js
@@ -4,31 +4,27 @@
 
 import { useEffect } from '@wordpress/element';
 
-
 import Settings from './settings';
 import Render from './render';
 
 const UAGBFormsEmailEdit = ( props ) => {
 	const { setAttributes, isSelected, clientId } = props;
-	
+
 	useEffect( () => {
 		// Assigning block_id in the attribute.
 		setAttributes( { block_id: clientId.substr( 0, 8 ) } );
 
 		// Pushing Style tag for this block css.
 		const $style = document.createElement( 'style' );
-		$style.setAttribute(
-			'id',
-			'uagb-style-forms-email-' + clientId.substr( 0, 8 )
-		);
+		$style.setAttribute( 'id', 'uagb-style-forms-email-' + clientId.substr( 0, 8 ) );
 		document.head.appendChild( $style );
 	}, [] );
 
 	return (
-			<>
+		<>
 			{ isSelected && <Settings parentProps={ props } /> }
-				<Render parentProps={ props } />
-			</>
+			<Render parentProps={ props } />
+		</>
 	);
 };
 

--- a/src/blocks/forms/child-blocks/email/render.js
+++ b/src/blocks/forms/child-blocks/email/render.js
@@ -5,7 +5,6 @@ import styles from './editor.lazy.scss';
 
 import { RichText } from '@wordpress/block-editor';
 
-
 const Render = ( props ) => {
 	// Add and remove the CSS on the drop and remove of the component.
 	useLayoutEffect( () => {
@@ -21,25 +20,16 @@ const Render = ( props ) => {
 
 	const { block_id, name, required, placeholder } = attributes;
 
-	const isRequired = required
-		? __( 'required', 'ultimate-addons-for-gutenberg' )
-		: '';
+	const isRequired = required ? __( 'required', 'ultimate-addons-for-gutenberg' ) : '';
 
 	return (
 		<>
 			<div
-				className={ classnames(
-					'uagb-forms-email-wrap',
-					'uagb-forms-field-set',
-					`uagb-block-${ block_id }`
-				) }
+				className={ classnames( 'uagb-forms-email-wrap', 'uagb-forms-field-set', `uagb-block-${ block_id }` ) }
 			>
 				<RichText
 					tagName="div"
-					placeholder={ __(
-						'Email',
-						'ultimate-addons-for-gutenberg'
-					) }
+					placeholder={ __( 'Email', 'ultimate-addons-for-gutenberg' ) }
 					value={ name }
 					onChange={ ( value ) => setAttributes( { name: value } ) }
 					className={ `uagb-forms-email-label ${ isRequired } uagb-forms-input-label` }

--- a/src/blocks/forms/child-blocks/email/save.js
+++ b/src/blocks/forms/child-blocks/email/save.js
@@ -13,18 +13,10 @@ export default function save( props ) {
 
 	const { block_id, name, required, placeholder, autocomplete } = attributes;
 
-	const isRequired = required
-		? __( 'required', 'ultimate-addons-for-gutenberg' )
-		: '';
+	const isRequired = required ? __( 'required', 'ultimate-addons-for-gutenberg' ) : '';
 
 	return (
-		<div
-			className={ classnames(
-				'uagb-forms-email-wrap',
-				'uagb-forms-field-set',
-				`uagb-block-${ block_id }`
-			) }
-		>
+		<div className={ classnames( 'uagb-forms-email-wrap', 'uagb-forms-field-set', `uagb-block-${ block_id }` ) }>
 			<RichText.Content
 				tagName="div"
 				value={ name }

--- a/src/blocks/forms/child-blocks/email/settings.js
+++ b/src/blocks/forms/child-blocks/email/settings.js
@@ -1,9 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { memo } from '@wordpress/element';
 import InspectorTabs from '@Components/inspector-tabs/InspectorTabs.js';
-import InspectorTab, {
-	UAGTabs,
-} from '@Components/inspector-tabs/InspectorTab.js';
+import InspectorTab, { UAGTabs } from '@Components/inspector-tabs/InspectorTab.js';
 import UAGSelectControl from '@Components/select-control';
 import { InspectorControls } from '@wordpress/block-editor';
 import { ToggleControl } from '@wordpress/components';
@@ -21,10 +19,7 @@ const Settings = ( props ) => {
 		return (
 			<UAGAdvancedPanelBody initialOpen={ true }>
 				<UAGSelectControl
-					label={ __(
-						'Autocomplete',
-						'ultimate-addons-for-gutenberg'
-					) }
+					label={ __( 'Autocomplete', 'ultimate-addons-for-gutenberg' ) }
 					data={ {
 						value: autocomplete,
 						label: 'autocomplete',
@@ -43,13 +38,8 @@ const Settings = ( props ) => {
 						label: 'placeholder',
 					} }
 					setAttributes={ setAttributes }
-					onChange={ ( value ) =>
-						setAttributes( { placeholder: value } )
-					}
-					placeholder={ __(
-						'Placeholder',
-						'ultimate-addons-for-gutenberg'
-					) }
+					onChange={ ( value ) => setAttributes( { placeholder: value } ) }
+					placeholder={ __( 'Placeholder', 'ultimate-addons-for-gutenberg' ) }
 				/>
 				<ToggleControl
 					label={ __( 'Required', 'ultimate-addons-for-gutenberg' ) }
@@ -63,9 +53,7 @@ const Settings = ( props ) => {
 	return (
 		<InspectorControls>
 			<InspectorTabs tabs={ [ 'general', 'advance' ] }>
-				<InspectorTab { ...UAGTabs.general }>
-					{ nameInspectorControls() }
-				</InspectorTab>
+				<InspectorTab { ...UAGTabs.general }>{ nameInspectorControls() }</InspectorTab>
 				<InspectorTab { ...UAGTabs.advance }></InspectorTab>
 			</InspectorTabs>
 		</InspectorControls>

--- a/src/blocks/forms/child-blocks/hidden/block.js
+++ b/src/blocks/forms/child-blocks/hidden/block.js
@@ -19,19 +19,15 @@ registerBlockType( 'uagb/forms-hidden', {
 	parent: [ 'uagb/forms' ],
 	attributes,
 	edit: ( props ) =>
-		props.attributes.isPreview ? (
-			<PreviewImage image="form-hidden" isChildren={ true } />
-		) : (
-			<Edit { ...props } />
-		),
+		props.attributes.isPreview ? <PreviewImage image="form-hidden" isChildren={ true } /> : <Edit { ...props } />,
 	supports: {
 		anchor: true,
 	},
 	example: {
 		attributes: {
 			isPreview: true,
-		}
+		},
 	},
 	save,
-	deprecated
+	deprecated,
 } );

--- a/src/blocks/forms/child-blocks/hidden/deprecated.js
+++ b/src/blocks/forms/child-blocks/hidden/deprecated.js
@@ -2,32 +2,23 @@
  * BLOCK: Forms - Date - Deprecared
  */
 
- import classnames from 'classnames';
- import { __ } from '@wordpress/i18n';
- import { RichText } from '@wordpress/block-editor';
- import attributes from './attributes';
- 
- const deprecated = [
-     {
-        attributes,
-        save( props ) {
-            const { block_id, hidden_field_value } = props.attributes;
-            return (
-                <div
-                    className={ classnames(
-                        'uagb-forms-hidden-wrap',
-                        `uagb-block-${ block_id }`
-                    ) }
-                >
-                    <input
-                        type="hidden"
-                        className="uagb-forms-hidden-input"
-                        value={ hidden_field_value }
-                    />
-                </div>
-            );
-        }
-    }
- ];
- 
- export default deprecated;
+import classnames from 'classnames';
+import { __ } from '@wordpress/i18n';
+import { RichText } from '@wordpress/block-editor';
+import attributes from './attributes';
+
+const deprecated = [
+	{
+		attributes,
+		save( props ) {
+			const { block_id, hidden_field_value } = props.attributes;
+			return (
+				<div className={ classnames( 'uagb-forms-hidden-wrap', `uagb-block-${ block_id }` ) }>
+					<input type="hidden" className="uagb-forms-hidden-input" value={ hidden_field_value } />
+				</div>
+			);
+		},
+	},
+];
+
+export default deprecated;

--- a/src/blocks/forms/child-blocks/hidden/edit.js
+++ b/src/blocks/forms/child-blocks/hidden/edit.js
@@ -4,7 +4,6 @@
 
 import { useEffect } from '@wordpress/element';
 
-
 import Settings from './settings';
 import Render from './render';
 
@@ -17,18 +16,15 @@ const UAGBFormsHiddenEdit = ( props ) => {
 
 		// Pushing Style tag for this block css.
 		const $style = document.createElement( 'style' );
-		$style.setAttribute(
-			'id',
-			'uagb-style-forms-hidden-' + clientId.substr( 0, 8 )
-		);
+		$style.setAttribute( 'id', 'uagb-style-forms-hidden-' + clientId.substr( 0, 8 ) );
 		document.head.appendChild( $style );
 	}, [] );
 
 	return (
-			<>
+		<>
 			{ isSelected && <Settings parentProps={ props } /> }
-				<Render parentProps={ props } />
-			</>
+			<Render parentProps={ props } />
+		</>
 	);
 };
 

--- a/src/blocks/forms/child-blocks/hidden/render.js
+++ b/src/blocks/forms/child-blocks/hidden/render.js
@@ -8,9 +8,7 @@ const Render = ( props ) => {
 
 	const { block_id, hidden_field_name, hidden_field_value } = attributes;
 
-	const hidden_field_label = hidden_field_name
-		.replace( /\s+/g, '-' )
-		.toLowerCase();
+	const hidden_field_label = hidden_field_name.replace( /\s+/g, '-' ).toLowerCase();
 
 	const changeHiddenName = ( value ) => {
 		const { setAttributes } = props;
@@ -19,12 +17,7 @@ const Render = ( props ) => {
 
 	return (
 		<>
-			<div
-				className={ classnames(
-					'uagb-forms-hidden-wrap',
-					`uagb-block-${ block_id }`
-				) }
-			>
+			<div className={ classnames( 'uagb-forms-hidden-wrap', `uagb-block-${ block_id }` ) }>
 				{ /* Edit View */ }
 				{ props.isSelected && (
 					<input
@@ -44,7 +37,7 @@ const Render = ( props ) => {
 							{ hidden_field_name }
 						</label>
 						<input
-						    id={ hidden_field_label }
+							id={ hidden_field_label }
 							type="hidden"
 							className="uagb-forms-hidden-input"
 							value={ hidden_field_value }

--- a/src/blocks/forms/child-blocks/hidden/save.js
+++ b/src/blocks/forms/child-blocks/hidden/save.js
@@ -9,18 +9,13 @@ export default function save( props ) {
 
 	const { block_id, hidden_field_value, hidden_field_name } = attributes;
 	return (
-		<div
-			className={ classnames(
-				'uagb-forms-hidden-wrap',
-				`uagb-block-${ block_id }`
-			) }
-		>
+		<div className={ classnames( 'uagb-forms-hidden-wrap', `uagb-block-${ block_id }` ) }>
 			<input
 				type="hidden"
 				id="hidden"
 				className="uagb-forms-hidden-input"
 				value={ hidden_field_value }
-				name = { hidden_field_name }
+				name={ hidden_field_name }
 			/>
 		</div>
 	);

--- a/src/blocks/forms/child-blocks/hidden/settings.js
+++ b/src/blocks/forms/child-blocks/hidden/settings.js
@@ -1,15 +1,11 @@
 import { __ } from '@wordpress/i18n';
 import { memo } from '@wordpress/element';
 import InspectorTabs from '@Components/inspector-tabs/InspectorTabs.js';
-import InspectorTab, {
-	UAGTabs,
-} from '@Components/inspector-tabs/InspectorTab.js';
+import InspectorTab, { UAGTabs } from '@Components/inspector-tabs/InspectorTab.js';
 
 import UAGTextControl from '@Components/text-control';
 
 import { InspectorControls } from '@wordpress/block-editor';
-
-
 
 import UAGAdvancedPanelBody from '@Components/advanced-panel-body';
 
@@ -26,14 +22,12 @@ const Settings = ( props ) => {
 				<UAGTextControl
 					label={ __( 'Value', 'ultimate-addons-for-gutenberg' ) }
 					value={ hidden_field_value }
-					data={{
+					data={ {
 						value: hidden_field_value,
 						label: 'hidden_field_value',
-					}}
+					} }
 					setAttributes={ setAttributes }
-					onChange={ ( value ) =>
-						setAttributes( { hidden_field_value: value } )
-					}
+					onChange={ ( value ) => setAttributes( { hidden_field_value: value } ) }
 				/>
 			</UAGAdvancedPanelBody>
 		);
@@ -43,9 +37,7 @@ const Settings = ( props ) => {
 		<>
 			<InspectorControls>
 				<InspectorTabs tabs={ [ 'general', 'advance' ] }>
-					<InspectorTab { ...UAGTabs.general }>
-						{ hiddenFieldSettings() }
-					</InspectorTab>
+					<InspectorTab { ...UAGTabs.general }>{ hiddenFieldSettings() }</InspectorTab>
 					<InspectorTab { ...UAGTabs.advance }></InspectorTab>
 				</InspectorTabs>
 			</InspectorControls>


### PR DESCRIPTION
### Description
Formatting of plugin using prettier.
**Script to format**: ` "lint-scripts:fix": "npm run pretty:fix && npm run lint-js -- --fix && npm run lint-css -- --fix",`

### Screenshots
<!-- if applicable -->

### Types of changes
**Changes in .prettierrc.js:**


`config.overrides = [
	{
		files: [ '*.scss', '*.css', '*.js' ],
		options: {
			printWidth: 120,
			singleQuote: true,
		},
	},
];`

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
