### PR TITLE
Fix: PHP Explode Parameter Two Handlers

### DIFF
--- a/classes/class-uagb-block-helper.php
+++ b/classes/class-uagb-block-helper.php
@@ -1732,7 +1732,7 @@ if ( ! class_exists( 'UAGB_Block_Helper' ) ) {
 		public static function get_matrix_alignment( $value, $pos, $format = '' ) {
 
 			// Return early if remote styles is not a string, or is empty.
-			if ( ! is_string( $value ) || empty( $value ) ) {
+			if ( ! is_string( $value ) || empty( $value ) || ! is_int( $pos ) ) {
 				return '';
 			}
 

--- a/classes/class-uagb-block-helper.php
+++ b/classes/class-uagb-block-helper.php
@@ -1731,8 +1731,8 @@ if ( ! class_exists( 'UAGB_Block_Helper' ) ) {
 		 */
 		public static function get_matrix_alignment( $value, $pos, $format = '' ) {
 
-			// Return early if remote styles is not a string.
-			if ( ! is_string( $value ) ) {
+			// Return early if remote styles is not a string, or is empty.
+			if ( ! is_string( $value ) || empty( $value ) ) {
 				return '';
 			}
 

--- a/classes/class-uagb-block-helper.php
+++ b/classes/class-uagb-block-helper.php
@@ -1731,8 +1731,8 @@ if ( ! class_exists( 'UAGB_Block_Helper' ) ) {
 		 */
 		public static function get_matrix_alignment( $value, $pos, $format = '' ) {
 
-			// Return early if remote styles is not set.
-			if ( empty( $value ) ) {
+			// Return early if remote styles is not a string.
+			if ( ! is_string( $value ) ) {
 				return '';
 			}
 

--- a/classes/class-uagb-block-helper.php
+++ b/classes/class-uagb-block-helper.php
@@ -1736,12 +1736,14 @@ if ( ! class_exists( 'UAGB_Block_Helper' ) ) {
 				return '';
 			}
 
-			$alignment_property = explode( ' ', esc_attr( $value ) )[ $pos - 1 ];
+			$alignment_array = explode( ' ', esc_attr( $value ) );
 
 			// Return early if alignment propery is not a string.
-			if ( ! is_string( $alignment_property ) ) {
+			if ( ! is_string( $alignment_array[ $pos - 1 ] ) || empty( $alignment_array[ $pos - 1 ] ) ) {
 				return '';
 			}
+
+			$alignment_property = $alignment_array[ $pos - 1 ];
 		
 			switch ( $format ) {
 				case 'flex':

--- a/classes/class-uagb-block-helper.php
+++ b/classes/class-uagb-block-helper.php
@@ -1731,7 +1731,7 @@ if ( ! class_exists( 'UAGB_Block_Helper' ) ) {
 		 */
 		public static function get_matrix_alignment( $value, $pos, $format = '' ) {
 
-			// Return early if remote styles is not a string, or is empty.
+			// Return early if remote styles is not a string, or is empty, of if the position is not an integer.
 			if ( ! is_string( $value ) || empty( $value ) || ! is_int( $pos ) ) {
 				return '';
 			}

--- a/classes/class-uagb-block-helper.php
+++ b/classes/class-uagb-block-helper.php
@@ -1737,6 +1737,12 @@ if ( ! class_exists( 'UAGB_Block_Helper' ) ) {
 			}
 
 			$alignment_property = explode( ' ', esc_attr( $value ) )[ $pos - 1 ];
+
+			// Return early if alignment propery is not a string.
+			if ( ! is_string( $alignment_property ) ) {
+				return '';
+			}
+		
 			switch ( $format ) {
 				case 'flex':
 					switch ( $alignment_property ) {

--- a/classes/class-uagb-block-helper.php
+++ b/classes/class-uagb-block-helper.php
@@ -1725,9 +1725,17 @@ if ( ! class_exists( 'UAGB_Block_Helper' ) ) {
 		 * @param string $value  Alignment Matrix value.
 		 * @param int    $pos    Human readable position.
 		 * @param string $format Response format.
+		 * @return string        The formatted Matrix Alignment.
+		 *
 		 * @since 2.1.0
 		 */
 		public static function get_matrix_alignment( $value, $pos, $format = '' ) {
+
+			// Return early if remote styles is not set.
+			if ( empty( $value ) ) {
+				return '';
+			}
+
 			$alignment_property = explode( ' ', esc_attr( $value ) )[ $pos - 1 ];
 			switch ( $format ) {
 				case 'flex':

--- a/classes/class-uagb-block-helper.php
+++ b/classes/class-uagb-block-helper.php
@@ -1738,7 +1738,7 @@ if ( ! class_exists( 'UAGB_Block_Helper' ) ) {
 
 			$alignment_array = explode( ' ', esc_attr( $value ) );
 
-			// Return early if alignment propery is not a string.
+			// Return early if alignment propery at the given position is not a string, or is empty.
 			if ( ! is_string( $alignment_array[ $pos - 1 ] ) || empty( $alignment_array[ $pos - 1 ] ) ) {
 				return '';
 			}

--- a/lib/uagb-webfont/uagb-webfont-loader.php
+++ b/lib/uagb-webfont/uagb-webfont-loader.php
@@ -447,6 +447,11 @@ if ( ! class_exists( 'UAGB_WebFont_Loader' ) ) {
 
 			$font_faces = explode( '@font-face', $this->remote_styles );
 
+			// Return early if font faces is not an array.
+			if ( ! is_array( $font_faces ) ) {
+				return array();
+			}
+
 			$result = array();
 
 			// Loop all our font-face declarations.

--- a/lib/uagb-webfont/uagb-webfont-loader.php
+++ b/lib/uagb-webfont/uagb-webfont-loader.php
@@ -448,7 +448,7 @@ if ( ! class_exists( 'UAGB_WebFont_Loader' ) ) {
 			$font_faces = explode( '@font-face', $this->remote_styles );
 
 			// Return early if font faces is not an array.
-			if ( ! is_array( $font_faces ) ) {
+			if ( ! is_array( $font_faces ) || empty( $font_faces ) ) {
 				return array();
 			}
 
@@ -462,8 +462,16 @@ if ( ! class_exists( 'UAGB_WebFont_Loader' ) ) {
 					continue;
 				}
 
+				// Get the styles based on the font face.
+				$style_array = explode( '}', $font_face );
+
+				// Continue the loop if the current font face is not a string, or is empty.
+				if ( ! is_string( $style_array[0] ) || empty( $style_array[0] ) ) {
+					continue;
+				}
+
 				// Make sure we only process styles inside this declaration.
-				$style = explode( '}', $font_face )[0];
+				$style = $style_array[0];
 
 				// Sanity check.
 				if ( false === strpos( $style, 'font-family' ) ) {

--- a/lib/uagb-webfont/uagb-webfont-loader.php
+++ b/lib/uagb-webfont/uagb-webfont-loader.php
@@ -447,7 +447,7 @@ if ( ! class_exists( 'UAGB_WebFont_Loader' ) ) {
 
 			$font_faces = explode( '@font-face', $this->remote_styles );
 
-			// Return early if font faces is not an array.
+			// Return early if font faces is not an array, or is empty.
 			if ( ! is_array( $font_faces ) || empty( $font_faces ) ) {
 				return array();
 			}

--- a/lib/uagb-webfont/uagb-webfont-loader.php
+++ b/lib/uagb-webfont/uagb-webfont-loader.php
@@ -440,8 +440,8 @@ if ( ! class_exists( 'UAGB_WebFont_Loader' ) ) {
 		 */
 		public function get_remote_files_from_css() {
 
-			// Return early if remote styles is not a string.
-			if ( ! is_string( $this->remote_styles ) ) {
+			// Return early if remote styles is not a string, or is empty.
+			if ( ! is_string( $this->remote_styles ) || empty( $this->remote_styles ) ) {
 				return array();
 			}
 
@@ -452,8 +452,8 @@ if ( ! class_exists( 'UAGB_WebFont_Loader' ) ) {
 			// Loop all our font-face declarations.
 			foreach ( $font_faces as $font_face ) {
 
-				// Continue the loop if the current font face is not a string.
-				if ( ! is_string( $font_face ) ) {
+				// Continue the loop if the current font face is not a string, or is empty.
+				if ( ! is_string( $font_face ) || empty( $font_face ) ) {
 					continue;
 				}
 

--- a/lib/uagb-webfont/uagb-webfont-loader.php
+++ b/lib/uagb-webfont/uagb-webfont-loader.php
@@ -440,12 +440,22 @@ if ( ! class_exists( 'UAGB_WebFont_Loader' ) ) {
 		 */
 		public function get_remote_files_from_css() {
 
+			// Return early if remote styles is not set.
+			if ( empty( $this->remote_styles ) ) {
+				return array();
+			}
+
 			$font_faces = explode( '@font-face', $this->remote_styles );
 
 			$result = array();
 
 			// Loop all our font-face declarations.
 			foreach ( $font_faces as $font_face ) {
+
+				// Continue the loop if the current font face is not set.
+				if ( empty( $font_face ) ) {
+					continue;
+				}
 
 				// Make sure we only process styles inside this declaration.
 				$style = explode( '}', $font_face )[0];

--- a/lib/uagb-webfont/uagb-webfont-loader.php
+++ b/lib/uagb-webfont/uagb-webfont-loader.php
@@ -440,8 +440,8 @@ if ( ! class_exists( 'UAGB_WebFont_Loader' ) ) {
 		 */
 		public function get_remote_files_from_css() {
 
-			// Return early if remote styles is not set.
-			if ( empty( $this->remote_styles ) ) {
+			// Return early if remote styles is not a string.
+			if ( ! is_string( $this->remote_styles ) ) {
 				return array();
 			}
 
@@ -452,8 +452,8 @@ if ( ! class_exists( 'UAGB_WebFont_Loader' ) ) {
 			// Loop all our font-face declarations.
 			foreach ( $font_faces as $font_face ) {
 
-				// Continue the loop if the current font face is not set.
-				if ( empty( $font_face ) ) {
+				// Continue the loop if the current font face is not a string.
+				if ( ! is_string( $font_face ) ) {
 					continue;
 				}
 


### PR DESCRIPTION
### Description
Updated PHP Explode Parameter Two Checks to ensure no null value passed in place of string.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Tested after regenerating assets in the front-end, as well as with matrix alignment for Image Gallery.

### Checklist:
- [x] My code is tested
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
