### PR TITLE
SPCTR-2547: Improvement: Prettier formatting

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -16,7 +16,6 @@ const uagLocalStorage = getUAGEditorStateLocalStorage();
 if ( uagLocalStorage ) {
 	uagLocalStorage.removeItem( 'uagSettingState' );
 	uagLocalStorage.removeItem( 'isSpectraFontAwesomeAPILoading' );
-
 }
 
 import blocksEditorSpacing from './blocks/extensions/blocks-editor-spacing';
@@ -106,7 +105,7 @@ import './blocks/wp-search/block.js';
 import './components/responsive-icons/index.js';
 
 // Keep category list in separate variable and remove category list from icons list.
-if( uagb_blocks_info.uagb_svg_icons?.uagb_category_list ){
+if ( uagb_blocks_info.uagb_svg_icons?.uagb_category_list ) {
 	wp.uagb_icon_category_list = [ ...uagb_blocks_info.uagb_svg_icons.uagb_category_list ];
 	delete uagb_blocks_info.uagb_svg_icons.uagb_category_list;
 }

--- a/src/common-editor.scss
+++ b/src/common-editor.scss
@@ -95,18 +95,16 @@
 		border-radius: 2px;
 	}
 
-
 	.block-editor-block-list__block:not([contenteditable]):focus {
 		z-index: 1;
 	}
-
 }
 
-.block-editor-block-list__layout .block-editor-block-list__block.is-selected { // Added CSS for better clarity to the users to indicates which block is selected & being edited.
+.block-editor-block-list__layout .block-editor-block-list__block.is-selected {
+	// Added CSS for better clarity to the users to indicates which block is selected & being edited.
 	box-shadow: 0 0 0 1.5px $spectra-color-primary;
 	border-radius: 2px;
 }
-
 
 /* UAG Control Label CSS*/
 .uag-control-label,
@@ -373,7 +371,8 @@ hr.uagb-editor__separator {
 }
 
 .uagb-size-type-field button.components-button.uagb-size-btn.is-primary,
-.uagb-size-type-field button.components-button.uagb-size-btn.is-primary:focus:not(:disabled):not([aria-disabled="true"]) {
+.uagb-size-type-field
+button.components-button.uagb-size-btn.is-primary:focus:not(:disabled):not([aria-disabled="true"]) {
 	box-shadow: none;
 	background: transparent;
 	border: none;
@@ -389,7 +388,8 @@ hr.uagb-editor__separator {
 }
 
 .uagb-size-type-field button.components-button.uagb-size-btn:hover,
-.uagb-size-type-field button.components-button.uagb-size-btn:hover:focus:not(:disabled):not([aria-disabled="true"]) {
+.uagb-size-type-field
+button.components-button.uagb-size-btn:hover:focus:not(:disabled):not([aria-disabled="true"]) {
 	color: $spectra-color-heading;
 	background: transparent;
 	-webkit-box-shadow: none;
@@ -719,7 +719,6 @@ button.components-button.uagb-review-select-btn.is-secondary {
 	circle {
 		stroke: $spectra-color-secondary;
 	}
-
 }
 
 /* Breadcrumbs css */
@@ -757,7 +756,6 @@ button.components-button.uagb-review-select-btn.is-secondary {
 
 /* Gradient Picker CSS */
 .uagb-gradient-picker {
-
 	// This helps to fix alignment of gradient control input fields.
 	.components-flex.components-custom-gradient-picker__ui-line {
 		align-items: baseline;
@@ -778,7 +776,8 @@ button.components-button.uagb-review-select-btn.is-secondary {
 
 	.components-toggle-control .components-base-control__field {
 
-		.components-flex { // WP6.1 compatibility.
+		.components-flex {
+			// WP6.1 compatibility.
 			display: flex;
 			flex-direction: row-reverse;
 			justify-content: space-between;

--- a/src/components/text-shadow/editor.lazy.scss
+++ b/src/components/text-shadow/editor.lazy.scss
@@ -1,6 +1,5 @@
 /** Text Shadow Popup CSS*/
 .uag-text-shadow-options {
-
 	margin-bottom: 24px;
 	position: relative;
 
@@ -87,4 +86,3 @@
 .block-editor-block-inspector .components-base-control:last-child {
 	margin-bottom: 0;
 }
-

--- a/src/components/text-shadow/index.js
+++ b/src/components/text-shadow/index.js
@@ -7,7 +7,7 @@ import Range from '@Components/range/Range.js';
 import AdvancedPopColorControl from '../color-control/advanced-pop-color-control';
 import { Button, Dashicon } from '@wordpress/components';
 import { useLayoutEffect, useEffect, useState, useRef } from '@wordpress/element';
-import { select } from '@wordpress/data'
+import { select } from '@wordpress/data';
 import getUAGEditorStateLocalStorage from '@Controls/getUAGEditorStateLocalStorage';
 import { getIdFromString, getPanelIdFromRef } from '@Utils/Helpers';
 import { blocksAttributes } from '@Attributes/getBlocksDefaultAttributes';
@@ -16,7 +16,7 @@ import { applyFilters } from '@wordpress/hooks';
 
 const TextShadowControl = ( props ) => {
 	const [ showAdvancedControls, toggleAdvancedControls ] = useState( false );
-	const [panelNameForHook, setPanelNameForHook] = useState( null );
+	const [ panelNameForHook, setPanelNameForHook ] = useState( null );
 	const panelRef = useRef( null );
 
 	const {
@@ -28,36 +28,46 @@ const TextShadowControl = ( props ) => {
 		label = __( 'Text Shadow', 'ultimate-addons-for-gutenberg' ),
 		popup = false,
 		blockId,
-		help = false
+		help = false,
 	} = props;
 
 	let advancedControls;
 	const activeClass = showAdvancedControls ? 'active' : '';
 
 	useLayoutEffect( () => {
-		window.addEventListener( 'click', function( e ){
-			const popupButton = document.querySelector( `.active.popup-${blockId} .spectra-control-popup__options--action-button` );
-			const popupWrap = document.querySelector( `.active.popup-${blockId} .spectra-control-popup` );
+		window.addEventListener( 'click', function ( e ) {
+			const popupButton = document.querySelector(
+				`.active.popup-${ blockId } .spectra-control-popup__options--action-button`
+			);
+			const popupWrap = document.querySelector( `.active.popup-${ blockId } .spectra-control-popup` );
 
-			if ( popupButton && ! popupButton?.contains( e.target ) && ! e.target?.classList?.contains( 'uagb-advanced-color-indicate' ) && ! e.target?.parentElement?.closest( '.uagb-popover-color' ) && popupWrap && ! popupWrap?.contains( e.target ) && ! e.target?.parentElement?.closest( '.uagb-reset' ) ) {
-				toggleAdvancedControls( false )
+			if (
+				popupButton &&
+				! popupButton?.contains( e.target ) &&
+				! e.target?.classList?.contains( 'uagb-advanced-color-indicate' ) &&
+				! e.target?.parentElement?.closest( '.uagb-popover-color' ) &&
+				popupWrap &&
+				! popupWrap?.contains( e.target ) &&
+				! e.target?.parentElement?.closest( '.uagb-reset' )
+			) {
+				toggleAdvancedControls( false );
 				const blockName = getSelectedBlock()?.name;
 				const uagSettingState = getUAGEditorStateLocalStorage( 'uagSettingState' );
 
 				const data = {
 					...uagSettingState,
-					[blockName] : {
-						...uagSettingState?.[blockName],
-						selectedSetting : false
-					}
-				}
+					[ blockName ]: {
+						...uagSettingState?.[ blockName ],
+						selectedSetting: false,
+					},
+				};
 
 				const uagLocalStorage = getUAGEditorStateLocalStorage();
 				if ( uagLocalStorage ) {
 					uagLocalStorage.setItem( 'uagSettingState', JSON.stringify( data ) );
 				}
 			}
-		  } );
+		} );
 	}, [] );
 
 	// Array of all the current Typography Control's Labels.
@@ -71,8 +81,8 @@ const TextShadowControl = ( props ) => {
 	const { getSelectedBlock } = select( 'core/block-editor' );
 	const blockNameForHook = getSelectedBlock()?.name.split( '/' ).pop(); // eslint-disable-line @wordpress/no-unused-vars-before-return
 	useEffect( () => {
-		setPanelNameForHook( getPanelIdFromRef( panelRef ) )
-	}, [blockNameForHook] )
+		setPanelNameForHook( getPanelIdFromRef( panelRef ) );
+	}, [ blockNameForHook ] );
 
 	// Function to get the Block's default Text Shadow Values.
 	const getBlockTextShadowValue = () => {
@@ -81,16 +91,19 @@ const TextShadowControl = ( props ) => {
 		if ( 'undefined' !== typeof blocksAttributes[ selectedBlockName ] ) {
 			attributeNames.forEach( ( attributeName ) => {
 				if ( attributeName ) {
-					const blockDefaultAttributeValue = ( 'undefined' !== typeof blocksAttributes[ selectedBlockName ][ attributeName ]?.default ) ? blocksAttributes[ selectedBlockName ][ attributeName ]?.default : '';
+					const blockDefaultAttributeValue =
+						'undefined' !== typeof blocksAttributes[ selectedBlockName ][ attributeName ]?.default
+							? blocksAttributes[ selectedBlockName ][ attributeName ]?.default
+							: '';
 					defaultValues = {
 						...defaultValues,
-						[ attributeName ] : blockDefaultAttributeValue,
-					}
+						[ attributeName ]: blockDefaultAttributeValue,
+					};
 				}
 			} );
 		}
 		return defaultValues;
-	}
+	};
 
 	// Function to check if any Text Shadow Setting has changed.
 	const getUpdateState = () => {
@@ -98,7 +111,10 @@ const TextShadowControl = ( props ) => {
 		const selectedBlockAttributes = getSelectedBlock()?.attributes;
 		let isTextShadowUpdated = false;
 		attributeNames.forEach( ( attributeName ) => {
-			if ( selectedBlockAttributes?.[ attributeName ] && ( selectedBlockAttributes?.[ attributeName ] !== defaultValues?.[ attributeName ] ) ) {
+			if (
+				selectedBlockAttributes?.[ attributeName ] &&
+				selectedBlockAttributes?.[ attributeName ] !== defaultValues?.[ attributeName ]
+			) {
 				isTextShadowUpdated = true;
 			}
 		} );
@@ -127,7 +143,7 @@ const TextShadowControl = ( props ) => {
 				min={ -100 }
 				max={ 100 }
 				displayUnit={ false }
-				setAttributes={setAttributes}
+				setAttributes={ setAttributes }
 				data={ {
 					value: textShadowHOffset.value,
 					label: textShadowHOffset.label,
@@ -140,7 +156,7 @@ const TextShadowControl = ( props ) => {
 				min={ -100 }
 				max={ 100 }
 				displayUnit={ false }
-				setAttributes={setAttributes}
+				setAttributes={ setAttributes }
 				data={ {
 					value: textShadowVOffset.value,
 					label: textShadowVOffset.label,
@@ -153,7 +169,7 @@ const TextShadowControl = ( props ) => {
 				min={ 0 }
 				max={ 100 }
 				displayUnit={ false }
-				setAttributes={setAttributes}
+				setAttributes={ setAttributes }
 				data={ {
 					value: textShadowBlur.value,
 					label: textShadowBlur.label,
@@ -163,60 +179,54 @@ const TextShadowControl = ( props ) => {
 	);
 
 	if ( showAdvancedControls ) {
-		advancedControls = (
-			<div className="uagb-text-shadow-advanced spectra-control-popup">
-				{ overallControls }
-			</div>
-		);
+		advancedControls = <div className="uagb-text-shadow-advanced spectra-control-popup">{ overallControls }</div>;
 	}
 
 	const textShadowAdvancedControls = (
 		<div className="spectra-control-popup__options--action-wrapper">
 			<span className="uag-control-label">
 				{ label }
-				{ isTextShadowUpdated && (
-					<div className="spectra__change-indicator--dot-right"/>
-				) }
+				{ isTextShadowUpdated && <div className="spectra__change-indicator--dot-right" /> }
 			</span>
 			<Button
 				className="uag-text-shadow-button spectra-control-popup__options--action-button"
 				aria-pressed={ showAdvancedControls }
 				onClick={ () => {
-						const allPopups = document.querySelectorAll( '.spectra-control-popup__options' );
-						if ( allPopups && 0 < allPopups.length ) {
-							for ( let i = 0; i < allPopups.length; i++ ) {
-								const popupButton = allPopups[i]?.querySelector( '.spectra-control-popup__options.active .spectra-control-popup__options--action-button' );
-								popupButton?.click();
-							}
+					const allPopups = document.querySelectorAll( '.spectra-control-popup__options' );
+					if ( allPopups && 0 < allPopups.length ) {
+						for ( let i = 0; i < allPopups.length; i++ ) {
+							const popupButton = allPopups[ i ]?.querySelector(
+								'.spectra-control-popup__options.active .spectra-control-popup__options--action-button'
+							);
+							popupButton?.click();
 						}
-						toggleAdvancedControls( ! showAdvancedControls )
-
-						const blockName = getSelectedBlock()?.name;
-						const uagSettingState = getUAGEditorStateLocalStorage( 'uagSettingState' );
-						let data = {
-							...uagSettingState,
-							[blockName] : {
-								...uagSettingState?.[blockName],
-								selectedSetting : '.uag-text-shadow-options'
-							}
-						}
-
-						if ( showAdvancedControls ) {
-							data = {
-								...uagSettingState,
-								[blockName] : {
-									...uagSettingState?.[blockName],
-									selectedSetting : false
-								}
-							}
-						}
-						const uagLocalStorage = getUAGEditorStateLocalStorage();
-						if ( uagLocalStorage ) {
-							uagLocalStorage.setItem( 'uagSettingState', JSON.stringify( data ) );
-						}
-
 					}
-				}
+					toggleAdvancedControls( ! showAdvancedControls );
+
+					const blockName = getSelectedBlock()?.name;
+					const uagSettingState = getUAGEditorStateLocalStorage( 'uagSettingState' );
+					let data = {
+						...uagSettingState,
+						[ blockName ]: {
+							...uagSettingState?.[ blockName ],
+							selectedSetting: '.uag-text-shadow-options',
+						},
+					};
+
+					if ( showAdvancedControls ) {
+						data = {
+							...uagSettingState,
+							[ blockName ]: {
+								...uagSettingState?.[ blockName ],
+								selectedSetting: false,
+							},
+						};
+					}
+					const uagLocalStorage = getUAGEditorStateLocalStorage();
+					if ( uagLocalStorage ) {
+						uagLocalStorage.setItem( 'uagSettingState', JSON.stringify( data ) );
+					}
+				} }
 			>
 				<Dashicon icon="edit" />
 			</Button>
@@ -224,36 +234,32 @@ const TextShadowControl = ( props ) => {
 	);
 
 	const controlName = getIdFromString( props.label );
-	const controlBeforeDomElement = applyFilters( `spectra.${blockNameForHook}.${panelNameForHook}.${controlName}.before`, '', blockNameForHook );
-	const controlAfterDomElement = applyFilters( `spectra.${blockNameForHook}.${panelNameForHook}.${controlName}`, '', blockNameForHook );
-
+	const controlBeforeDomElement = applyFilters(
+		`spectra.${ blockNameForHook }.${ panelNameForHook }.${ controlName }.before`,
+		'',
+		blockNameForHook
+	);
+	const controlAfterDomElement = applyFilters(
+		`spectra.${ blockNameForHook }.${ panelNameForHook }.${ controlName }`,
+		'',
+		blockNameForHook
+	);
 
 	return (
-		<div
-			ref={panelRef}
-			className={ popup ? 'components-base-control' : ''}
-		>
-			{
-				controlBeforeDomElement
-			}
-			{
-				popup ? (
-					<div
-						className={ ` uag-text-shadow-options spectra-control-popup__options popup-${blockId} ${ activeClass }` }
-					>
-						{ textShadowAdvancedControls }
-						{ showAdvancedControls && advancedControls }
-					</div>
-				) : (
-					<>
-						{ overallControls }
-					</>
-				)
-			}
+		<div ref={ panelRef } className={ popup ? 'components-base-control' : '' }>
+			{ controlBeforeDomElement }
+			{ popup ? (
+				<div
+					className={ ` uag-text-shadow-options spectra-control-popup__options popup-${ blockId } ${ activeClass }` }
+				>
+					{ textShadowAdvancedControls }
+					{ showAdvancedControls && advancedControls }
+				</div>
+			) : (
+				<>{ overallControls }</>
+			) }
 			<UAGHelpText text={ help } />
-			{
-				controlAfterDomElement
-			}
+			{ controlAfterDomElement }
 		</div>
 	);
 };

--- a/src/components/typography/editor.lazy.scss
+++ b/src/components/typography/editor.lazy.scss
@@ -44,7 +44,6 @@
 		}
 
 		.uag-font-family-select__dropdown-indicator {
-
 			padding-left: 6px;
 
 			svg {
@@ -59,7 +58,6 @@
 		}
 
 		.uag-font-family-select__value-container {
-
 			top: 0;
 
 			> div {

--- a/src/components/typography/font-typography.js
+++ b/src/components/typography/font-typography.js
@@ -7,16 +7,40 @@ import RangeTypographyControl from './range-typography';
 import googleFonts from '@Controls/fonts';
 import Select from 'react-select';
 
-const { uag_select_font_globally , uag_load_select_font_globally } = uagb_blocks_info;
+const { uag_select_font_globally, uag_load_select_font_globally } = uagb_blocks_info;
 
 function FontFamilyControl( props ) {
-
 	const fonts = [
-		{ value: 'Default', label: __( 'Default','ultimate-addons-for-gutenberg' ), weight: [ 'Default', '100', '200', '300', '400', '500', '600', '700', '800', '900' ], google: false },
-		{ value: 'Arial', label: 'Arial', weight: [ 'Default', '100', '200', '300', '400', '500', '600', '700', '800', '900' ], google: false },
-		{ value: 'Helvetica', label: 'Helvetica', weight: [ 'Default', '100', '200', '300', '400', '500', '600', '700', '800', '900' ], google: false },
-		{ value: 'Times New Roman', label: 'Times New Roman', weight: [ 'Default', '100', '200', '300', '400', '500', '600', '700', '800', '900' ], google: false },
-		{ value: 'Georgia', label: 'Georgia', weight: [ 'Default', '100', '200', '300', '400', '500', '600', '700', '800', '900' ], google: false },
+		{
+			value: 'Default',
+			label: __( 'Default', 'ultimate-addons-for-gutenberg' ),
+			weight: [ 'Default', '100', '200', '300', '400', '500', '600', '700', '800', '900' ],
+			google: false,
+		},
+		{
+			value: 'Arial',
+			label: 'Arial',
+			weight: [ 'Default', '100', '200', '300', '400', '500', '600', '700', '800', '900' ],
+			google: false,
+		},
+		{
+			value: 'Helvetica',
+			label: 'Helvetica',
+			weight: [ 'Default', '100', '200', '300', '400', '500', '600', '700', '800', '900' ],
+			google: false,
+		},
+		{
+			value: 'Times New Roman',
+			label: 'Times New Roman',
+			weight: [ 'Default', '100', '200', '300', '400', '500', '600', '700', '800', '900' ],
+			google: false,
+		},
+		{
+			value: 'Georgia',
+			label: 'Georgia',
+			weight: [ 'Default', '100', '200', '300', '400', '500', '600', '700', '800', '900' ],
+			google: false,
+		},
 	];
 
 	let fontWeight = '';
@@ -24,7 +48,8 @@ function FontFamilyControl( props ) {
 	const customFonts = uagb_blocks_info.spectra_custom_fonts;
 
 	//Push Google Fonts into stytem fonts object
-	Object.keys( googleFonts ).map( ( k ) => {  // eslint-disable-line array-callback-return
+	// eslint-disable-next-line array-callback-return
+	Object.keys( googleFonts ).map( ( k ) => {
 		fonts.push( { value: k, label: k, weight: googleFonts[ k ].weight } );
 
 		if ( k === props.fontFamily.value ) {
@@ -33,7 +58,8 @@ function FontFamilyControl( props ) {
 	} );
 
 	//Push custom Fonts into stytem fonts object.
-	Object.keys( customFonts ).map( ( k ) => {  // eslint-disable-line array-callback-return
+	// eslint-disable-next-line array-callback-return
+	Object.keys( customFonts ).map( ( k ) => {
 		fonts.push( { value: k, label: k, weight: customFonts[ k ].weight } );
 		if ( k === props.fontFamily.value ) {
 			fontWeight = customFonts[ k ].weight;
@@ -48,11 +74,10 @@ function FontFamilyControl( props ) {
 	const fontWeightObj = [];
 	fontWeight.forEach( function ( item ) {
 		fontWeightObj.push( {
-			value: ( 'Default' === item ) ? '' : item,
+			value: 'Default' === item ? '' : item,
 			label: item,
 		} );
 	} );
-
 
 	const onFontfamilyChange = ( value ) => {
 		const font = value.value;
@@ -64,10 +89,7 @@ function FontFamilyControl( props ) {
 	const onLoadGoogleFonts = ( loadGoogleFonts, fontFamily ) => {
 		let value;
 
-		if (
-			fontFamily !== '' &&
-			typeof googleFonts[ fontFamily ] !== 'object'
-		) {
+		if ( fontFamily !== '' && typeof googleFonts[ fontFamily ] !== 'object' ) {
 			value = false;
 		} else {
 			value = true;
@@ -76,7 +98,10 @@ function FontFamilyControl( props ) {
 		props.setAttributes( { [ loadGoogleFonts.label ]: value } );
 	};
 
-	const gFonts = uag_load_select_font_globally === 'enabled' && uag_select_font_globally !== 0 ? uag_select_font_globally : fonts;
+	const gFonts =
+		uag_load_select_font_globally === 'enabled' && uag_select_font_globally !== 0
+			? uag_select_font_globally
+			: fonts;
 
 	const customSelectStyles = {
 		container: ( provided ) => ( {
@@ -118,13 +143,13 @@ function FontFamilyControl( props ) {
 			height: '30px',
 			padding: '0px 8px',
 		} ),
-	}
+	};
 
 	let fontFamilyValue;
 	//Push Google Fonts into stytem fonts object
 	if ( gFonts ) {
-		gFonts.map( ( font ) => {  // eslint-disable-line array-callback-return
-
+		// eslint-disable-next-line array-callback-return
+		gFonts.map( ( font ) => {
 			if ( ! props.fontFamily.weight && font.value === props.fontFamily.value ) {
 				fontFamilyValue = { ...props.fontFamily, weight: font.weight, label: font.value };
 			}
@@ -132,7 +157,7 @@ function FontFamilyControl( props ) {
 	}
 
 	let fontSize;
-	const fontSizeStepsVal = ( 'em' === props.fontSizeType.value ? 0.1 : 1 ); // fractional value when unit is em.
+	const fontSizeStepsVal = 'em' === props.fontSizeType.value ? 0.1 : 1; // fractional value when unit is em.
 	if ( true !== props.disableFontSize ) {
 		fontSize = (
 			<RangeTypographyControl
@@ -145,19 +170,13 @@ function FontFamilyControl( props ) {
 				size={ props.fontSize }
 				sizeLabel={ props.fontSize.label }
 				sizeMobileText={
-					! props.fontSizeLabel
-						? __( 'Font Size', 'ultimate-addons-for-gutenberg' )
-						: props.fontSizeLabel
+					! props.fontSizeLabel ? __( 'Font Size', 'ultimate-addons-for-gutenberg' ) : props.fontSizeLabel
 				}
 				sizeTabletText={
-					! props.fontSizeLabel
-						? __( 'Font Size', 'ultimate-addons-for-gutenberg' )
-						: props.fontSizeLabel
+					! props.fontSizeLabel ? __( 'Font Size', 'ultimate-addons-for-gutenberg' ) : props.fontSizeLabel
 				}
 				sizeText={
-					! props.fontSizeLabel
-						? __( 'Font Size', 'ultimate-addons-for-gutenberg' )
-						: props.fontSizeLabel
+					! props.fontSizeLabel ? __( 'Font Size', 'ultimate-addons-for-gutenberg' ) : props.fontSizeLabel
 				}
 				step={ fontSizeStepsVal }
 				{ ...props }
@@ -169,15 +188,17 @@ function FontFamilyControl( props ) {
 		<>
 			{ /* Font Family */ }
 			<div className="components-base-control uag-font-family-searchable-select__wrapper">
-				<label className="components-input-control__label" htmlFor="font-family">{ __( 'Font Family' ) }</label>
+				<label className="components-input-control__label" htmlFor="font-family">
+					{ __( 'Font Family' ) }
+				</label>
 				<Select
 					styles={ customSelectStyles }
 					placeholder={ __( 'Default', 'ultimate-addons-for-gutenberg' ) }
 					onChange={ onFontfamilyChange }
 					options={ gFonts }
 					value={ fontFamilyValue }
-					defaultValue = { fontFamilyValue }
-					isSearchable={true}
+					defaultValue={ fontFamilyValue }
+					isSearchable={ true }
 					className="uag-font-family-searchable-select"
 					classNamePrefix="uag-font-family-select"
 				/>
@@ -186,10 +207,7 @@ function FontFamilyControl( props ) {
 			{ fontSize }
 			{ /* Font Weitght */ }
 			<UAGSelectControl
-				label={ __(
-					'Weight',
-					'ultimate-addons-for-gutenberg'
-				) }
+				label={ __( 'Weight', 'ultimate-addons-for-gutenberg' ) }
 				data={ {
 					value: props.fontWeight.value,
 					label: props.fontWeight.label,
@@ -198,12 +216,9 @@ function FontFamilyControl( props ) {
 				options={ fontWeightObj }
 			/>
 			{ /* Font Style */ }
-			{ props.fontStyle &&
+			{ props.fontStyle && (
 				<UAGSelectControl
-					label={ __(
-						'Style',
-						'ultimate-addons-for-gutenberg'
-					) }
+					label={ __( 'Style', 'ultimate-addons-for-gutenberg' ) }
 					data={ {
 						value: props.fontStyle.value,
 						label: props.fontStyle.label,
@@ -212,28 +227,19 @@ function FontFamilyControl( props ) {
 					options={ [
 						{
 							value: 'normal',
-							label: __(
-								'Default',
-								'ultimate-addons-for-gutenberg'
-							),
+							label: __( 'Default', 'ultimate-addons-for-gutenberg' ),
 						},
 						{
 							value: 'italic',
-							label: __(
-								'Italic',
-								'ultimate-addons-for-gutenberg'
-							),
+							label: __( 'Italic', 'ultimate-addons-for-gutenberg' ),
 						},
 						{
 							value: 'oblique',
-							label: __(
-								'Oblique',
-								'ultimate-addons-for-gutenberg'
-							),
+							label: __( 'Oblique', 'ultimate-addons-for-gutenberg' ),
 						},
 					] }
 				/>
-			}
+			) }
 		</>
 	);
 }

--- a/src/components/typography/fontloader.js
+++ b/src/components/typography/fontloader.js
@@ -64,19 +64,17 @@ const WebfontLoader = ( props ) => {
 		const mobilePreview = document.getElementsByClassName( 'is-mobile-preview' );
 
 		if ( 0 !== tabletPreview.length || 0 !== mobilePreview.length ) {
+			const preview = tabletPreview[ 0 ] || mobilePreview[ 0 ];
 
-			const preview = tabletPreview[0] || mobilePreview[0];
-
-			const iframe = preview.getElementsByTagName( 'iframe' )[0];
+			const iframe = preview.getElementsByTagName( 'iframe' )[ 0 ];
 
 			if ( iframe ) {
-
 				WebFont.load( {
 					...props.config,
 					loading: handleLoading,
 					active: handleActive,
 					inactive: handleInactive,
-					context: iframe?.contentWindow
+					context: iframe?.contentWindow,
 				} );
 				addFont( props.config.google.families[ 0 ] );
 			}

--- a/src/components/typography/index.js
+++ b/src/components/typography/index.js
@@ -25,7 +25,7 @@ import UAGHelpText from '@Components/help-text';
 export { TypographyStyles };
 
 const TypographyControl = ( props ) => {
-	const [panelNameForHook, setPanelNameForHook] = useState( null );
+	const [ panelNameForHook, setPanelNameForHook ] = useState( null );
 	const panelRef = useRef( null );
 
 	const [ showAdvancedControls, toggleAdvancedControls ] = useState( false );
@@ -40,23 +40,36 @@ const TypographyControl = ( props ) => {
 	}, [] );
 
 	useLayoutEffect( () => {
-		window.addEventListener( 'click', function( e ){
-			const popupButton = document.querySelector( `.active.popup-${props?.attributes?.block_id} .spectra-control-popup__options--action-button` );
-			const popupWrap = document.querySelector( `.active.popup-${props?.attributes?.block_id} .spectra-control-popup` );
+		window.addEventListener( 'click', function ( e ) {
+			const popupButton = document.querySelector(
+				`.active.popup-${ props?.attributes?.block_id } .spectra-control-popup__options--action-button`
+			);
+			const popupWrap = document.querySelector(
+				`.active.popup-${ props?.attributes?.block_id } .spectra-control-popup`
+			);
 
-			if ( popupButton && ! popupButton?.contains( e.target ) && popupWrap && ! popupWrap?.contains( e.target ) && ! e.target?.parentElement?.parentElement?.classList?.contains( 'uag-font-family-select__menu' ) && ! e.target?.classList?.contains( 'uag-responsive-common-button' ) && ! e.target?.closest( '.uag-responsive-common-button' ) && ! e.target?.parentElement?.closest( '.uagb-reset' ) ) {
-				toggleAdvancedControls( false )
+			if (
+				popupButton &&
+				! popupButton?.contains( e.target ) &&
+				popupWrap &&
+				! popupWrap?.contains( e.target ) &&
+				! e.target?.parentElement?.parentElement?.classList?.contains( 'uag-font-family-select__menu' ) &&
+				! e.target?.classList?.contains( 'uag-responsive-common-button' ) &&
+				! e.target?.closest( '.uag-responsive-common-button' ) &&
+				! e.target?.parentElement?.closest( '.uagb-reset' )
+			) {
+				toggleAdvancedControls( false );
 
 				const blockName = getSelectedBlock()?.name;
 				const uagSettingState = getUAGEditorStateLocalStorage( 'uagSettingState' );
 
 				const data = {
 					...uagSettingState,
-					[blockName] : {
-						...uagSettingState?.[blockName],
-						selectedSetting : false
-					}
-				}
+					[ blockName ]: {
+						...uagSettingState?.[ blockName ],
+						selectedSetting: false,
+					},
+				};
 
 				const uagLocalStorage = getUAGEditorStateLocalStorage();
 				if ( uagLocalStorage ) {
@@ -83,24 +96,20 @@ const TypographyControl = ( props ) => {
 		disableTransform,
 		disableDecoration,
 		disableAdvancedOptions = false,
-		help = false
+		help = false,
 	} = props;
 
 	if ( true !== disableFontFamily ) {
 		fontFamily = <FontFamilyControl { ...props } />;
 	}
-	const lineHeightStepsVal = ( 'em' === props.lineHeightType?.value ? 0.1 : 1 ); // fractional value when unit is em.
-	const letterSpacingStepsVal = ( 'em' === props.letterSpacingType?.value ? 0.1 : 1 ); // fractional value when unit is em.
+	const lineHeightStepsVal = 'em' === props.lineHeightType?.value ? 0.1 : 1; // fractional value when unit is em.
+	const letterSpacingStepsVal = 'em' === props.letterSpacingType?.value ? 0.1 : 1; // fractional value when unit is em.
 
 	// Array of all the current Typography Control's Labels.
 	const attributeNames = [];
 
 	if ( ! disableFontFamily ) {
-		attributeNames.push(
-			props.fontFamily.label,
-			props.fontWeight.label,
-			props.fontStyle.label,
-		);
+		attributeNames.push( props.fontFamily.label, props.fontWeight.label, props.fontStyle.label );
 	}
 
 	if ( ! disableFontSize ) {
@@ -108,7 +117,7 @@ const TypographyControl = ( props ) => {
 			props.fontSizeType.label,
 			props.fontSize.label,
 			props.fontSizeMobile.label,
-			props.fontSizeTablet.label,
+			props.fontSizeTablet.label
 		);
 	}
 
@@ -117,20 +126,16 @@ const TypographyControl = ( props ) => {
 			props.lineHeightType.label,
 			props.lineHeight.label,
 			props.lineHeightMobile.label,
-			props.lineHeightTablet.label,
+			props.lineHeightTablet.label
 		);
 	}
 
 	if ( ! disableTransform ) {
-		attributeNames.push(
-			props.transform.label,
-		);
+		attributeNames.push( props.transform.label );
 	}
 
 	if ( ! disableDecoration ) {
-		attributeNames.push(
-			props.decoration.label,
-		);
+		attributeNames.push( props.decoration.label );
 	}
 
 	if ( props.letterSpacing ) {
@@ -138,15 +143,15 @@ const TypographyControl = ( props ) => {
 			props.letterSpacing.label,
 			props.letterSpacingTablet.label,
 			props.letterSpacingMobile.label,
-			props.letterSpacingType.label,
+			props.letterSpacingType.label
 		);
 	}
 
 	const { getSelectedBlock } = select( 'core/block-editor' );
 	const blockNameForHook = getSelectedBlock()?.name.split( '/' ).pop(); // eslint-disable-line @wordpress/no-unused-vars-before-return
 	useEffect( () => {
-		setPanelNameForHook( getPanelIdFromRef( panelRef ) )
-	}, [blockNameForHook] )
+		setPanelNameForHook( getPanelIdFromRef( panelRef ) );
+	}, [ blockNameForHook ] );
 
 	// Function to get the Block's default Typography Values.
 	const getBlockTypographyValue = () => {
@@ -155,16 +160,19 @@ const TypographyControl = ( props ) => {
 		if ( 'undefined' !== typeof allBlocksAttributes[ selectedBlockName ] ) {
 			attributeNames.forEach( ( attributeName ) => {
 				if ( attributeName ) {
-					const blockDefaultAttributeValue = ( 'undefined' !== typeof allBlocksAttributes[ selectedBlockName ][ attributeName ]?.default ) ? allBlocksAttributes[ selectedBlockName ][ attributeName ]?.default : '';
+					const blockDefaultAttributeValue =
+						'undefined' !== typeof allBlocksAttributes[ selectedBlockName ][ attributeName ]?.default
+							? allBlocksAttributes[ selectedBlockName ][ attributeName ]?.default
+							: '';
 					defaultValues = {
 						...defaultValues,
-						[ attributeName ] : blockDefaultAttributeValue,
-					}
+						[ attributeName ]: blockDefaultAttributeValue,
+					};
 				}
 			} );
 		}
 		return defaultValues;
-	}
+	};
 
 	// Function to check if any Typography Setting has changed.
 	const getUpdateState = () => {
@@ -172,7 +180,10 @@ const TypographyControl = ( props ) => {
 		const selectedBlockAttributes = getSelectedBlock()?.attributes;
 		let isTypographyUpdated = false;
 		attributeNames.forEach( ( attributeName ) => {
-			if ( selectedBlockAttributes?.[ attributeName ] && ( selectedBlockAttributes?.[ attributeName ] !== defaultValues?.[ attributeName ] ) ) {
+			if (
+				selectedBlockAttributes?.[ attributeName ] &&
+				selectedBlockAttributes?.[ attributeName ] !== defaultValues?.[ attributeName ]
+			) {
 				isTypographyUpdated = true;
 			}
 		} );
@@ -193,18 +204,9 @@ const TypographyControl = ( props ) => {
 				sizeTabletLabel={ props.lineHeightTablet.label }
 				size={ props.lineHeight }
 				sizeLabel={ props.lineHeight.label }
-				sizeMobileText={ __(
-					'Line Height',
-					'ultimate-addons-for-gutenberg'
-				) }
-				sizeTabletText={ __(
-					'Line Height',
-					'ultimate-addons-for-gutenberg'
-				) }
-				sizeText={ __(
-					'Line Height',
-					'ultimate-addons-for-gutenberg'
-				) }
+				sizeMobileText={ __( 'Line Height', 'ultimate-addons-for-gutenberg' ) }
+				sizeTabletText={ __( 'Line Height', 'ultimate-addons-for-gutenberg' ) }
+				sizeText={ __( 'Line Height', 'ultimate-addons-for-gutenberg' ) }
 				step={ lineHeightStepsVal }
 				{ ...props }
 			/>
@@ -222,18 +224,9 @@ const TypographyControl = ( props ) => {
 				sizeTabletLabel={ props.letterSpacingTablet.label }
 				size={ props.letterSpacing }
 				sizeLabel={ props.letterSpacing.label }
-				sizeMobileText={ __(
-					'Letter Spacing',
-					'ultimate-addons-for-gutenberg'
-				) }
-				sizeTabletText={ __(
-					'Letter Spacing',
-					'ultimate-addons-for-gutenberg'
-				) }
-				sizeText={ __(
-					'Letter Spacing',
-					'ultimate-addons-for-gutenberg'
-				) }
+				sizeMobileText={ __( 'Letter Spacing', 'ultimate-addons-for-gutenberg' ) }
+				sizeTabletText={ __( 'Letter Spacing', 'ultimate-addons-for-gutenberg' ) }
+				sizeText={ __( 'Letter Spacing', 'ultimate-addons-for-gutenberg' ) }
 				step={ letterSpacingStepsVal }
 				{ ...props }
 			/>
@@ -243,10 +236,7 @@ const TypographyControl = ( props ) => {
 	if ( ! disableTransform && props.transform ) {
 		transform = (
 			<UAGSelectControl
-				label={ __(
-					'Transform',
-					'ultimate-addons-for-gutenberg'
-				) }
+				label={ __( 'Transform', 'ultimate-addons-for-gutenberg' ) }
 				data={ {
 					value: props.transform.value,
 					label: props.transform.label,
@@ -255,38 +245,23 @@ const TypographyControl = ( props ) => {
 				options={ [
 					{
 						value: '',
-						label: __(
-							'Default',
-							'ultimate-addons-for-gutenberg'
-						),
+						label: __( 'Default', 'ultimate-addons-for-gutenberg' ),
 					},
 					{
 						value: 'normal',
-						label: __(
-							'Normal',
-							'ultimate-addons-for-gutenberg'
-						),
+						label: __( 'Normal', 'ultimate-addons-for-gutenberg' ),
 					},
 					{
 						value: 'capitalize',
-						label: __(
-							'Capitalize',
-							'ultimate-addons-for-gutenberg'
-						),
+						label: __( 'Capitalize', 'ultimate-addons-for-gutenberg' ),
 					},
 					{
 						value: 'uppercase',
-						label: __(
-							'Uppercase',
-							'ultimate-addons-for-gutenberg'
-						),
+						label: __( 'Uppercase', 'ultimate-addons-for-gutenberg' ),
 					},
 					{
 						value: 'lowercase',
-						label: __(
-							'Lowercase',
-							'ultimate-addons-for-gutenberg'
-						),
+						label: __( 'Lowercase', 'ultimate-addons-for-gutenberg' ),
 					},
 				] }
 			/>
@@ -296,10 +271,7 @@ const TypographyControl = ( props ) => {
 		decoration = (
 			<div className="uag-typography-decoration">
 				<UAGSelectControl
-					label={ __(
-						'Decoration',
-						'ultimate-addons-for-gutenberg'
-					) }
+					label={ __( 'Decoration', 'ultimate-addons-for-gutenberg' ) }
 					data={ {
 						value: props.decoration.value,
 						label: props.decoration.label,
@@ -308,38 +280,23 @@ const TypographyControl = ( props ) => {
 					options={ [
 						{
 							value: '',
-							label: __(
-								'Default',
-								'ultimate-addons-for-gutenberg'
-							),
+							label: __( 'Default', 'ultimate-addons-for-gutenberg' ),
 						},
 						{
 							value: 'none',
-							label: __(
-								'None',
-								'ultimate-addons-for-gutenberg'
-							),
+							label: __( 'None', 'ultimate-addons-for-gutenberg' ),
 						},
 						{
 							value: 'underline',
-							label: __(
-								'Underline',
-								'ultimate-addons-for-gutenberg'
-							),
+							label: __( 'Underline', 'ultimate-addons-for-gutenberg' ),
 						},
 						{
 							value: 'overline',
-							label: __(
-								'Overline',
-								'ultimate-addons-for-gutenberg'
-							),
+							label: __( 'Overline', 'ultimate-addons-for-gutenberg' ),
 						},
 						{
 							value: 'line-through',
-							label: __(
-								'Line Through',
-								'ultimate-addons-for-gutenberg'
-							),
+							label: __( 'Line Through', 'ultimate-addons-for-gutenberg' ),
 						},
 					] }
 				/>
@@ -352,43 +309,42 @@ const TypographyControl = ( props ) => {
 				className="uag-typography-button spectra-control-popup__options--action-button"
 				aria-pressed={ showAdvancedControls }
 				onClick={ () => {
-
-						const allPopups = document.querySelectorAll( '.spectra-control-popup__options' );
-						if ( allPopups && 0 < allPopups.length ) {
-							for ( let i = 0; i < allPopups.length; i++ ) {
-								const popupButton = allPopups[i]?.querySelector( '.spectra-control-popup__options.active .spectra-control-popup__options--action-button' );
-								popupButton?.click();
-							}
+					const allPopups = document.querySelectorAll( '.spectra-control-popup__options' );
+					if ( allPopups && 0 < allPopups.length ) {
+						for ( let i = 0; i < allPopups.length; i++ ) {
+							const popupButton = allPopups[ i ]?.querySelector(
+								'.spectra-control-popup__options.active .spectra-control-popup__options--action-button'
+							);
+							popupButton?.click();
 						}
-						toggleAdvancedControls( ! showAdvancedControls )
-
-						const blockName = getSelectedBlock()?.name;
-						const uagSettingState = getUAGEditorStateLocalStorage( 'uagSettingState' );
-						let data = {
-							...uagSettingState,
-							[blockName] : {
-								...uagSettingState?.[blockName],
-								selectedSetting : '.uag-typography-options'
-							}
-						}
-
-						if ( showAdvancedControls ) {
-							data = {
-								...uagSettingState,
-								[blockName] : {
-									...uagSettingState?.[blockName],
-									selectedSetting : false
-								}
-							}
-						}
-
-						const uagLocalStorage = getUAGEditorStateLocalStorage();
-						if ( uagLocalStorage ) {
-							uagLocalStorage.setItem( 'uagSettingState', JSON.stringify( data ) );
-						}
-
 					}
-				}
+					toggleAdvancedControls( ! showAdvancedControls );
+
+					const blockName = getSelectedBlock()?.name;
+					const uagSettingState = getUAGEditorStateLocalStorage( 'uagSettingState' );
+					let data = {
+						...uagSettingState,
+						[ blockName ]: {
+							...uagSettingState?.[ blockName ],
+							selectedSetting: '.uag-typography-options',
+						},
+					};
+
+					if ( showAdvancedControls ) {
+						data = {
+							...uagSettingState,
+							[ blockName ]: {
+								...uagSettingState?.[ blockName ],
+								selectedSetting: false,
+							},
+						};
+					}
+
+					const uagLocalStorage = getUAGEditorStateLocalStorage();
+					if ( uagLocalStorage ) {
+						uagLocalStorage.setItem( 'uagSettingState', JSON.stringify( data ) );
+					}
+				} }
 			>
 				<Dashicon icon="edit" />
 			</Button>
@@ -422,9 +378,7 @@ const TypographyControl = ( props ) => {
 			<div className="spectra-control-popup__options--action-wrapper">
 				<span className="uag-control-label">
 					{ props.label }
-					{ isTypographyUpdated && (
-						<div className="spectra__change-indicator--dot-right"/>
-					) }
+					{ isTypographyUpdated && <div className="spectra__change-indicator--dot-right" /> }
 				</span>
 				{ fontAdvancedControls }
 			</div>
@@ -432,20 +386,22 @@ const TypographyControl = ( props ) => {
 	}
 
 	const controlName = getIdFromString( props.label );
-	const controlBeforeDomElement = applyFilters( `spectra.${blockNameForHook}.${panelNameForHook}.${controlName}.before`, '', blockNameForHook );
-	const controlAfterDomElement = applyFilters( `spectra.${blockNameForHook}.${panelNameForHook}.${controlName}`, '', blockNameForHook );
-
+	const controlBeforeDomElement = applyFilters(
+		`spectra.${ blockNameForHook }.${ panelNameForHook }.${ controlName }.before`,
+		'',
+		blockNameForHook
+	);
+	const controlAfterDomElement = applyFilters(
+		`spectra.${ blockNameForHook }.${ panelNameForHook }.${ controlName }`,
+		'',
+		blockNameForHook
+	);
 
 	return (
-		<div
-			ref={panelRef}
-			className="components-base-control"
-		>
-			{
-				controlBeforeDomElement
-			}
+		<div ref={ panelRef } className="components-base-control">
+			{ controlBeforeDomElement }
 			<div
-				className={ ` uag-typography-options spectra-control-popup__options popup-${props?.attributes?.block_id} ${ activeClass }` }
+				className={ ` uag-typography-options spectra-control-popup__options popup-${ props?.attributes?.block_id } ${ activeClass }` }
 			>
 				{ ! disableAdvancedOptions && (
 					<>
@@ -455,9 +411,7 @@ const TypographyControl = ( props ) => {
 				) }
 				<UAGHelpText text={ help } />
 			</div>
-			{
-				controlAfterDomElement
-			}
+			{ controlAfterDomElement }
 		</div>
 	);
 };

--- a/src/components/typography/range-typography.js
+++ b/src/components/typography/range-typography.js
@@ -27,7 +27,7 @@ export default function RangeTypographyControl( props ) {
 				max={ 200 }
 				unit={ props.type }
 				responsive={ true }
-				setAttributes={props.setAttributes}
+				setAttributes={ props.setAttributes }
 				data={ {
 					value: props.size.value,
 					label: props.sizeLabel,
@@ -46,7 +46,7 @@ export default function RangeTypographyControl( props ) {
 				max={ 200 }
 				unit={ props.type }
 				responsive={ true }
-				setAttributes={props.setAttributes}
+				setAttributes={ props.setAttributes }
 				data={ {
 					value: props.sizeTablet.value,
 					label: props.sizeTabletLabel,
@@ -65,7 +65,7 @@ export default function RangeTypographyControl( props ) {
 				max={ 200 }
 				unit={ props.type }
 				responsive={ true }
-				setAttributes={props.setAttributes}
+				setAttributes={ props.setAttributes }
 				data={ {
 					value: props.sizeMobile.value,
 					label: props.sizeMobileLabel,
@@ -78,9 +78,7 @@ export default function RangeTypographyControl( props ) {
 	return (
 		<div className="uagb-size-type-field-tabs">
 			<div className="uagb-responsive-control-inner">
-				{ output[ deviceType ]
-					? output[ deviceType ]
-					: output.Desktop }
+				{ output[ deviceType ] ? output[ deviceType ] : output.Desktop }
 			</div>
 		</div>
 	);

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -11,94 +11,94 @@
 
 // Spectra Colors.
 
-$spectra-color-primary          : #007CBA;
-$spectra-color-secondary        : #0063A1;
-$spectra-color-heading          : #1D2327;
-$spectra-color-body             : #50575E;
-$spectra-color-light-background : #F0F0F1;
-$spectra-color-plain-background : #FFFFFF;
-$spectra-color-border           : #E6E7E9;
-$spectra-color-border-hover     : #959595;
-$spectra-color-icon             : #555D66;
-$spectra-color-icon-disabled    : #CCCCCC;
-$spectra-color-tab-background   : #DCF2FF;
-$spectra-color-tab-border       : #CDE9F9;
+$spectra-color-primary: #007cba;
+$spectra-color-secondary: #0063a1;
+$spectra-color-heading: #1d2327;
+$spectra-color-body: #50575e;
+$spectra-color-light-background: #f0f0f1;
+$spectra-color-plain-background: #ffffff;
+$spectra-color-border: #e6e7e9;
+$spectra-color-border-hover: #959595;
+$spectra-color-icon: #555d66;
+$spectra-color-icon-disabled: #cccccc;
+$spectra-color-tab-background: #dcf2ff;
+$spectra-color-tab-border: #cde9f9;
 
 // Spectra Font Sizes.
 
-$spectra-font-size-title-large       : 32px;
-$spectra-font-size-title-medium      : 24px;
-$spectra-font-size-title-small       : 20px;
-$spectra-font-size-subtitle          : 16px;
-$spectra-font-size-subtitle-small    : 14px;
-$spectra-font-size-body              : 13px;
-$spectra-font-size-button            : 13px;
-$spectra-font-size-label             : 13px;
-$spectra-font-size-label-semibold    : 13px;
-$spectra-font-size-link-text         : 13px;
-$spectra-font-size-placeholder       : 13px;
-$spectra-font-size-body-small        : 12px;
-$spectra-font-size-helper-text       : 12px;
-$spectra-font-size-small-button-text : 11px;
-$spectra-font-size-section-heading   : 11px;
+$spectra-font-size-title-large: 32px;
+$spectra-font-size-title-medium: 24px;
+$spectra-font-size-title-small: 20px;
+$spectra-font-size-subtitle: 16px;
+$spectra-font-size-subtitle-small: 14px;
+$spectra-font-size-body: 13px;
+$spectra-font-size-button: 13px;
+$spectra-font-size-label: 13px;
+$spectra-font-size-label-semibold: 13px;
+$spectra-font-size-link-text: 13px;
+$spectra-font-size-placeholder: 13px;
+$spectra-font-size-body-small: 12px;
+$spectra-font-size-helper-text: 12px;
+$spectra-font-size-small-button-text: 11px;
+$spectra-font-size-section-heading: 11px;
 
 // Spectra Font Weights.
 
-$spectra-font-weight-title-large       : 400;
-$spectra-font-weight-title-medium      : 400;
-$spectra-font-weight-title-small       : 400;
-$spectra-font-weight-subtitle          : 600;
-$spectra-font-weight-subtitle-small    : 600;
-$spectra-font-weight-body              : 400;
-$spectra-font-weight-button            : 400;
-$spectra-font-weight-label             : 400;
-$spectra-font-weight-label-semibold    : 600;
-$spectra-font-weight-link-text         : 400;
-$spectra-font-weight-placeholder       : 400;
-$spectra-font-weight-body-small        : 400;
-$spectra-font-weight-helper-text       : 400;
-$spectra-font-weight-small-button-text : 400;
-$spectra-font-weight-section-heading   : 500;
+$spectra-font-weight-title-large: 400;
+$spectra-font-weight-title-medium: 400;
+$spectra-font-weight-title-small: 400;
+$spectra-font-weight-subtitle: 600;
+$spectra-font-weight-subtitle-small: 600;
+$spectra-font-weight-body: 400;
+$spectra-font-weight-button: 400;
+$spectra-font-weight-label: 400;
+$spectra-font-weight-label-semibold: 600;
+$spectra-font-weight-link-text: 400;
+$spectra-font-weight-placeholder: 400;
+$spectra-font-weight-body-small: 400;
+$spectra-font-weight-helper-text: 400;
+$spectra-font-weight-small-button-text: 400;
+$spectra-font-weight-section-heading: 500;
 
 // Spectra Line Heights.
 
-$spectra-line-height-title-large       : 40px;
-$spectra-line-height-title-medium      : 32px;
-$spectra-line-height-title-small       : 28px;
-$spectra-line-height-subtitle          : 24px;
-$spectra-line-height-subtitle-small    : 20px;
-$spectra-line-height-body              : 1.4em;
-$spectra-line-height-button            : 13px;
-$spectra-line-height-label             : 1.4em;
-$spectra-line-height-label-semibold    : 1.4em;
-$spectra-line-height-link-text         : 1.4em;
-$spectra-line-height-placeholder       : 1em;
-$spectra-line-height-body-small        : 1.4em;
-$spectra-line-height-helper-text       : 1.4em;
-$spectra-line-height-small-button-text : 22px;
-$spectra-line-height-section-heading   : 1.4em;
+$spectra-line-height-title-large: 40px;
+$spectra-line-height-title-medium: 32px;
+$spectra-line-height-title-small: 28px;
+$spectra-line-height-subtitle: 24px;
+$spectra-line-height-subtitle-small: 20px;
+$spectra-line-height-body: 1.4em;
+$spectra-line-height-button: 13px;
+$spectra-line-height-label: 1.4em;
+$spectra-line-height-label-semibold: 1.4em;
+$spectra-line-height-link-text: 1.4em;
+$spectra-line-height-placeholder: 1em;
+$spectra-line-height-body-small: 1.4em;
+$spectra-line-height-helper-text: 1.4em;
+$spectra-line-height-small-button-text: 22px;
+$spectra-line-height-section-heading: 1.4em;
 
 // Spectra Text Transforms.
 
-$spectra-text-transform-title-large       : none;
-$spectra-text-transform-title-medium      : none;
-$spectra-text-transform-title-small       : none;
-$spectra-text-transform-subtitle          : none;
-$spectra-text-transform-subtitle-small    : none;
-$spectra-text-transform-body              : none;
-$spectra-text-transform-button            : none;
-$spectra-text-transform-label             : none;
-$spectra-text-transform-label-semibold    : none;
-$spectra-text-transform-link-text         : none;
-$spectra-text-transform-placeholder       : none;
-$spectra-text-transform-body-small        : none;
-$spectra-text-transform-helper-text       : none;
-$spectra-text-transform-small-button-text : uppercase;
-$spectra-text-transform-section-heading   : uppercase;
+$spectra-text-transform-title-large: none;
+$spectra-text-transform-title-medium: none;
+$spectra-text-transform-title-small: none;
+$spectra-text-transform-subtitle: none;
+$spectra-text-transform-subtitle-small: none;
+$spectra-text-transform-body: none;
+$spectra-text-transform-button: none;
+$spectra-text-transform-label: none;
+$spectra-text-transform-label-semibold: none;
+$spectra-text-transform-link-text: none;
+$spectra-text-transform-placeholder: none;
+$spectra-text-transform-body-small: none;
+$spectra-text-transform-helper-text: none;
+$spectra-text-transform-small-button-text: uppercase;
+$spectra-text-transform-section-heading: uppercase;
 
 // Spectra Letter Spacing.
 
-$spectra-letter-spacing : 0;
+$spectra-letter-spacing: 0;
 
 // --------------------------------------------
 // All Specific CSS Variables Below This Point.
@@ -106,31 +106,31 @@ $spectra-letter-spacing : 0;
 
 // Spectra Panel UI.
 
-$spectra-panel-heading-padding : 16px 48px 16px 16px;
-$spectra-panel-body-padding    : 16px;
+$spectra-panel-heading-padding: 16px 48px 16px 16px;
+$spectra-panel-body-padding: 16px;
 
 // Spectra Control UI.
 
-$spectra-control-vertical-gap             : 25px;
-$spectra-control-label-bottom-margin      : 10px;
-$spectra-control-border-radius            : 3px;
-$spectra-control-input-padding            : 7px 12px;
-$spectra-control-input-height             : 30px;
-$spectra-control-circle-indicator         : 28px;
-$spectra-control-mediapicker-height       : 130px;
-$spectra-control-mediapicker-height-small : 96px;
+$spectra-control-vertical-gap: 25px;
+$spectra-control-label-bottom-margin: 10px;
+$spectra-control-border-radius: 3px;
+$spectra-control-input-padding: 7px 12px;
+$spectra-control-input-height: 30px;
+$spectra-control-circle-indicator: 28px;
+$spectra-control-mediapicker-height: 130px;
+$spectra-control-mediapicker-height-small: 96px;
 
 // Spectra Control Popup UI.
 
-$spectra-control-popup-padding       : 16px;
-$spectra-control-popup-vertical-gap  : 15px;
-$spectra-control-popup-border-radius : 2px;
-$spectra-control-popup-box-shadow    : 0 2px 8px rgba(0, 0, 0, 0.2);
+$spectra-control-popup-padding: 16px;
+$spectra-control-popup-vertical-gap: 15px;
+$spectra-control-popup-border-radius: 2px;
+$spectra-control-popup-box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
 
 // Spectra Fullscreen Popup UI.
 
-$spectra-popup-heading-padding : 18px 66px 18px 30px;
-$spectra-popup-content-padding : 18px 30px;
-$spectra-popup-vertical-gap    : 30px;
-$spectra-popup-border-radius   : 2px;
-$spectra-popup-box-shadow      : 0 4px 4px rgba(0, 0, 0, 0.25);
+$spectra-popup-heading-padding: 18px 66px 18px 30px;
+$spectra-popup-content-padding: 18px 30px;
+$spectra-popup-vertical-gap: 30px;
+$spectra-popup-border-radius: 2px;
+$spectra-popup-box-shadow: 0 4px 4px rgba(0, 0, 0, 0.25);

--- a/src/styles/control-popup.scss
+++ b/src/styles/control-popup.scss
@@ -22,7 +22,6 @@
 	}
 
 	& > .uagb-size-type-field-tabs {
-
 		margin-bottom: $spectra-control-popup-vertical-gap !important;
 
 		.components-base-control {

--- a/src/styles/gutenberg-override.scss
+++ b/src/styles/gutenberg-override.scss
@@ -8,11 +8,15 @@
 
 	.uagb-inspector-tab {
 
-		&::-webkit-input-placeholder { /* Edge */
+		&::-webkit-input-placeholder {
+
+			/* Edge */
 			color: #aaa;
 		}
 
-		&:-ms-input-placeholder { /* Internet Explorer 10-11 */
+		&:-ms-input-placeholder {
+
+			/* Internet Explorer 10-11 */
 			color: #aaa;
 		}
 
@@ -212,7 +216,6 @@
 
 	// Input Wrapper for Multiple Gutenberg Components.
 	.components-input-control__container {
-
 		// Select Control.
 		// ----------------------------------------------------------------------------------------------------------
 		// NOTE: We will have to implement CustomSelectControl in place of SelectControl to style the Selected State.
@@ -262,7 +265,6 @@
 
 		// Input Wrapper for Multiple Gutenberg Components.
 		.components-input-control__container {
-
 			// Select Control.
 			// ----------------------------------------------------------------------------------------------------------
 			// NOTE: We will have to implement CustomSelectControl in place of SelectControl to style the Selected State.


### PR DESCRIPTION
### Description
Formatting of plugin using prettier.
**Script to format**: ` "lint-scripts:fix": "npm run pretty:fix && npm run lint-js -- --fix && npm run lint-css -- --fix",`

### Screenshots
<!-- if applicable -->

### Types of changes
**Changes in .prettierrc.js:**


`config.overrides = [
	{
		files: [ '*.scss', '*.css', '*.js' ],
		options: {
			printWidth: 120,
			singleQuote: true,
		},
	},
];`

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
