### PR TITLE
fix(hook) Rename uag_font_disaply hook to uag_font_display

### DIFF
--- a/classes/class-uagb-post-assets.php
+++ b/classes/class-uagb-post-assets.php
@@ -697,7 +697,15 @@ class UAGB_Post_Assets {
 			$extra_attr .= '&subset=latin';
 		}
 
-		$display = apply_filters( 'uag_font_disaply', 'fallback' );
+		$display = apply_filters_deprecated( 'uag_font_disaply', 'fallback' );
+
+		/**
+		 * Filters the font display query parameter.
+		 *
+		 * @see https://developers.google.com/fonts/docs/getting_started#use_font-display
+		 * @param string $display The global post.
+		 */
+		$display = apply_filters( 'uag_font_display', $display );
 
 		if ( ! empty( $display ) ) {
 			$extra_attr .= '&display=' . $display;


### PR DESCRIPTION
### Description

Introduced `uag_font_display` filter and deprecated `uag_font_disaply`.
