### PR TITLE
SPCTR-2957 - Hotfix: Post Carousel - Added Visibility Check for Carousels that Show Less Posts Per Page than Columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ Our external packages use [Rating Star Component](https://github.com/n49/react-s
 
 ## Changelog ##
 
+### x.x.x ###
+* Fix: Post Carousel - Resolved an issue in which the posts would not show up on the front end when the number of columns was greater than the number of posts.
+
 ### 2.6.2 - WEDNESDAY, 31st MAY 2023 ###
 * New: Introducing the Inherit From Theme option - Choose to make buttons in Spectra blocks inherit their styles from the theme.
 * Improvement: Icon List - Added the functionality to create a new list item when pressing the enter key inside the Icon List block.

--- a/blocks-config/post/class-uagb-post.php
+++ b/blocks-config/post/class-uagb-post.php
@@ -1762,7 +1762,12 @@ if ( ! class_exists( 'UAGB_Post' ) ) {
 										}
 									}
 								}
-								if ( ! $scope.hasClass('is-carousel') || cols >= $scope.children('article.uagb-post__inner-wrap').length ) {
+								// If this is not a Post Carousel, return.
+								// Else if it is a carousel but has less posts than the number of columns, return after setting visibility.
+								if ( ! $scope.hasClass('is-carousel') ) {
+									return;
+								} else if ( cols >= $scope.children('article.uagb-post__inner-wrap').length ) {
+									$scope.css( 'visibility', 'visible' );
 									return;
 								}
 								var slider_options = {

--- a/readme.txt
+++ b/readme.txt
@@ -166,6 +166,9 @@ Our external packages use [Rating Star Component](https://github.com/n49/react-s
 
 == Changelog ==
 
+= x.x.x =
+* Fix: Post Carousel - Resolved an issue in which the posts would not show up on the front end when the number of columns was greater than the number of posts.
+
 = 2.6.2 - WEDNESDAY, 31st MAY 2023 =
 * New: Introducing the Inherit From Theme option - Choose to make buttons in Spectra blocks inherit their styles from the theme.
 * Improvement: Icon List - Added the functionality to create a new list item when pressing the enter key inside the Icon List block.


### PR DESCRIPTION
### Description
Added Visibility Check for Carousels that Show Less Posts Per Page than Columns.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### How has this been tested?
Tested as stated in [this comment](https://brainstormforce.atlassian.net/browse/SPCTR-2957?focusedCommentId=36313).

### Checklist:
- [x] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
