### PR TITLE
Fix: Table of Contents - FSE Front-end Generation and Refresh Issues

### DIFF
--- a/blocks-config/table-of-content/class-uagb-table-of-content.php
+++ b/blocks-config/table-of-content/class-uagb-table-of-content.php
@@ -451,9 +451,11 @@ if ( ! class_exists( 'UAGB_Table_Of_Content' ) ) {
 
 			if ( empty( $uagb_toc_heading_content ) || UAGB_ASSET_VER !== $uagb_toc_version ) {
 				global $_wp_current_template_content;
-				$content = get_post( $post->ID )->post_content;
+				// If the current template contents exist, use that - else get the content from the post ID.
 				if ( $_wp_current_template_content ) {
-					$content .= $_wp_current_template_content;
+					$content = $_wp_current_template_content;
+				} else {
+					$content = get_post( $post->ID )->post_content;
 				}
 				$uagb_toc_heading_content          = $this->table_of_contents_get_headings_from_content( $content );
 				$blocks                            = parse_blocks( $content );

--- a/classes/class-uagb-rest-api.php
+++ b/classes/class-uagb-rest-api.php
@@ -112,7 +112,10 @@ if ( ! class_exists( 'UAGB_Rest_API' ) ) {
 		 */
 		public function delete_page_assets( $post_id ) {
 			$current_post_type = get_post_type( $post_id );
-			if ( 'wp_template_part' === $current_post_type ) {
+			if ( 'wp_template_part' === $current_post_type || 'wp_template' === $current_post_type ) {
+
+				// Delete all the TOC Post Meta on update of the template.
+				delete_post_meta_by_key( '_uagb_toc_options' );
 
 				$wp_upload_dir = UAGB_Helper::get_uag_upload_dir_path();
 


### PR DESCRIPTION
### Description
Fixed the Front-end Generation based on content of the FSE, as well as updation of the post meta on save for FSEs.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Tested with Twenty Twenty Three home template editor in the front-end, then tested in single page and Astra to ensure no loss of original functionality.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
