### PR TITLE
Spectra v2.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Requires at least:** 5.6  
 **Requires PHP:** 5.6  
 **Tested up to:** 6.2  
-**Stable tag:** 2.4.1  
+**Stable tag:** 2.4.2  
 **License:** GPLv2 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -169,6 +169,9 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 1. /assets/screenshots/1.png
 
 ## Changelog ##
+
+### 2.4.2 - WEDNESDAY, 12th APRIL 2023 ###
+* Fix: Container - Updated default content width for block based themes to wideSize.
 
 ### 2.4.1 - TUESDAY, 28th MARCH 2023 ###
 * Improvement: Updated Spectra to work with WordPress 6.2 and Full Site Editing (FSE) themes.

--- a/classes/class-uagb-admin-helper.php
+++ b/classes/class-uagb-admin-helper.php
@@ -398,7 +398,7 @@ if ( ! class_exists( 'UAGB_Admin_Helper' ) ) {
 				}
 				if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {
 					$settings      = wp_get_global_settings();
-					$content_width = intval( $settings['layout']['contentSize'] );
+					$content_width = intval( $settings['layout']['wideSize'] );
 					self::update_admin_settings_option( 'uag_content_width_set_by', __( "Full Site Editor's Global Styles", 'ultimate-addons-for-gutenberg' ) );
 				}
 			}

--- a/classes/class-uagb-loader.php
+++ b/classes/class-uagb-loader.php
@@ -84,7 +84,7 @@ if ( ! class_exists( 'UAGB_Loader' ) ) {
 			define( 'UAGB_BASE', plugin_basename( UAGB_FILE ) );
 			define( 'UAGB_DIR', plugin_dir_path( UAGB_FILE ) );
 			define( 'UAGB_URL', plugins_url( '/', UAGB_FILE ) );
-			define( 'UAGB_VER', '2.4.1' );
+			define( 'UAGB_VER', '2.4.2' );
 			define( 'UAGB_MODULES_DIR', UAGB_DIR . 'modules/' );
 			define( 'UAGB_MODULES_URL', UAGB_URL . 'modules/' );
 			define( 'UAGB_SLUG', 'spectra' );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ultimate-addons-for-gutenberg",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "The Ultimate Addons for Gutenberg extends the Gutenberg functionality with several unique and feature-rich blocks that help build websites faster.",
   "author": "Brainstorm Force",
   "license": "ISC",

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: gutenberg, blocks, gutenberg blocks, editor, block
 Requires at least: 5.6
 Requires PHP: 5.6
 Tested up to: 6.2
-Stable tag: 2.4.1
+Stable tag: 2.4.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -169,6 +169,9 @@ The awesome React FontIconPicker is developed by [Alessandro Benoit](http://code
 1. /assets/screenshots/1.png
 
 == Changelog ==
+
+= 2.4.2 - WEDNESDAY, 12th APRIL 2023 =
+* Fix: Container - Updated default content width for block based themes to wideSize.
 
 = 2.4.1 - TUESDAY, 28th MARCH 2023 =
 * Improvement: Updated Spectra to work with WordPress 6.2 and Full Site Editing (FSE) themes.

--- a/ultimate-addons-for-gutenberg.php
+++ b/ultimate-addons-for-gutenberg.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://www.brainstormforce.com
  * Author: Brainstorm Force
  * Author URI: https://www.brainstormforce.com
- * Version: 2.4.1
+ * Version: 2.4.2
  * Description: The Spectra extends the Gutenberg functionality with several unique and feature-rich blocks that help build websites faster.
  * Text Domain: ultimate-addons-for-gutenberg
  *


### PR DESCRIPTION
* Fix: Container - Updated default content width for block based themes to wideSize.