### PR TITLE
SPCTR-3466 : local font loading issue

### DIFF
--- a/lib/uagb-webfont/uagb-webfont-loader.php
+++ b/lib/uagb-webfont/uagb-webfont-loader.php
@@ -313,6 +313,11 @@ if ( ! class_exists( 'UAGB_WebFont_Loader' ) ) {
 				return;
 			}
 
+			// Check if response code is 400.
+			if ( wp_remote_retrieve_response_code( $response ) === 400 ) {
+				return;
+			}
+
 			// Get the CSS from our response.
 			$contents = wp_remote_retrieve_body( $response );
 


### PR DESCRIPTION
### Description
The error comes when we enable Load Google Fonts Locally.

### Screenshots
<!-- if applicable -->

### Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->

### Checklist:
- [ ] My code is tested
- [ ] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [ ] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [ ] I've included any necessary tests <!-- if applicable -->
- [ ] I've included developer documentation <!-- if applicable -->
- [ ] I've added proper labels to this pull request <!-- if applicable -->
