### PR TITLE
Fixed: Form block (uagb/forms) support in block themes

### DIFF
--- a/blocks-config/forms/class-uagb-forms.php
+++ b/blocks-config/forms/class-uagb-forms.php
@@ -215,7 +215,7 @@ if ( ! class_exists( 'UAGB_Forms' ) ) {
 						$template_post_content = $template->content . ( ! empty( $post_content ) ? $post_content : '' );
 						$template_content      = parse_blocks( $template_post_content );
 						if ( get_template() === $template->theme && ! empty( $template_content ) && is_array( $template_content ) ) {
-							$current_block_attributes = $this->recursive_inner_forms( $template_content, $block_id );
+							$current_block_attributes = $this->recursive_inner_forms( $template_content, $block_id ) ?: $current_block_attributes;
 						}
 					}
 				}


### PR DESCRIPTION
### Description
Before it was not always possible to use `uagb/forms` in sites templates (block themes).

### Reason
`$current_block_attributes` must only be set if not null/empty.

PS: Can you please also check following MR (#3200)? It just adds an additional filter, which we rly need... <3